### PR TITLE
[UI Refresh] - Add InfoBox component

### DIFF
--- a/components/InfoBox/InfoBox.tsx
+++ b/components/InfoBox/InfoBox.tsx
@@ -21,6 +21,7 @@ const InfoBoxContainer = styled.div`
 	border-radius: 16px;
 	padding: 14px;
 	box-sizing: border-box;
+	width: 100%;
 
 	div {
 		display: flex;

--- a/components/InfoBox/InfoBox.tsx
+++ b/components/InfoBox/InfoBox.tsx
@@ -34,6 +34,7 @@ const InfoBoxContainer = styled.div`
 		.key {
 			color: #787878;
 			font-size: 12px;
+			text-transform: capitalize;
 		}
 
 		.value {

--- a/components/InfoBox/InfoBox.tsx
+++ b/components/InfoBox/InfoBox.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+
+type InfoBoxProps = {
+	details: Record<string, string>;
+};
+
+const InfoBox: React.FC<InfoBoxProps> = ({ details }) => (
+	<InfoBoxContainer>
+		{Object.entries(details).map(([key, value]) => (
+			<div key={key}>
+				<p className="key">{key}:</p>
+				<p className="value">{value}</p>
+			</div>
+		))}
+	</InfoBoxContainer>
+);
+
+const InfoBoxContainer = styled.div`
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 16px;
+	padding: 14px;
+	box-sizing: border-box;
+
+	div {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		p {
+			margin: 0;
+		}
+
+		.key {
+			color: #787878;
+			font-size: 12px;
+		}
+
+		.value {
+			color: #ece8e3;
+			font-family: ${(props) => props.theme.fonts.mono};
+			font-size: 12px;
+		}
+
+		&:not(:last-of-type) {
+			margin-bottom: 8px;
+		}
+	}
+`;
+
+export default InfoBox;

--- a/components/InfoBox/index.ts
+++ b/components/InfoBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InfoBox';


### PR DESCRIPTION
## Description
This PR adds an `InfoBox` component, used for displaying (mostly numerical) information about market, trades, fees etc.

It works by taking in a `details` prop, which is a key-value representation of the data to be displayed. A sample instance is shown in the screenshot below.

## Related issue
N/A

## Motivation and Context
This PR is part of the Kwenta UI refresh.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15985212/148614390-48ec142a-7106-4fd1-bc4a-8740c2942c13.png)

