### PR TITLE
feat: (connector) handle unsupported networks

### DIFF
--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -75,10 +75,10 @@ const useConnector = () => {
 			});
 			const useOvm = getIsOVM(networkId);
 
-			const networks = await snx.networks;
+			const supportedNetworks = await snx.networks;
 			const currentNetwork = await _provider.getNetwork()?.name;
 
-			if (!networks.includes(currentNetwork)) {
+			if (!supportedNetworks.includes(currentNetwork)) {
 				console.error('Network not supported');
 				// TODO: Show a warning dialog - needs design
 				return;


### PR DESCRIPTION
Currently if you connect to the app with an unsupported network like Matic the app will break. This handles that.

## Description
Update Connector to check for supported networks and show a `console.error`

## Motivation and Context
We want to provide a good experience to users even if they are on the wrong network.

To be more useful this probably needs more design to show a modal or similar telling the user to switch networks, and/or a a MetaMask prompt to switch to another network? This change is not included.

## How Has This Been Tested?
Manual testing with Chrome and MetaMask 10.0.3

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/90406474/132718911-dbd68f7f-55ef-49a5-9687-3560c33c0a8f.png)
