### PR TITLE
Add git hash to bottom of pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 // next.config.js
+const gitRevision = require('child_process').execSync('git rev-parse --short HEAD').toString().trim();
 
 module.exports = {
+	env: {
+		GIT_HASH_ID: gitRevision,
+	},
 	webpack: (config, options) => {
 
 		config.resolve.mainFields = ['module', 'browser', 'main'];

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -18,7 +18,7 @@ import AppLayout from 'sections/shared/Layout/AppLayout';
 import DashboardCard from 'sections/dashboard/DashboardCard';
 import TrendingSynths from 'sections/dashboard/TrendingSynths';
 import Onboard from 'sections/dashboard/Onboard';
-import GitIDFooter from 'sections/shared/Layout/AppLayout/Footer'
+import GitIDFooter from 'sections/shared/Layout/AppLayout/Footer';
 
 import { isL2State, isWalletConnectedState } from 'store/wallet';
 
@@ -53,6 +53,7 @@ const DashboardPage = () => {
 					</DesktopOnlyView>
 					<MobileOrTabletView>
 						<MobileContainer>{activeView}</MobileContainer>
+						<GitIDFooter />
 					</MobileOrTabletView>
 				</PageContent>
 			</AppLayout>

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -18,6 +18,7 @@ import AppLayout from 'sections/shared/Layout/AppLayout';
 import DashboardCard from 'sections/dashboard/DashboardCard';
 import TrendingSynths from 'sections/dashboard/TrendingSynths';
 import Onboard from 'sections/dashboard/Onboard';
+import GitIDFooter from 'sections/shared/Layout/AppLayout/Footer'
 
 import { isL2State, isWalletConnectedState } from 'store/wallet';
 
@@ -38,7 +39,10 @@ const DashboardPage = () => {
 				<PageContent>
 					<DesktopOnlyView>
 						<FullHeightContainer>
-							<MainContent>{activeView}</MainContent>
+							<MainContent>
+								{activeView}
+								<GitIDFooter />
+							</MainContent>
 							{isWalletConnected && (
 								<RightSideContent>
 									<TrendingSynths />

--- a/pages/exchange/[[...market]].tsx
+++ b/pages/exchange/[[...market]].tsx
@@ -27,6 +27,7 @@ import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import useExchange from 'sections/exchange/hooks/useExchange';
 import { CurrencyKey } from 'constants/currency';
 import { DEFAULT_WIDTH } from 'sections/exchange/TradeCard/constants';
+import GitIDFooter from 'sections/shared/Layout/AppLayout/Footer';
 
 const ExchangePage = () => {
 	const { t } = useTranslation();
@@ -177,6 +178,7 @@ const ExchangePage = () => {
 									)}
 								</ChartsContainer>
 							</AnimateSharedLayout>
+							<GitIDFooter />
 						</DesktopContainer>
 					</DesktopOnlyView>
 					<MobileOrTabletView>
@@ -212,6 +214,7 @@ const ExchangePage = () => {
 									</Slider>
 								</SliderContainer>
 							)}
+							<GitIDFooter />
 						</MobileContainer>
 					</MobileOrTabletView>
 				</StyledPageContent>

--- a/pages/shorting/index.tsx
+++ b/pages/shorting/index.tsx
@@ -10,6 +10,7 @@ import ShortingRewards from 'sections/shorting/ShortingRewards';
 import ShortingStats from 'sections/shorting/ShortingStats';
 
 import AppLayout from 'sections/shared/Layout/AppLayout';
+import GitIDFooter from 'sections/shared/Layout/AppLayout/Footer';
 
 import { PageContent, MainContent, RightSideContent, FullHeightContainer } from 'styles/common';
 
@@ -45,6 +46,7 @@ const Shorting: FC = () => {
 							<MainContent>
 								<ShortingCard />
 								{isWalletConnected && <ShortingHistory />}
+								<GitIDFooter />
 							</MainContent>
 							<DesktopOnlyView>
 								<StyledRightSideContent>

--- a/sections/shared/Layout/AppLayout/Footer/Footer.tsx
+++ b/sections/shared/Layout/AppLayout/Footer/Footer.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import styled from 'styled-components';
+
+const Footer: FC = () => {
+    const gitID = process.env.GIT_HASH_ID!.toString();
+
+    return (
+        <GitIDFooter>
+            {gitID}
+        </GitIDFooter>
+    );
+};
+
+const GitIDFooter = styled.div`
+	font-family: Akkurat LL TT;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 10px;
+    line-height: 140%;
+    /* identical to box height, or 14px */
+    
+    display: flex;
+    justify-items: center;
+    position: absolute;
+    bottom: 0px;
+    display: grid;
+    width: 100%;
+    margin-bottom: 15px;
+    
+    color: #2B3035;
+`;
+
+export default Footer;

--- a/sections/shared/Layout/AppLayout/Footer/Footer.tsx
+++ b/sections/shared/Layout/AppLayout/Footer/Footer.tsx
@@ -17,7 +17,6 @@ const GitIDFooter = styled.div`
     font-weight: normal;
     font-size: 10px;
     line-height: 140%;
-    /* identical to box height, or 14px */
     
     display: flex;
     justify-items: center;

--- a/sections/shared/Layout/AppLayout/Footer/Footer.tsx
+++ b/sections/shared/Layout/AppLayout/Footer/Footer.tsx
@@ -25,7 +25,7 @@ const GitIDFooter = styled.div`
     bottom: 0px;
     display: grid;
     width: 100%;
-    margin-bottom: 15px;
+    margin-bottom: 5px;
     
     color: #2B3035;
 `;

--- a/sections/shared/Layout/AppLayout/Footer/Footer.tsx
+++ b/sections/shared/Layout/AppLayout/Footer/Footer.tsx
@@ -24,8 +24,7 @@ const GitIDFooter = styled.div`
     bottom: 0px;
     display: grid;
     width: 100%;
-    margin-bottom: 5px;
-    
+    margin-bottom: 5px;    
     color: #2B3035;
 `;
 

--- a/sections/shared/Layout/AppLayout/Footer/index.ts
+++ b/sections/shared/Layout/AppLayout/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made the git hash a global variable in next.config.js, added a GitIDFooter section that could be pulled into any page in Footer.tsx, and threaded that through the dashboard, exchange, and shorting pages at the bottom of each page.

## Related issue
https://github.com/Kwenta/kwenta/issues/36

## Motivation and Context
https://github.com/Kwenta/kwenta/issues/36

## How Has This Been Tested?
Visual testing in Chrome

## Screenshots (if appropriate):
Really faint at the bottom per the figma spec
![image](https://user-images.githubusercontent.com/90298419/132968182-4a28f1e2-8ab3-4fcd-a149-be47d6e6a45f.png)

