### PR TITLE
Asset dropdown to quickly change asset from trading view

### DIFF
--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -29,8 +29,8 @@ function Select<T>(props: Props<T>) {
 				border: `1px solid ${colors.navy}`,
 				borderRadius: '4px',
 				outline: 'none',
-				minHeight: 'unset',
-				height: state.selectProps.controlHeight ?? 'unset',
+				minHeight: props.height ?? 'unset',
+				height: props.height ?? state.selectProps.controlHeight ?? 'unset',
 				'&:hover': {
 					border: `1px solid rgba(255, 255, 255, 0.1)`,
 				},

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -29,8 +29,8 @@ function Select<T>(props: Props<T>) {
 				border: `1px solid ${colors.navy}`,
 				borderRadius: '4px',
 				outline: 'none',
-				minHeight: props.height ?? 'unset',
-				height: props.height ?? state.selectProps.controlHeight ?? 'unset',
+				minHeight: 'unset',
+				height: state.selectProps.controlHeight ?? 'unset',
 				'&:hover': {
 					border: `1px solid rgba(255, 255, 255, 0.1)`,
 				},

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -9,13 +9,13 @@ import Connector from 'containers/Connector';
 import QUERY_KEYS from 'constants/queryKeys';
 import { FuturesMarket } from './types';
 
-const useGetFuturesMarkets = (options?: UseQueryOptions<[FuturesMarket]>) => {
+const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 	const isAppReady = useRecoilValue(appReadyState);
 	const isL2 = useRecoilValue(isL2State);
 	const walletAddress = useRecoilValue(walletAddressState);
 	const { synthetixjs } = Connector.useContainer();
 
-	return useQuery<[FuturesMarket]>(
+	return useQuery<FuturesMarket[]>(
 		QUERY_KEYS.Futures.Markets,
 		async () => {
 			const {

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -1,0 +1,56 @@
+import Select from 'components/Select';
+import React from 'react';
+import { FlexDivRowCentered } from 'styles/common';
+import CurrencyIcon from 'components/Currency/CurrencyIcon';
+import { useRouter } from 'next/router';
+import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
+import ROUTES from 'constants/routes';
+import styled from 'styled-components';
+
+const assetToCurrencyOption = (asset: string) =>
+	({ value: asset, label: asset } as { value: CurrencyKey; label: CurrencyKey });
+
+type Props = {
+	asset: string;
+};
+const MarketsDropdown: React.FC<Props> = ({ asset }) => {
+	const futuresMarketsQuery = useGetFuturesMarkets();
+	const router = useRouter();
+	const markets = futuresMarketsQuery?.data ?? [];
+	return (
+		<SelectContainer>
+			<Select
+				height={48}
+				formatOptionLabel={(option) => (
+					<FlexDivRowCentered>
+						<CurrencyIcon currencyKey={option.value} />
+						<CurrencyLabel>{option.value}</CurrencyLabel>
+					</FlexDivRowCentered>
+				)}
+				onChange={(x) => {
+					// Types are not perfect from react-select, this should always be true (just helping typescript)
+					if (x && 'value' in x) {
+						router.push(ROUTES.Futures.Market.MarketPair(x.value));
+					}
+				}}
+				value={assetToCurrencyOption(asset)}
+				options={markets.map((x) => assetToCurrencyOption(x.asset))}
+			/>
+		</SelectContainer>
+	);
+};
+const SelectContainer = styled.div`
+	margin-top: 5px;
+	margin-bottom: 24px;
+`;
+
+const CurrencyLabel = styled.div`
+	color: ${(props) => props.theme.colors.white};
+	font-size: 14px;
+	font-family: ${(props) => props.theme.fonts.bold};
+	margin-right: 12px;
+	margin-left: 2px;
+`;
+
+export default MarketsDropdown;

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -1,6 +1,6 @@
 import Select from 'components/Select';
 import React from 'react';
-import { FlexDivRowCentered } from 'styles/common';
+import { FlexDivCentered } from 'styles/common';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { useRouter } from 'next/router';
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
@@ -21,12 +21,13 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 	return (
 		<SelectContainer>
 			<Select
-				height={48}
+				controlHeight={48}
+				menuWidth={'100%'}
 				formatOptionLabel={(option) => (
-					<FlexDivRowCentered>
+					<FlexDivCentered>
 						<CurrencyIcon currencyKey={option.value} />
 						<CurrencyLabel>{option.value}</CurrencyLabel>
-					</FlexDivRowCentered>
+					</FlexDivCentered>
 				)}
 				onChange={(x) => {
 					// Types are not perfect from react-select, this should always be true (just helping typescript)
@@ -49,8 +50,7 @@ const CurrencyLabel = styled.div`
 	color: ${(props) => props.theme.colors.white};
 	font-size: 14px;
 	font-family: ${(props) => props.theme.fonts.bold};
-	margin-right: 12px;
-	margin-left: 2px;
+	margin-left: 5px;
 `;
 
 export default MarketsDropdown;

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -5,7 +5,7 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { useRecoilValue } from 'recoil';
 import Wei, { wei } from '@synthetixio/wei';
 
-import { FlexDivCol, FlexDivRow, FlexDivColCentered } from 'styles/common';
+import { FlexDivCol, FlexDivRow, FlexDivColCentered, FlexDivRowCentered } from 'styles/common';
 import { useState } from 'react';
 import { Synths } from 'constants/currency';
 
@@ -34,6 +34,7 @@ import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesPositionHistory from 'queries/futures/useGetFuturesPositionHistory';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import { gasPriceInWei } from 'utils/network';
+import MarketsDropdown from './MarketsDropdown';
 
 type TradeProps = {};
 
@@ -226,6 +227,10 @@ const Trade: React.FC<TradeProps> = () => {
 	return (
 		<Panel>
 			<TopRow>
+				<FlexDivRow>
+					<Title>{t('futures.market.trade.market')}</Title>
+				</FlexDivRow>
+				<MarketsDropdown asset={marketAsset || Synths.sUSD} />
 				<FlexDivRow>
 					<Title>{t('futures.market.trade.title')}</Title>
 				</FlexDivRow>

--- a/sections/futures/TradeSizeInput/TradeSizeInput.tsx
+++ b/sections/futures/TradeSizeInput/TradeSizeInput.tsx
@@ -1,18 +1,13 @@
 import { FC, ChangeEvent } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
-import { useRouter } from 'next/router';
 import Wei from '@synthetixio/wei';
 
 import NumericInput from 'components/Input/NumericInput';
 import Button from 'components/Button';
-import CurrencyIcon from 'components/Currency/CurrencyIcon';
-import Select from 'components/Select';
-import { CurrencyKey, Synths } from 'constants/currency';
+import { Synths } from 'constants/currency';
 import { FlexDivCol, FlexDivRow, FlexDivRowCentered, FlexDivCentered } from 'styles/common';
 import { formatCurrency, formatCryptoCurrency } from 'utils/formatters/number';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
-import ROUTES from 'constants/routes';
 
 type TradeSizeInputProps = {
 	balance: Wei;
@@ -24,44 +19,20 @@ type TradeSizeInputProps = {
 	balanceLabel: string;
 };
 
-const assetToCurrencyOption = (asset: string) =>
-	({ value: asset, label: asset } as { value: CurrencyKey; label: CurrencyKey });
-
 const TradeSizeInput: FC<TradeSizeInputProps> = ({
 	amount,
 	onAmountChange,
 	balance,
-	asset,
 	balanceLabel,
 	assetRate,
 	handleOnMax,
 }) => {
 	const { t } = useTranslation();
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const router = useRouter();
-	const markets = futuresMarketsQuery?.data ?? [];
+
 	const amountValue = Number(amount) * assetRate;
 	return (
 		<InputRow>
 			<StyledFlexDivCentered>
-				<SelectContainer>
-					<Select
-						formatOptionLabel={(option) => (
-							<FlexDivRowCentered>
-								<CurrencyIcon currencyKey={option.value} />
-								<CurrencyLabel>{option.value}</CurrencyLabel>
-							</FlexDivRowCentered>
-						)}
-						onChange={(x) => {
-							// Types are not perfect from react-select, this should always be true (just helping typescript)
-							if (x && 'value' in x) {
-								router.push(ROUTES.Futures.Market.MarketPair(x.value));
-							}
-						}}
-						value={assetToCurrencyOption(asset)}
-						options={markets.map((x) => assetToCurrencyOption(x.asset))}
-					/>
-				</SelectContainer>
 				<InputContainer>
 					<FlexDivCol>
 						<InputAmount
@@ -84,26 +55,15 @@ const TradeSizeInput: FC<TradeSizeInputProps> = ({
 		</InputRow>
 	);
 };
-const SelectContainer = styled.div`
-	min-width: 120px;
-	margin-right: 10px;
-`;
 
 const InputRow = styled(FlexDivCol)`
 	width: 100%;
+	margin-top: 5px;
 	margin-bottom: 24px;
 `;
 
 const StyledFlexDivCentered = styled(FlexDivCentered)`
 	width: 100%;
-`;
-
-const CurrencyLabel = styled.div`
-	color: ${(props) => props.theme.colors.white};
-	font-size: 14px;
-	font-family: ${(props) => props.theme.fonts.bold};
-	margin-right: 12px;
-	margin-left: 2px;
 `;
 
 const InputContainer = styled(FlexDivRowCentered)`

--- a/translations/en.json
+++ b/translations/en.json
@@ -554,6 +554,7 @@
 				"rate": "24H funding rate"
 			},
 			"trade": {
+				"market": "market",
 				"title": "trade",
 				"input": {
 					"buy": "buy",

--- a/translations/en.json
+++ b/translations/en.json
@@ -554,7 +554,7 @@
 				"rate": "24H funding rate"
 			},
 			"trade": {
-				"market": "market",
+				"market": "isolated market",
 				"title": "trade",
 				"input": {
 					"buy": "buy",


### PR DESCRIPTION
## Description
Asset dropdown to quickly change asset from trading view. When changing asset the URL whille change and update the whole trading UI

## Motivation and Context
Beta testing feedback

## How Has This Been Tested?
Locally, Optimism Kovan

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/5688912/136728201-b36d7a21-e16f-48d3-ab80-c962e51ed82e.mov

:
