### PR TITLE
Allow git+https: in lockfile lint

### DIFF
--- a/.github/workflows/audit_build_verify.yml
+++ b/.github/workflows/audit_build_verify.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm audit --audit-level=critical
 
       - name: Lockfile lint
-        run: lockfile-lint -p package-lock.json --type npm --allowed-hosts npm github.com --allowed-schemes "https:" "git+ssh:" "npm:"
+        run: lockfile-lint -p package-lock.json --type npm --allowed-hosts npm github.com --allowed-schemes "https:" "git+ssh:" "npm:" "git+https:"
 
   build:
     needs: audit


### PR DESCRIPTION
There's a dependency on another package that uses the git+https scheme and was breaking CI