### PR TITLE
prevent infinite gasPrice fetching in L1 Shorting Rewards

### DIFF
--- a/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useEffect, useCallback, Dispatch, SetStateAction } from 'react';
+import { FC, useMemo, useState, useCallback, Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
@@ -118,14 +118,6 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 		return null;
 	}, [walletAddress, currencyKey, synthetixjs, gasPrice, getL1SecurityFee]);
 
-	useEffect(() => {
-		async function getGasEstimateCall() {
-			const gasInfo = await getGasEstimate();
-			setGasInfo(gasInfo);
-		}
-		getGasEstimateCall();
-	}, [getGasEstimate, setGasInfo, gasPrice]);
-
 	const handleSubmit = useCallback(async () => {
 		if (synthetixjs != null && gasPrice != null) {
 			setTxError(null);
@@ -161,7 +153,7 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 				setTxConfirmationModalOpen(false);
 			} catch (e) {
 				console.log(e);
-				setTxError(e.message);
+				setTxError(e?.message);
 			} finally {
 				setIsSubmitting(false);
 			}

--- a/sections/shorting/ShortingRewards/ShortingRewards.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewards.tsx
@@ -9,7 +9,7 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { CRYPTO_CURRENCY_MAP, Synths } from 'constants/currency';
 import { SYNTHS_TO_SHORT } from '../constants';
 
-import ShortingReward, { GasInfo } from './ShortingRewardRow';
+import ShortingRewardRow, { GasInfo } from './ShortingRewardRow';
 
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
 import { getTransactionPrice } from 'utils/network';
@@ -76,9 +76,14 @@ const ShortingRewards: FC = () => {
 		<div>
 			<Title>{t('shorting.rewards.title')}</Title>
 			{SYNTHS_TO_SHORT.map((currencyKey) => (
-				<ShortingReward
+				<ShortingRewardRow
 					key={currencyKey}
-					{...{ gasPrice, setGasInfo, currencyKey, snxPriceRate }}
+					{...{
+						gasPrice,
+						setGasInfo,
+						currencyKey,
+						snxPriceRate,
+					}}
 				/>
 			))}
 			<StyledGasPriceSummaryItem {...{ gasPrices, transactionFee }} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Shorting Rewards section on L1 is doing a fetch for each currency, then updating the gasInfo based on the requests.

I'm not sure why this was done this way, since each result of the API call is overwritten by the subsequent result. e.g. the call for sETH overwrites the result from the previous call to sBTC.

Removing these fetches altogether takes care of the memory leak issue.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Kwenta/kwenta/issues/231

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
If you visit L1 shorts and pop open the `Performance Monitor` tab in Chrome Dev Tools, you'll now see the CPU usage steadily in the single digits (as opposed to 100+, as it's currently behaving in production)
![image](https://user-images.githubusercontent.com/16483341/147980504-42aab4bc-a9ff-48c0-ab54-ad66ea058a93.png)


## Screenshots (if appropriate):
