### PR TITLE
fix(links): fix Learn More broken link

### DIFF
--- a/constants/links.ts
+++ b/constants/links.ts
@@ -25,4 +25,7 @@ export const EXTERNAL_LINKS = {
 		Zapper: 'https://zapper.fi/api/token-list',
 		OneInch: 'https://gateway.ipfs.io/ipns/tokens.1inch.eth',
 	},
+	Docs: {
+		DocsRoot: 'https://docs.kwenta.io/',
+	},
 };

--- a/sections/homepage/L2/L2.tsx
+++ b/sections/homepage/L2/L2.tsx
@@ -9,6 +9,7 @@ import {
 	FlexDivCol,
 	FlexDivColCentered,
 	FlexDivRow,
+	ExternalLink,
 } from 'styles/common';
 
 import { Copy, FlexSection, GridContainer, LeftSubHeader, Title } from '../common';
@@ -24,6 +25,7 @@ import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
 import { useRecoilValue } from 'recoil';
 import { isL2State } from 'store/wallet';
 import ROUTES from 'constants/routes';
+import { EXTERNAL_LINKS } from 'constants/links';
 
 const L2 = () => {
 	const { t } = useTranslation();
@@ -72,11 +74,11 @@ const L2 = () => {
 						</L2Copy>
 						<Media lessThan="lg">{OptimismStats}</Media>
 						<CTARow>
-							<Link href={'https://blog.kwenta.io/hello-optimism-kwenta-is-live-on-l2/'}>
+							<ExternalLink href={EXTERNAL_LINKS.Docs.DocsRoot}>
 								<Button variant={'outline'} size={'lg'}>
 									{t('homepage.l2.cta-buttons.learn-more')}
 								</Button>
-							</Link>
+							</ExternalLink>
 							{isL2 ? (
 								<Link href={ROUTES.Dashboard.Home}>
 									<Button variant="primary" isRounded={false} size="lg">

--- a/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
+++ b/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
@@ -14,6 +14,7 @@ import BlockExplorer from 'containers/BlockExplorer';
 import { components } from 'react-select';
 import { IndicatorSeparator } from 'components/Select/Select';
 import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
+import { EXTERNAL_LINKS } from 'constants/links';
 
 type ReactSelectOptionProps = {
 	label: string;
@@ -49,7 +50,7 @@ const NetworksSwitcher: FC<NetworksSwitcherProps> = () => {
 		{
 			label: 'header.networks-switcher.learn-more',
 			postfixIcon: 'Link',
-			link: 'https://blog.kwenta.io/hello-optimism-kwenta-is-live-on-l2/',
+			link: EXTERNAL_LINKS.Docs.DocsRoot,
 		},
 	];
 


### PR DESCRIPTION
This commit adds Docs link to the external links constant (links.ts) and uses the added link in the homepage and NetworkSwitcher sections. fixes #301
