### PR TITLE
[UI Refresh] - Add Input component

### DIFF
--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -4,17 +4,18 @@ export const inputCSS = css`
 	width: 100%;
 	min-width: 0;
 	font-family: ${(props) => props.theme.fonts.regular};
-	background-color: ${(props) => props.theme.colors.black};
-	height: 32px;
-	padding: 0 8px;
-	font-size: 14px;
-	border: 0;
-	border-radius: 4px;
-	color: ${(props) => props.theme.colors.white};
-	::placeholder {
-		color: ${(props) => props.theme.colors.silver};
-	}
+	border: 1px solid #ffffff1a;
+	background: linear-gradient(180deg, #1b1b1b 0%, rgba(27, 27, 27, 0.3) 100%);
+	height: 46px;
+	padding: 0 12px;
+	font-size: 18px;
+	border-radius: 16px;
+	color: #ece8e3;
 	outline: none;
+
+	::placeholder {
+		color: #787878;
+	}
 `;
 
 export const Input = styled.input`

--- a/components/Input/OrderSizingInput.tsx
+++ b/components/Input/OrderSizingInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 type OrderSizingInputProps = {
-	value?: string;
+	value?: string | number;
 	onChange: React.ChangeEventHandler<HTMLInputElement>;
 	synth: string;
 };

--- a/components/Input/OrderSizingInput.tsx
+++ b/components/Input/OrderSizingInput.tsx
@@ -2,20 +2,17 @@ import React from 'react';
 import styled from 'styled-components';
 
 type OrderSizingInputProps = {
-	value: string;
-	onChange(text: string): void;
+	value?: string;
+	onChange: React.ChangeEventHandler<HTMLInputElement>;
 	synth: string;
-	style?: React.CSSProperties;
 };
 
-const OrderSizingInput: React.FC<OrderSizingInputProps> = ({ value, onChange, synth, style }) => {
-	return (
-		<OrderSizingInputContainer {...{ style }}>
-			<input value={value} onChange={(e) => onChange(e.target.value)} />
-			<span>{synth}</span>
-		</OrderSizingInputContainer>
-	);
-};
+const OrderSizingInput: React.FC<OrderSizingInputProps> = ({ value, onChange, synth }) => (
+	<OrderSizingInputContainer>
+		<input value={value} onChange={onChange} />
+		<span>{synth}</span>
+	</OrderSizingInputContainer>
+);
 
 const OrderSizingInputContainer = styled.div`
 	display: flex;
@@ -39,6 +36,10 @@ const OrderSizingInputContainer = styled.div`
 
 		&:focus {
 			outline: none;
+		}
+
+		::placeholder {
+			color: #787878;
 		}
 	}
 

--- a/components/Input/OrderSizingInput.tsx
+++ b/components/Input/OrderSizingInput.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+
+type OrderSizingInputProps = {
+	value: string;
+	onChange(text: string): void;
+	synth: string;
+	style?: React.CSSProperties;
+};
+
+const OrderSizingInput: React.FC<OrderSizingInputProps> = ({ value, onChange, synth, style }) => {
+	return (
+		<OrderSizingInputContainer {...{ style }}>
+			<input value={value} onChange={(e) => onChange(e.target.value)} />
+			<span>{synth}</span>
+		</OrderSizingInputContainer>
+	);
+};
+
+const OrderSizingInputContainer = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	box-sizing: border-box;
+	height: 46px;
+	background: linear-gradient(180deg, #1b1b1b 0%, rgba(27, 27, 27, 0.75) 100%);
+	box-shadow: 0px 0.5px 0px 0px #ffffff14;
+	border: 1px solid #ffffff1a;
+	border-radius: 16px;
+	padding: 12px 14px;
+
+	input {
+		font-family: ${(props) => props.theme.fonts.mono};
+		font-size: 18px;
+		line-height: 22px;
+		background-color: transparent;
+		border: none;
+		color: #ece8e3;
+
+		&:focus {
+			outline: none;
+		}
+	}
+
+	span {
+		font-family: monospace;
+		font-size: 16px;
+		color: #787878;
+	}
+`;
+
+export default OrderSizingInput;


### PR DESCRIPTION
## Description
This PR updates the existing `Input` component, according to the new design specifications. It also adds a new component `OrderSizingInput`, which is used on the futures screen to set the order size. Attached is a screenshot of the futures market screen with the updated inputs.

## Related issue
N/A

## Motivation and Context
This is part of the Kwenta UI refresh.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15985212/148662130-2f9ef7a6-5177-4163-9136-74e61279620c.png)

