### PR TITLE
Correct synths link for snx.

### DIFF
--- a/constants/links.ts
+++ b/constants/links.ts
@@ -19,8 +19,7 @@ export const EXTERNAL_LINKS = {
 		GitHub: 'https://github.com/synthetixio/kwenta',
 	},
 	TokenLists: {
-		Synthetix:
-			'https://bafybeidkpj743vthl5chzdxibjxfbf2hv3y4mmtcbciu4kdh4d6xqfezpa.ipfs.dweb.link/',
+		Synthetix: 'https://synths.snx.eth.link/',
 		Zapper: 'https://zapper.fi/api/token-list',
 		OneInch: 'https://gateway.ipfs.io/ipns/tokens.1inch.eth',
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make sure we use the latest synths icons.
## Motivation and Context
Before we used a hardcoded ipfs link, now the use ens that will point to the latest one.
## How Has This Been Tested?
Tested locally
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5688912/137045973-b631e267-3721-445a-ba11-a088f7da6a9b.png)
