### PR TITLE
Upgrade immer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"framer-motion": "4.1.17",
 				"graphql-request": "3.4.0",
 				"i18next": "19.7.0",
-				"immer": "8.0.1",
+				"immer": "9.0.6",
 				"lodash": "4.17.20",
 				"moment-business-time": "1.1.1",
 				"next": "10.0.0",
@@ -25294,9 +25294,9 @@
 			"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
 		},
 		"node_modules/immer": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-			"integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+			"integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/immer"
@@ -64938,9 +64938,9 @@
 			"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
 		},
 		"immer": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-			"integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+			"integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"framer-motion": "4.1.17",
 		"graphql-request": "3.4.0",
 		"i18next": "19.7.0",
-		"immer": "8.0.1",
+		"immer": "9.0.6",
 		"lodash": "4.17.20",
 		"moment-business-time": "1.1.1",
 		"next": "10.0.0",


### PR DESCRIPTION
Immer has a vulnerability npm audit consider critical and failing CI. Going from v8 -> v9 is a breaking change. 
You can see release notes here: https://github.com/immerjs/immer/releases/tag/v9.0.0.
No type errors and I was able to do trades without any problem. Not sure how I should be testing it more. I haven't used immer too much so a bit unclear to me what the impact of that breaking change is.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
CI failing

## How Has This Been Tested?
Tested locally
