### PR TITLE
only block for maintenance on prod

### DIFF
--- a/constants/links.ts
+++ b/constants/links.ts
@@ -1,5 +1,7 @@
 import { CurrencyKey } from './currency';
 
+export const PROD_HOSTNAME = 'kwenta.io';
+
 export const EXTERNAL_LINKS = {
 	Trading: {
 		DexAG: 'https://dex.ag/',

--- a/sections/shared/SystemStatus/SystemStatus.tsx
+++ b/sections/shared/SystemStatus/SystemStatus.tsx
@@ -15,7 +15,7 @@ import {
 
 import Logo from 'sections/shared/Layout/Logo';
 
-import { EXTERNAL_LINKS } from 'constants/links';
+import { EXTERNAL_LINKS, PROD_HOSTNAME } from 'constants/links';
 import { HEADER_HEIGHT } from 'constants/ui';
 
 import SystemDownIcon from 'assets/svg/app/system-down.svg';
@@ -62,9 +62,10 @@ const SystemStatus: FC<SystemStatusProps> = ({ children }) => {
 		refetchInterval: REFRESH_INTERVAL,
 	});
 
-	const appOnMaintenance = isSystemOnMaintenanceQuery.isSuccess
-		? isSystemOnMaintenanceQuery.data
-		: false;
+	const appOnMaintenance =
+		typeof window !== 'undefined' &&
+		window.location.hostname === PROD_HOSTNAME &&
+		(isSystemOnMaintenanceQuery.isSuccess ? isSystemOnMaintenanceQuery.data : false);
 
 	return appOnMaintenance ? (
 		<>


### PR DESCRIPTION
only block kwenta app for maintenance on prod deployment

## Description
Uses a simple hostname check and only blocks app on prod

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This way synthetix developers can test the system on `dev.kwenta.io` without needing to go through dapp maintenance blockage.

## How Has This Been Tested?
The system is (as of writing) suspended. It does not show maintenance page outside of `kwenta.io` hsotname in browser.