### PR TITLE
Synth Onramp Decimal Conversion Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lint-results.sarif
 # misc
 .DS_Store
 notes.md
+.idea/
 
 # debug
 npm-debug.log*

--- a/containers/Convert/Convert.tsx
+++ b/containers/Convert/Convert.tsx
@@ -55,7 +55,7 @@ const useConvert = () => {
 	) => ({
 		fromTokenAddress: quoteTokenAddress,
 		toTokenAddress: baseTokenAddress,
-		amount: wei(amount).toString(0, true),
+		amount: wei(amount, decimals).toString(0, true),
 	});
 
 	const quote1Inch = async (


### PR DESCRIPTION
## Description
Populating a quote for assets with non-standard decimal's (EG: USDC ~> sUSD) in the Synth Onramp page is producing incorrect results, as outlined in issue https://github.com/Kwenta/kwenta/issues/25

<img width="1027" alt="Screenshot 2021-09-09 at 03 24 10" src="https://user-images.githubusercontent.com/90358058/132612005-fb3d1781-c6a8-4b7f-b5dd-19bf12d8a55c.png">

## The Problem
On inspection, it appears that the [get1InchQuoteSwapParams](https://github.com/Kwenta/kwenta/blob/03aa1620043fb4a7dd729d7d42c864194b97f52c/containers/Convert/Convert.tsx#L50) is using the `wei` convenience function which instantiates a `Wei` object with a default precision of 18 decimals.  

During initialisation, `Wei` [uses the following transformation](https://github.com/Synthetixio/js-monorepo/blob/4e76071b7b63ad112281899c2224b78cc46ff41d/packages/wei/src/wei.ts#L88) to cast the decimal user input to a `BigNumber` compatible format:

```typescript
this.bn = BigNumber.from(new Big(n as any).mul(new Big(10).pow(this.p)).toFixed(0));
```

In the above screenshot, `n` would equal `1.000000`, which eventually gets expanded to `1000000000000000000 (1e18)`.  We can observe this format being passed through to the 1inch api in the example request below:

```
https://api.1inch.exchange/v3.0/1/quote?fromTokenAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&toTokenAddress=0x57ab1ec28d129707052df4df418d58a2d46d5f51&amount=1000000000000000000 
```

This then prompts 1inch to return a quote for our unexpectedly large input. 

## The Solution

The most lightweight solution appears to be leveraging the [unused decimals](https://github.com/Kwenta/kwenta/blob/03aa1620043fb4a7dd729d7d42c864194b97f52c/containers/Convert/Convert.tsx#L54) parameter in `get1InchQuoteSwapParams`.  If undefined, `Wei` should default to the 18 precision, and if defined and other than 18, the `Wei` constructor will take care of performing the correct mapping thanks to  `new Big(10).pow(this.p)`.

## How Has This Been Tested?
Changes were tested locally via a swap from usdc ~> susd, and from eth ~> susd.  Both worked as expected following the change. 

### Code Impacted
By making the change in `get1InchQuoteSwapParams`, the correct mapping will be performed prior to a [quote](https://github.com/Kwenta/kwenta/blob/03aa1620043fb4a7dd729d7d42c864194b97f52c/containers/Convert/Convert.tsx#L67), and prior to a [swap](https://github.com/Kwenta/kwenta/blob/03aa1620043fb4a7dd729d7d42c864194b97f52c/containers/Convert/Convert.tsx#L90).  `get1inchQuoteSwapParams` is not used in any other part of the codebase.
