### PR TITLE
update OVM Shorts' subgraph endpoint

### DIFF
--- a/queries/collateral/subgraph/utils.ts
+++ b/queries/collateral/subgraph/utils.ts
@@ -13,8 +13,7 @@ export const SHORT_GRAPH_ENDPOINT_OVM_KOVAN =
 	'https://api.thegraph.com/subgraphs/name/dbeal-eth/optimism-kovan-shorts4';
 
 export const SHORT_GRAPH_ENDPOINT_OVM =
-	'https://api.thegraph.com/subgraphs/name/kmeraz/optimism-main';
-// 'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main';
+	'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main';
 
 export const formatShort = (response: any): Partial<HistoricalShortPosition> => {
 	return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We were using my own subgraph that we deployed while the synthetix subgraph synced. This PR switches away from the former to now use the latter.
