### PR TITLE
Add Issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,22 @@
+---
+name: Report a bug
+about: I would like to report a bug with Kwenta
+labels: 'bug'
+assignees: ''
+---
+
+### Subject of the issue
+Describe your issue here.
+
+### Your environment
+* Network used (Mainnet? L2?)
+* Which browser and its version
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Steps to reproduce
+Tell us how to reproduce this issue.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,16 @@
+---
+name: Request a feature
+about: I would like to propose a feature
+title: ''
+labels: 'enhancement'
+assignees: ''
+---
+
+### Feature Proposal
+Describe your proposal in detail here.
+
+### Rationale
+Why should this feature exist? Provide at least one use-case.
+
+### Implementation
+Do you have ideas how this feature could be implemented?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related issue
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):


### PR DESCRIPTION
## Description
- Add Standardized Issue Templates for Bug Reports and Feature Requests
- Add Standardized Pull Request Template

## Related issue

## Further ToDo
A repository owner should enable and set up the two issue templates (bug report, feature idea) as well as the pull request template in the repo settings. See [Github Docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)

## Motivation and Context
Streamline and standardize issues and PR requests with templates to improve the quality of issues to be reported and make it easier for community members to report and contribute

## How Has This Been Tested?

## Screenshots (if appropriate):
