### PR TITLE
fetch a short's initialCollateralPrice from L1 rates subgraph on L1

### DIFF
--- a/queries/collateral/useCollateralShortPositionQuery.ts
+++ b/queries/collateral/useCollateralShortPositionQuery.ts
@@ -130,8 +130,7 @@ const useCollateralShortPositionQuery = (
 			if (txHash != null && provider != null && createdAt != null) {
 				const tx = await provider.getTransaction(txHash);
 				if (tx != null) {
-					const RATE_UPDATES_ENDPOINT =
-						'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main';
+					const RATE_UPDATES_ENDPOINT = isL2 ? SHORT_GRAPH_ENDPOINT_OVM : SHORT_GRAPH_ENDPOINT;
 
 					let [initialCollateralPriceResponse, latestCollateralPrice] = (await Promise.all([
 						request(


### PR DESCRIPTION
## Description
We will now fetch the `initialCollateralPrice` from L1 when the short is on L1.

We were seeing an error around fetching the initialCollateralPrice from a short that was opened up before L2 Optimism was deployed. The price was fetch via a timestamp, but due to the age of the short, the rate at that timestamp didn't exist.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
