### PR TITLE
[UI Refresh] - Add MarketDetails component

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -111,7 +111,7 @@ const Button = styled.button<ButtonProps>`
 	${(props) =>
 		props.size === 'md' &&
 		css`
-			height: 41px;
+			height: 55px;
 		`};
 
 	${(props) =>

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -1,0 +1,91 @@
+import { CurrencyKey } from '@synthetixio/contracts-interface';
+import React from 'react';
+import styled from 'styled-components';
+
+type MarketDetailsProps = {
+	baseCurrencyKey: CurrencyKey;
+};
+
+type MarketData = Record<string, { value: string; color?: string }>;
+
+const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
+	const data: MarketData = React.useMemo(() => {
+		return {
+			[`${baseCurrencyKey}/sUSD`]: {
+				value: '$12,392.92',
+				color: 'green',
+			},
+			'Live Price': {
+				value: '$12,392.92',
+			},
+			'24H Change': {
+				value: '$12,392.92',
+				color: 'red',
+			},
+			'24h Volume': {
+				value: '$12,392.92',
+			},
+			'24H Trades': {
+				value: '$12,392.92',
+			},
+			'Open Interest': {
+				value: '$12,392.92',
+			},
+			'1H Funding': {
+				value: '$12,392.92',
+				color: 'green',
+			},
+		};
+	}, [baseCurrencyKey]);
+
+	return (
+		<MarketDetailsContainer>
+			{Object.entries(data).map(([key, { value, color }]) => (
+				<div key={key}>
+					<p className="heading">{key}</p>
+					<p className={color ? `value ${color}` : 'value'}>{value}</p>
+				</div>
+			))}
+		</MarketDetailsContainer>
+	);
+};
+
+const MarketDetailsContainer = styled.div`
+	width: 100%;
+	padding: 12px 18px;
+
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 16px;
+	box-sizing: border-box;
+
+	p {
+		margin: 0;
+		text-align: left;
+	}
+
+	.heading {
+		font-size: 12px;
+		color: #787878;
+	}
+
+	.value {
+		margin-top: 4px;
+		font-family: ${(props) => props.theme.fonts.mono};
+		font-size: 12px;
+		color: #ece8e3;
+	}
+
+	.green {
+		color: #7fd482;
+	}
+
+	.red {
+		color: #ef6868;
+	}
+`;
+
+export default MarketDetails;

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -53,6 +53,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 const MarketDetailsContainer = styled.div`
 	width: 100%;
 	padding: 12px 18px;
+	box-sizing: border-box;
 
 	display: flex;
 	justify-content: space-between;

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -19,20 +19,20 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 				value: '$12,392.92',
 			},
 			'24H Change': {
-				value: '$12,392.92',
+				value: '$392.92 (1.8%)',
 				color: 'red',
 			},
-			'24h Volume': {
-				value: '$12,392.92',
+			'24H Volume': {
+				value: '$1,392,988.92',
 			},
 			'24H Trades': {
-				value: '$12,392.92',
+				value: '22,321',
 			},
 			'Open Interest': {
-				value: '$12,392.92',
+				value: '88,278.12 ETH',
 			},
 			'1H Funding': {
-				value: '$12,392.92',
+				value: '0.004418%',
 				color: 'green',
 			},
 		};

--- a/sections/futures/MarketDetails/index.ts
+++ b/sections/futures/MarketDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MarketDetails';


### PR DESCRIPTION
## Description
This PR adds a `MarketDetails` component, for use on the new futures UI. This PR contains purely presentational features for this component. However, since it is futures specific, it is expected that the computations required to display accurate market information will be added to this component.

Also, the PR fixes an issue with the button component, that renders `md` buttons at `sm` height.

## Related issue
N/A

## Motivation and Context
This PR is part of the Kwenta UI refresh.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15985212/149023274-aa42b723-d591-48f6-9d88-dcb01879a276.png)

