### PR TITLE
Kwenta/Kwenta#37 Remove extra padding

### DIFF
--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -400,7 +400,6 @@ export const ExchangeCardsWithSelector = styled.div`
 		}
 		.currency-card-body {
 			position: relative;
-			padding-left: 61px;
 			${media.lessThan('md')`
 				padding-left: 18px;
 			`}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed `padding-left: 61px` in the ``.currency-card-quote`` box styling to align the "From" box properly. The padding only affected desktop.

## Related issue
#37 

## Motivation and Context
See #37 
## How Has This Been Tested?
Locally with latest Chromium

## Screenshots (if appropriate):
![localhost_3000_dashboard_convert](https://user-images.githubusercontent.com/548702/132777664-74991015-6d09-49ae-8eb3-38c5d84b9925.png)