### PR TITLE
fix(typo): fix a typo (Etherem->Ethereum) in the Kwenta homepage

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -97,7 +97,7 @@
 			"one": {
 				"title": "You’ll need a web3 wallet with ETH for gas",
 				"subtitle": "Step One",
-				"copy": "Kwenta is on the Etherem blockchain, so like all other dApps on Ethereum you’ll need a web3 wallet with ETH in it as gas to pay for transactions to be processed. Popular cryptocurrency wallet categories include hardware wallets, browser extension wallets, and mobile wallets."
+				"copy": "Kwenta is on the Ethereum blockchain, so like all other dApps on Ethereum you’ll need a web3 wallet with ETH in it as gas to pay for transactions to be processed. Popular cryptocurrency wallet categories include hardware wallets, browser extension wallets, and mobile wallets."
 			},
 			"two": {
 				"title": "Acquire sUSD (or any other Synth)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a typo (Etherem->Ethereum) in `en.json`, which affects the Kwenta homepage.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes a typo in the Kwenta homepage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is a text file change and shouldn't break any test.

## Screenshots (if appropriate):
![typo](https://user-images.githubusercontent.com/53351186/145682993-e8beb8de-29ed-474d-b12d-6a87e05c32b4.png)

