### PR TITLE
Added graceful redirect message from L1 to L2 for shorting

### DIFF
--- a/sections/shorting/ShortingCard/ShortingCard.tsx
+++ b/sections/shorting/ShortingCard/ShortingCard.tsx
@@ -15,8 +15,8 @@ import { useTranslation, Trans } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 import { isL2State } from 'store/wallet';
 
-import { MessageContainer, Message } from '../common';
-import NetworksSwitcher from 'sections/shared/Layout/AppLayout/Header/NetworksSwitcher';
+import { MessageContainer, Message, MessageButton } from '../common';
+import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
 
 const ShortingCard: FC = () => {
 	const { quoteCurrencyCard, baseCurrencyCard, footerCard } = useShort({
@@ -26,6 +26,7 @@ const ShortingCard: FC = () => {
 
 	const { t } = useTranslation();
 	const isL2 = useRecoilValue(isL2State);
+	const { switchToL1, switchToL2 } = useNetworkSwitcher();
 
 	return (
 		<Container>
@@ -45,7 +46,9 @@ const ShortingCard: FC = () => {
 					<Message>
 						<Trans t={t} i18nKey="shorting.l1-deprecated" />
 					</Message>
-					<NetworksSwitcher />
+					<MessageButton size="lg" variant="primary" isRounded={true} onClick={switchToL2}>
+						{t('header.networks-switcher.l2')}
+					</MessageButton>
 				</MessageContainer>
 			)}
 		</Container>

--- a/sections/shorting/ShortingCard/ShortingCard.tsx
+++ b/sections/shorting/ShortingCard/ShortingCard.tsx
@@ -11,24 +11,43 @@ import useShort from '../hooks/useShort';
 
 import { CurrencyCardsSelector, ExchangeCardsWithSelector } from 'styles/common';
 
+import { useTranslation, Trans } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
+import { isL2State } from 'store/wallet';
+
+import { MessageContainer, Message } from '../common';
+import NetworksSwitcher from 'sections/shared/Layout/AppLayout/Header/NetworksSwitcher';
+
 const ShortingCard: FC = () => {
 	const { quoteCurrencyCard, baseCurrencyCard, footerCard } = useShort({
 		defaultBaseCurrencyKey: Synths.sETH,
 		defaultQuoteCurrencyKey: Synths.sUSD,
 	});
 
+	const { t } = useTranslation();
+	const isL2 = useRecoilValue(isL2State);
+
 	return (
 		<Container>
-			<ConvertContainer>
-				<ExchangeCardsWithSelector>
-					{quoteCurrencyCard}
-					{baseCurrencyCard}
-					<StyledCurrencyCardsSelector>
-						<CRatioSelector />
-					</StyledCurrencyCardsSelector>
-				</ExchangeCardsWithSelector>
-				<ExchangeFooter>{footerCard}</ExchangeFooter>
-			</ConvertContainer>
+			{isL2 ? (
+				<ConvertContainer>
+					<ExchangeCardsWithSelector>
+						{quoteCurrencyCard}
+						{baseCurrencyCard}
+						<StyledCurrencyCardsSelector>
+							<CRatioSelector />
+						</StyledCurrencyCardsSelector>
+					</ExchangeCardsWithSelector>
+					<ExchangeFooter>{footerCard}</ExchangeFooter>
+				</ConvertContainer>
+			) : (
+				<MessageContainer>
+					<Message>
+						<Trans t={t} i18nKey="shorting.l1-deprecated" />
+					</Message>
+					<NetworksSwitcher />
+				</MessageContainer>
+			)}
 		</Container>
 	);
 };

--- a/sections/shorting/ShortingCard/ShortingCard.tsx
+++ b/sections/shorting/ShortingCard/ShortingCard.tsx
@@ -26,7 +26,7 @@ const ShortingCard: FC = () => {
 
 	const { t } = useTranslation();
 	const isL2 = useRecoilValue(isL2State);
-	const { switchToL1, switchToL2 } = useNetworkSwitcher();
+	const { switchToL2 } = useNetworkSwitcher();
 
 	return (
 		<Container>

--- a/sections/shorting/common.tsx
+++ b/sections/shorting/common.tsx
@@ -35,15 +35,6 @@ export const MessageContainer = styled(GridDivCentered)<{
 	padding: 16px 32px;
 	margin: 0 0 20px;
 
-	/*
-	width: 100%;
-	border-radius: 1000px;
-	grid-template-columns: 1fr auto;
-	background-color: ${(props) => props.theme.colors.elderberry};
-	padding: 16px 32px;
-	max-width: 750px;
-	margin: 0 auto;
-	*/
 	${(props) =>
 		props.attached &&
 		css`

--- a/sections/shorting/common.tsx
+++ b/sections/shorting/common.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import Button from 'components/Button';
 
 import { FixedFooterMixin, GridDivCentered } from 'styles/common';
 import media from 'styles/media';
@@ -48,3 +49,9 @@ export const MessageContainer = styled(GridDivCentered)<{
 		z-index: ${zIndex.BASE};
 	`}
 `;
+
+export const MessageButton = styled(Button).attrs({
+	variant: 'primary',
+	size: 'lg',
+	isRounded: true,
+})``;

--- a/sections/shorting/common.tsx
+++ b/sections/shorting/common.tsx
@@ -1,4 +1,9 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+import { FixedFooterMixin, GridDivCentered } from 'styles/common';
+import media from 'styles/media';
+
+import { zIndex } from 'constants/ui';
 
 export const Title = styled.div`
 	color: ${(props) => props.theme.colors.white};
@@ -6,4 +11,49 @@ export const Title = styled.div`
 	font-size: 14px;
 	text-transform: capitalize;
 	padding-bottom: 15px;
+`;
+
+export const Message = styled.div`
+	color: ${(props) => props.theme.colors.white};
+	font-size: 14px;
+	font-family: ${(props) => props.theme.fonts.bold};
+	flex-grow: 1;
+	text-align: center;
+`;
+
+export const MessageContainer = styled(GridDivCentered)<{
+	attached?: boolean;
+	showProvider?: boolean;
+}>`
+	display: grid;
+	-webkit-box-align: center;
+	align-items: center;
+	width: 100%;
+	border-radius: 4px;
+	grid-template-columns: ${(props) => props.showProvider && '.5fr'} 1fr auto;
+	background-color: ${(props) => props.theme.colors.elderberry};
+	padding: 16px 32px;
+	margin: 0 0 20px;
+
+	/*
+	width: 100%;
+	border-radius: 1000px;
+	grid-template-columns: 1fr auto;
+	background-color: ${(props) => props.theme.colors.elderberry};
+	padding: 16px 32px;
+	max-width: 750px;
+	margin: 0 auto;
+	*/
+	${(props) =>
+		props.attached &&
+		css`
+			border-radius: 4px;
+		`}
+	${media.lessThan('md')`
+		${FixedFooterMixin};
+		box-shadow: 0 -8px 8px 0 ${(props) => props.theme.colors.black};
+		justify-content: center;
+		display: flex;
+		z-index: ${zIndex.BASE};
+	`}
 `;

--- a/translations/en.json
+++ b/translations/en.json
@@ -510,7 +510,9 @@
 				"no-results": "No shorts found",
 				"accrued-interest": "Accrued Interest"
 			}
-		}
+		},
+		"l1-deprecated": "Shorting on L1 is no longer available; please switch to L2, or manage your L1 positions below."
+
 	},
 	"not-found": {
 		"page-title": "Not Found | Kwenta",

--- a/translations/en.json
+++ b/translations/en.json
@@ -511,7 +511,7 @@
 				"accrued-interest": "Accrued Interest"
 			}
 		},
-		"l1-deprecated": "Shorting on L1 is no longer available; please switch to L2, or manage your L1 positions below."
+		"l1-deprecated": "Shorting on L1 is deprecated; please switch to L2, or manage your L1 positions below."
 
 	},
 	"not-found": {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added MessageContainer and Message to shorting/common and ShortingCard
Display message and "Switch to L2' button when L1 ShortingCard visible
Added new redirect message to translations/en.json
 - "Shorting on L1 is no longer available; please switch to L2, or manage your L1 positions below."


## Related issue
https://github.com/Kwenta/kwenta/issues/303

## Motivation and Context
Shorting on Ethereum mainnet (L1) is deprecated (SCCP-146)
This improves the user experience, compared to attempted L1 shorting transactions failing.

## How Has This Been Tested?
Tested on Ubuntu 21.04 and Firefox and Chrome.
Switching between L1 and L2 Shorting tabs from App Header Layout

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/94415863/151910682-59fe2fa4-9d68-46ae-8ac3-cd8de9136151.png)
