### PR TITLE
issue 291 - integrated tally wallet

### DIFF
--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -65,6 +65,7 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 				{ walletName: 'torus' },
 				{ walletName: 'status' },
 				{ walletName: 'authereum' },
+				{ walletName: 'tally' },
 			],
 		},
 		walletCheck: [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"@tippyjs/react": "4.1.0",
 		"axios": "0.21.1",
 		"bignumber.js": "9.0.0",
-		"bnc-onboard": "1.35.3",
+		"bnc-onboard": "1.36.0",
 		"date-fns": "2.21.3",
 		"date-fns-tz": "1.1.4",
 		"ethcall": "3.2.0",


### PR DESCRIPTION
## Description
Copy pasted two lines of code from their documentation, then wasted everyone's time with an incomplete .env.local configuration

## Related issue
https://github.com/Kwenta/kwenta/issues/291

## Motivation and Context
Request by Users.  Verbal approval by PE, CC, Council.  More wallet support is always better.

## How Has This Been Tested?
Deployed locally.
Checked functionality before changes were made.
Made changes.
Checked functionality after changes were made.

Specifically tested for connect, disconnect correctness and flow, no errors when connecting to other wallets with this wallet installed and integrated.

Ubuntu 21.04, Chrome and Chromium. Firefox Extension has been pulled by Devs for some reason.

No expected secondary impact from upgrading bnc-onboard from 1.35.3 to 1.36.0.
No expected secondary impact from adding another icon to the wallet list.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/94415863/151271585-a3fbe961-eec2-4b8b-9bec-4a94ea768e02.png)
