### PR TITLE
Kwenta/kwenta#26 Twitter Card Image Workaround

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -78,7 +78,7 @@ const App: FC<AppProps> = (props) => {
 				<meta name="twitter:card" content="summary_large_image" />
 				<meta name="twitter:site" content="@kwenta_io" />
 				<meta name="twitter:creator" content="@kwenta_io" />
-				<meta name="twitter:image" content="/images/kwenta-twitter.jpg?1" />
+				<meta name="twitter:image" content="https://kwenta.io/images/kwenta-twitter.jpg" />
 				<meta name="twitter:url" content="https://kwenta.io" />
 				<link rel="icon" href="/images/favicon.svg" />
 			</Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -78,7 +78,7 @@ const App: FC<AppProps> = (props) => {
 				<meta name="twitter:card" content="summary_large_image" />
 				<meta name="twitter:site" content="@kwenta_io" />
 				<meta name="twitter:creator" content="@kwenta_io" />
-				<meta name="twitter:image" content="/images/kwenta-twitter.jpg" />
+				<meta name="twitter:image" content="/images/kwenta-twitter.jpg?1" />
 				<meta name="twitter:url" content="https://kwenta.io" />
 				<link rel="icon" href="/images/favicon.svg" />
 			</Head>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simple Workaround to have Twitterbot fetch the Kwenta Logo Image, as suggested per Twitter Docs

## Related issue
https://github.com/Kwenta/kwenta/issues/26

## Motivation and Context
Twitterbot should immediately re-fetch the image and properly show the Kwenta Logo on Twitter Cards

## How Has This Been Tested?
Tested locally and verified with Twitter Card Validator

## Screenshots (if appropriate):
![cards-dev twitter com_validator](https://user-images.githubusercontent.com/548702/132517931-4d93c3ba-f12f-4efd-99b6-ce3667e9812c.png)
