### PR TITLE
[UI Refresh] - Futures View

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { ThemeProvider } from 'styled-components';
-import theme from '../styles/theme';
+import { CustomThemeProvider } from '../contexts/CustomThemeContext';
 import '../styles/main.css';
 
 export const parameters = {
@@ -15,8 +14,8 @@ export const parameters = {
 
 export const decorators = [
 	(Story) => (
-		<ThemeProvider theme={theme}>
+		<CustomThemeProvider>
 			<Story />
-		</ThemeProvider>
+		</CustomThemeProvider>
 	),
 ];

--- a/components/Button/TabButton.tsx
+++ b/components/Button/TabButton.tsx
@@ -7,10 +7,11 @@ type TabButtonProps = {
 	detail?: string;
 	badge?: number;
 	active?: boolean;
+	onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
 	disabled?: boolean;
 };
 
-const TabButton: React.FC<TabButtonProps> = ({ title, detail, badge, ...props }) => {
+const TabButton: React.FC<TabButtonProps> = ({ title, detail, badge, active, ...props }) => {
 	return (
 		<StyledButton {...props}>
 			<div>

--- a/components/Button/TabButton.tsx
+++ b/components/Button/TabButton.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from './Button';
+
+type TabButtonProps = {
+	title: string;
+	detail?: string;
+	badge?: number;
+	active?: boolean;
+	disabled?: boolean;
+};
+
+const TabButton: React.FC<TabButtonProps> = ({ title, detail, badge, ...props }) => {
+	return (
+		<StyledButton {...props}>
+			<div>
+				<p className="title">{title}</p>
+				{detail && <p className="detail">{detail}</p>}
+			</div>
+			{badge && <div className="badge">{badge}</div>}
+		</StyledButton>
+	);
+};
+
+const StyledButton = styled(Button)`
+	height: initial;
+	display: flex;
+
+	padding-top: 10px;
+	padding-bottom: 10px;
+
+	p {
+		margin: 0;
+		font-size: 13px;
+		text-align: left;
+	}
+
+	.title {
+		color: ${(props) => props.theme.colors.common.primaryWhite};
+	}
+
+	.detail {
+		color: ${(props) => props.theme.colors.common.secondaryGray};
+		margin-top: 2px;
+	}
+
+	.badge {
+		height: 16px;
+		width: fit-content;
+		padding-left: 4px;
+		padding-right: 4px;
+		margin-left: 7px;
+		font-size: 12px;
+		color: ${(props) => props.theme.colors.selectedTheme.button.tab.badge.text};
+		background-color: ${(props) => props.theme.colors.selectedTheme.button.tab.badge.background};
+		box-shadow: ${(props) => props.theme.colors.selectedTheme.button.tab.badge.shadow};
+		border-radius: 4px;
+	}
+
+	&:disabled {
+		background-color: transparent;
+
+		p {
+			color: ${(props) => props.theme.colors.selectedTheme.button.tab.disabled.text};
+		}
+
+		border: ${(props) => props.theme.colors.selectedTheme.button.tab.disabled.border};
+
+		.badge {
+			display: none;
+		}
+	}
+`;
+
+export default TabButton;

--- a/components/InfoBox/InfoBox.tsx
+++ b/components/InfoBox/InfoBox.tsx
@@ -3,10 +3,12 @@ import styled from 'styled-components';
 
 type InfoBoxProps = {
 	details: Record<string, string>;
+	style?: React.CSSProperties;
+	className?: string;
 };
 
-const InfoBox: React.FC<InfoBoxProps> = ({ details }) => (
-	<InfoBoxContainer>
+const InfoBox: React.FC<InfoBoxProps> = ({ details, style, className }) => (
+	<InfoBoxContainer style={style} className={className}>
 		{Object.entries(details).map(([key, value]) => (
 			<div key={key}>
 				<p className="key">{key}:</p>

--- a/components/Input/OrderSizingInput.tsx
+++ b/components/Input/OrderSizingInput.tsx
@@ -3,12 +3,20 @@ import styled from 'styled-components';
 
 type OrderSizingInputProps = {
 	value?: string | number;
-	onChange: React.ChangeEventHandler<HTMLInputElement>;
+	onChange?: React.ChangeEventHandler<HTMLInputElement>;
 	synth: string;
+	style?: React.CSSProperties;
+	className?: string;
 };
 
-const OrderSizingInput: React.FC<OrderSizingInputProps> = ({ value, onChange, synth }) => (
-	<OrderSizingInputContainer>
+const OrderSizingInput: React.FC<OrderSizingInputProps> = ({
+	value,
+	onChange,
+	synth,
+	style,
+	className,
+}) => (
+	<OrderSizingInputContainer style={style} className={className}>
 		<input value={value} onChange={onChange} />
 		<span>{synth}</span>
 	</OrderSizingInputContainer>
@@ -47,7 +55,7 @@ const OrderSizingInputContainer = styled.div`
 	}
 
 	span {
-		font-family: monospace;
+		font-family: ${(props) => props.theme.fonts.mono};
 		font-size: 16px;
 		color: ${(props) => props.theme.colors.selectedTheme.input.placeholder};
 	}

--- a/components/SegmentedControl/SegmentedControl.tsx
+++ b/components/SegmentedControl/SegmentedControl.tsx
@@ -5,10 +5,17 @@ interface SegmentedControlProps {
 	values: string[];
 	selectedIndex: number;
 	onChange(index: number): void;
+	style?: React.CSSProperties;
+	className?: string;
 }
 
-const SegmentedControl: React.FC<SegmentedControlProps> = ({ values, selectedIndex, onChange }) => (
-	<SegmentedControlContainer length={values.length}>
+const SegmentedControl: React.FC<SegmentedControlProps> = ({
+	values,
+	selectedIndex,
+	onChange,
+	...props
+}) => (
+	<SegmentedControlContainer $length={values.length} {...props}>
 		{values.map((value, index) => (
 			<SegmentedControlOption
 				key={value}
@@ -21,9 +28,9 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({ values, selectedInd
 	</SegmentedControlContainer>
 );
 
-const SegmentedControlContainer = styled.div<{ length: number }>`
+const SegmentedControlContainer = styled.div<{ $length: number }>`
 	display: grid;
-	grid-template-columns: repeat(${(props) => props.length}, 1fr);
+	grid-template-columns: repeat(${(props) => props.$length}, 1fr);
 	box-sizing: border-box;
 	grid-gap: 14px;
 	width: 100%;

--- a/components/SegmentedControl/SegmentedControl.tsx
+++ b/components/SegmentedControl/SegmentedControl.tsx
@@ -52,7 +52,7 @@ const SegmentedControlOption = styled.button<{ isSelected: boolean }>`
 			: css`
 					background: transparent;
 					border: none;
-					color: ${(props) => props.theme.colors.selectedTheme.segmented.button.inactive};
+					color: ${(props) => props.theme.colors.selectedTheme.segmented.button.inactive.color};
 			  `}
 `;
 

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -40,7 +40,7 @@ function Select<T>(props: Props<T>) {
 			menu: (provided, state) => ({
 				...provided,
 				background: 'linear-gradient(180deg, #39332D 0%, #2D2A28 100%)',
-				border: '1px solid rgba(255, 255, 255, 0.1)',
+				border: colors.selectedTheme.border,
 				borderRadius: '8px',
 				boxShadow: colors.selectedTheme.button.shadow,
 				padding: 0,

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -39,7 +39,7 @@ function Select<T>(props: Props<T>) {
 			}),
 			menu: (provided, state) => ({
 				...provided,
-				background: 'linear-gradient(180deg, #39332D 0%, #2D2A28 100%)',
+				background: colors.selectedTheme.button.background,
 				border: colors.selectedTheme.border,
 				borderRadius: '8px',
 				boxShadow: colors.selectedTheme.button.shadow,

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -1,16 +1,8 @@
 import React, { FC, useContext, useMemo } from 'react';
-import ReactSelect, { components, Props, StylesConfig, IndicatorProps } from 'react-select';
+import ReactSelect, { Props, StylesConfig } from 'react-select';
 import { ThemeContext } from 'styled-components';
-import { Svg } from 'react-optimized-image';
-import dropdownArrow from '../../assets/svg/app/dropdown-arrow.svg';
 
 export const IndicatorSeparator: FC = () => null;
-
-export const DropdownIndicator: FC<IndicatorProps<any>> = (props) => (
-	<components.DropdownIndicator {...props}>
-		<Svg src={dropdownArrow} />
-	</components.DropdownIndicator>
-);
 
 function Select<T>(props: Props<T>) {
 	const { colors, fonts } = useContext(ThemeContext);
@@ -98,7 +90,7 @@ function Select<T>(props: Props<T>) {
 			styles={computedStyles}
 			classNamePrefix="react-select"
 			{...props}
-			components={{ IndicatorSeparator, DropdownIndicator, ...props.components }}
+			components={{ IndicatorSeparator, ...props.components }}
 		/>
 	);
 }

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -74,16 +74,14 @@ function Select<T>(props: Props<T>) {
 				'&:hover': {
 					color: state.selectProps.dropdownIndicatorColorHover ?? colors.goldColors.color3,
 				},
-				marginRight: '22px',
 			}),
 			valueContainer: (provided) => ({
 				...provided,
 				height: '100%',
 			}),
-			...props.styles,
 		};
 		return styles;
-	}, [colors, fonts, props]);
+	}, [colors, fonts]);
 
 	return (
 		<ReactSelect

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -84,7 +84,7 @@ const StyledSlider = styled(Slider)`
 
 	.MuiSlider-thumb {
 		background-color: #e4b378;
-		box-shadow: ${(props) => props.theme.colors.selectedTheme.slider.thumb.hover.shadow} !important;
+		box-shadow: ${(props) => props.theme.colors.selectedTheme.slider.thumb.shadow} !important;
 		width: 14px;
 		height: 14px;
 		margin-left: initial;
@@ -93,7 +93,7 @@ const StyledSlider = styled(Slider)`
 
 	.MuiSlider-thumb.Mui-focusVisible,
 	.MuiSlider-thumb:hover {
-		box-shadow: ${(props) => props.theme.colors.selectedTheme.slider.thumb.hover.shadow} !important;
+		box-shadow: ${(props) => props.theme.colors.selectedTheme.slider.thumb.shadow} !important;
 	}
 
 	.MuiSlider-markLabel {

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -45,7 +45,7 @@ export default SliderComponent;
 const SliderContainer = styled.div`
 	width: 334px;
 	height: 24px;
-	background: url(${imageBackground as any}) no-repeat;
+	background: url(${imageBackground.src}) no-repeat;
 	padding: 0 19px 0 4px;
 	box-sizing: border-box;
 `;

--- a/pages/market/[[...market]].tsx
+++ b/pages/market/[[...market]].tsx
@@ -41,7 +41,7 @@ const Market: FC = () => {
 export default Market;
 
 const StyledRightSideContent = styled(RightSideContent)`
-	width: 400px;
-	padding-left: 32px;
+	width: 385px;
+	padding-left: 15px;
 	padding-right: 32px;
 `;

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+import Wei from '@synthetixio/wei';
+
+import InfoBox from 'components/InfoBox';
+import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
+import { formatCurrency } from 'utils/formatters/number';
+import { CurrencyKey } from 'constants/currency';
+import { NO_VALUE } from 'constants/placeholder';
+
+type FeeInfoBoxProps = {
+	transactionFee: number | null;
+	feeCost: Wei | null;
+};
+
+const FeeInfoBox: React.FC<FeeInfoBoxProps> = ({ transactionFee, feeCost }) => {
+	const { selectedPriceCurrency } = useSelectedPriceCurrency();
+	return (
+		<StyledInfoBox
+			details={{
+				Fee: transactionFee
+					? `${formatCurrency(selectedPriceCurrency.name as CurrencyKey, transactionFee, {
+							sign: selectedPriceCurrency.sign,
+							maxDecimals: 1,
+					  })}`
+					: NO_VALUE,
+				'Gas Fee/Cost':
+					feeCost != null
+						? formatCurrency(selectedPriceCurrency.name as CurrencyKey, feeCost, {
+								sign: selectedPriceCurrency.sign,
+								minDecimals: feeCost.lt(0.01) ? 4 : 2,
+						  })
+						: NO_VALUE,
+				Total: '10%',
+			}}
+		/>
+	);
+};
+
+const StyledInfoBox = styled(InfoBox)`
+	margin-bottom: 16px;
+`;
+
+export default FeeInfoBox;

--- a/sections/futures/FeeInfoBox/index.ts
+++ b/sections/futures/FeeInfoBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FeeInfoBox';

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -53,6 +53,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 const MarketDetailsContainer = styled.div`
 	width: 100%;
 	padding: 12px 18px;
+	margin-bottom: 16px;
 	box-sizing: border-box;
 
 	display: flex;

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -25,7 +25,7 @@ import { singleChartTypeState, singleChartPeriodState } from 'store/app';
 import usePersistedRecoilState from 'hooks/usePersistedRecoilState';
 import { CurrencyKey } from 'constants/currency';
 import MarketDetails from '../MarketDetails';
-import Button from 'components/Button';
+import TabButton from 'components/Button/TabButton';
 
 type MarketInfoProps = {
 	market: string;
@@ -135,9 +135,9 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 				setSelectedChartPeriod={setChartPeriod}
 			/>
 			<TabButtonsContainer>
-				<Button>Open Positions</Button>
-				<Button disabled>Open History</Button>
-				<Button disabled>Open Orders</Button>
+				<TabButton title="Open Positions" badge={3} />
+				<TabButton title="Open History" disabled />
+				<TabButton title="Open Orders" disabled />
 			</TabButtonsContainer>
 			{/* <MarketInfoContainer>
 				<StyledFlexDiv>
@@ -188,6 +188,7 @@ const StyledCurrencyIcon = styled(CurrencyIcon)`
 `;
 
 const TabButtonsContainer = styled.div`
+	display: flex;
 	margin-top: 16px;
 	margin-bottom: 16px;
 

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -14,9 +14,7 @@ import { formatCurrency, formatPercent, zeroBN } from 'utils/formatters/number';
 
 import PriceChartCard from 'sections/exchange/TradeCard/Charts/PriceChartCard';
 
-import { FlexDivCol, FlexDivRow } from 'styles/common';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
-import Card from 'components/Card';
 import UserInfo from '../UserInfo';
 import { FuturesMarket } from 'queries/futures/types';
 import { ChartType } from 'constants/chartType';
@@ -25,7 +23,6 @@ import { singleChartTypeState, singleChartPeriodState } from 'store/app';
 import usePersistedRecoilState from 'hooks/usePersistedRecoilState';
 import { CurrencyKey } from 'constants/currency';
 import MarketDetails from '../MarketDetails';
-import TabButton from 'components/Button/TabButton';
 
 type MarketInfoProps = {
 	market: string;
@@ -134,70 +131,12 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 				selectedChartPeriod={chartPeriod}
 				setSelectedChartPeriod={setChartPeriod}
 			/>
-			<TabButtonsContainer>
-				<TabButton title="Open Positions" badge={3} />
-				<TabButton title="Open History" disabled />
-				<TabButton title="Open Orders" disabled />
-			</TabButtonsContainer>
-			{/* <MarketInfoContainer>
-				<StyledFlexDiv>
-					{marketInfoCols.map(({ title, data }, i) => (
-						<InfoBox key={`infobox-${i}`}>
-							<InfoTitle>{title}</InfoTitle>
-							<InfoData>{data}</InfoData>
-						</InfoBox>
-					))}
-				</StyledFlexDiv>
-			</MarketInfoContainer> */}
 			<UserInfo marketAsset={baseCurrencyKey} />
 		</>
 	);
 };
 export default MarketInfo;
 
-const MarketInfoContainer = styled(Card)`
-	margin: 16px 0px;
-`;
-
-const StyledFlexDiv = styled(FlexDivRow)`
-	justify-content: space-between;
-	align-items: center;
-`;
-
-const InfoBox = styled(FlexDivCol)`
-	padding: 20px;
-`;
-
-const InfoTitle = styled.div`
-	color: ${(props) => props.theme.colors.blueberry};
-	font-family: ${(props) => props.theme.fonts.regular};
-	font-size: 12px;
-	text-transform: capitalize;
-	margin-bottom: 16px;
-`;
-
-const InfoData = styled(FlexDivRow)`
-	align-items: center;
-	color: ${(props) => props.theme.colors.white};
-	font-family: ${(props) => props.theme.fonts.mono};
-	font-size: 12px;
-`;
-
 const StyledCurrencyIcon = styled(CurrencyIcon)`
 	margin-right: 4px;
-`;
-
-const TabButtonsContainer = styled.div`
-	display: flex;
-	margin-top: 16px;
-	margin-bottom: 16px;
-
-	& > button {
-		height: 38px;
-		font-size: 13px;
-
-		&:not(:last-of-type) {
-			margin-right: 14px;
-		}
-	}
 `;

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -24,6 +24,8 @@ import { Period } from 'constants/period';
 import { singleChartTypeState, singleChartPeriodState } from 'store/app';
 import usePersistedRecoilState from 'hooks/usePersistedRecoilState';
 import { CurrencyKey } from 'constants/currency';
+import MarketDetails from '../MarketDetails';
+import Button from 'components/Button';
 
 type MarketInfoProps = {
 	market: string;
@@ -122,6 +124,7 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 						: t('futures.market.page-title')}
 				</title>
 			</Head>
+			<MarketDetails baseCurrencyKey={baseCurrencyKey} />
 			<PriceChartCard
 				side="base"
 				currencyKey={baseCurrencyKey}
@@ -131,7 +134,12 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 				selectedChartPeriod={chartPeriod}
 				setSelectedChartPeriod={setChartPeriod}
 			/>
-			<MarketInfoContainer>
+			<TabButtonsContainer>
+				<Button>Open Positions</Button>
+				<Button disabled>Open History</Button>
+				<Button disabled>Open Orders</Button>
+			</TabButtonsContainer>
+			{/* <MarketInfoContainer>
 				<StyledFlexDiv>
 					{marketInfoCols.map(({ title, data }, i) => (
 						<InfoBox key={`infobox-${i}`}>
@@ -140,7 +148,7 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 						</InfoBox>
 					))}
 				</StyledFlexDiv>
-			</MarketInfoContainer>
+			</MarketInfoContainer> */}
 			<UserInfo marketAsset={baseCurrencyKey} />
 		</>
 	);
@@ -177,4 +185,18 @@ const InfoData = styled(FlexDivRow)`
 
 const StyledCurrencyIcon = styled(CurrencyIcon)`
 	margin-right: 4px;
+`;
+
+const TabButtonsContainer = styled.div`
+	margin-top: 16px;
+	margin-bottom: 16px;
+
+	& > button {
+		height: 38px;
+		font-size: 13px;
+
+		&:not(:last-of-type) {
+			margin-right: 14px;
+		}
+	}
 `;

--- a/sections/futures/MarketInfoBox/MarketInfoBox.tsx
+++ b/sections/futures/MarketInfoBox/MarketInfoBox.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import Wei from '@synthetixio/wei';
+import InfoBox from 'components/InfoBox';
+import { formatCurrency } from 'utils/formatters/number';
+import { Synths } from '@synthetixio/contracts-interface';
+
+type MarketInfoBoxProps = {
+	availableMargin: Wei;
+	buyingPower: Wei;
+};
+
+const MarketInfoBox: React.FC<MarketInfoBoxProps> = ({ availableMargin, buyingPower }) => {
+	return (
+		<StyledInfoBox
+			details={{
+				'Available Margin': `${formatCurrency(Synths.sUSD, availableMargin, { sign: '$' })}`,
+				'Buying Power': `${formatCurrency(Synths.sUSD, buyingPower, { sign: '$' })}`,
+				'Margin Usage': '10%',
+				Leverage: '4x',
+				'Liquidation Price': '$3,718.33',
+			}}
+		/>
+	);
+};
+
+const StyledInfoBox = styled(InfoBox)`
+	margin-bottom: 16px;
+`;
+
+export default MarketInfoBox;

--- a/sections/futures/MarketInfoBox/index.ts
+++ b/sections/futures/MarketInfoBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MarketInfoBox';

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Synths } from 'constants/currency';
+import OrderSizingInput from 'components/Input/OrderSizingInput';
+
+type OrderSizingProps = {
+	marketAsset: string | null;
+};
+
+const OrderSizing: React.FC<OrderSizingProps> = ({ marketAsset }) => {
+	return (
+		<OrderSizingContainer>
+			<OrderSizingTitle>
+				Amount <span>— Set order size</span>
+			</OrderSizingTitle>
+			<OrderSizingInput style={{ marginBottom: '8px' }} synth={marketAsset || Synths.sUSD} />
+			<OrderSizingInput synth={Synths.sUSD} />
+		</OrderSizingContainer>
+	);
+};
+
+const OrderSizingContainer = styled.div`
+	margin-bottom: 8px;
+`;
+
+const OrderSizingTitle = styled.p`
+	color: ${(props) => props.theme.colors.common.primaryWhite};
+	font-size: 12px;
+	margin-bottom: 8px;
+	margin-left: 14px;
+
+	span {
+		color: ${(props) => props.theme.colors.common.secondaryGray};
+	}
+`;
+
+export default OrderSizing;

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -5,23 +5,45 @@ import { Synths } from 'constants/currency';
 import OrderSizingInput from 'components/Input/OrderSizingInput';
 
 type OrderSizingProps = {
+	assetRate: number;
+	amount: string;
+	onAmountChange: (value: string) => void;
 	marketAsset: string | null;
 };
 
-const OrderSizing: React.FC<OrderSizingProps> = ({ marketAsset }) => {
+const OrderSizing: React.FC<OrderSizingProps> = ({
+	marketAsset,
+	amount,
+	assetRate,
+	onAmountChange,
+}) => {
+	const amountValue = Number(amount) * assetRate;
+	const valueToAmount = (value: string) => (Number(value) / assetRate).toString();
+
 	return (
 		<OrderSizingContainer>
 			<OrderSizingTitle>
 				Amount <span>— Set order size</span>
 			</OrderSizingTitle>
-			<OrderSizingInput style={{ marginBottom: '8px' }} synth={marketAsset || Synths.sUSD} />
-			<OrderSizingInput synth={Synths.sUSD} />
+
+			<OrderSizingInput
+				synth={marketAsset || Synths.sUSD}
+				value={amount}
+				onChange={(e) => onAmountChange(e.target.value)}
+				style={{ marginBottom: '8px' }}
+			/>
+
+			<OrderSizingInput
+				synth={Synths.sUSD}
+				value={amountValue}
+				onChange={(e) => onAmountChange(valueToAmount(e.target.value))}
+			/>
 		</OrderSizingContainer>
 	);
 };
 
 const OrderSizingContainer = styled.div`
-	margin-bottom: 8px;
+	margin-bottom: 16px;
 `;
 
 const OrderSizingTitle = styled.p`

--- a/sections/futures/OrderSizing/index.ts
+++ b/sections/futures/OrderSizing/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderSizing';

--- a/sections/futures/PositionButtons/PositionButtons.tsx
+++ b/sections/futures/PositionButtons/PositionButtons.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import Button from 'components/Button';
-
-export type MarketPosition = 'long' | 'short';
+import { PositionSide } from '../types';
 
 interface PositionButtonsProps {
-	selected: MarketPosition;
-	setSelected(position: MarketPosition): void;
+	selected: PositionSide;
+	setSelected(position: PositionSide): void;
 }
 
 const PositionButtons: React.FC<PositionButtonsProps> = ({ selected, setSelected }) => {
@@ -14,17 +13,17 @@ const PositionButtons: React.FC<PositionButtonsProps> = ({ selected, setSelected
 		<PositionButtonsContainer>
 			<StyledPositionButton
 				fullWidth
-				$position="long"
+				$position={PositionSide.LONG}
 				$isActive={selected === 'long'}
-				onClick={() => setSelected('long')}
+				onClick={() => setSelected(PositionSide.LONG)}
 			>
 				Long
 			</StyledPositionButton>
 			<StyledPositionButton
 				fullWidth
-				$position="short"
+				$position={PositionSide.SHORT}
 				$isActive={selected === 'short'}
-				onClick={() => setSelected('short')}
+				onClick={() => setSelected(PositionSide.SHORT)}
 			>
 				Short
 			</StyledPositionButton>
@@ -33,7 +32,7 @@ const PositionButtons: React.FC<PositionButtonsProps> = ({ selected, setSelected
 };
 
 type PositionButtonProps = {
-	$position: MarketPosition;
+	$position: PositionSide;
 	$isActive: boolean;
 };
 
@@ -59,7 +58,7 @@ const StyledPositionButton = styled(Button)<PositionButtonProps>`
 	}
 
 	${(props) =>
-		props.$position === 'long' &&
+		props.$position === PositionSide.LONG &&
 		css`
 			border: 1px solid ${props.theme.colors.common.primaryGreen};
 
@@ -74,7 +73,7 @@ const StyledPositionButton = styled(Button)<PositionButtonProps>`
 		`};
 
 	${(props) =>
-		props.$position === 'short' &&
+		props.$position === PositionSide.SHORT &&
 		css`
 			border: 1px solid ${props.theme.colors.common.primaryRed};
 

--- a/sections/futures/PositionButtons/PositionButtons.tsx
+++ b/sections/futures/PositionButtons/PositionButtons.tsx
@@ -40,6 +40,8 @@ const PositionButtonsContainer = styled.div`
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-gap: 15px;
+	margin-bottom: 16px;
+	margin-top: 8px;
 `;
 
 const StyledPositionButton = styled(Button)<PositionButtonProps>`

--- a/sections/futures/PositionButtons/PositionButtons.tsx
+++ b/sections/futures/PositionButtons/PositionButtons.tsx
@@ -5,17 +5,17 @@ import { PositionSide } from '../types';
 
 interface PositionButtonsProps {
 	selected: PositionSide;
-	setSelected(position: PositionSide): void;
+	onSelect(position: PositionSide): void;
 }
 
-const PositionButtons: React.FC<PositionButtonsProps> = ({ selected, setSelected }) => {
+const PositionButtons: React.FC<PositionButtonsProps> = ({ selected, onSelect }) => {
 	return (
 		<PositionButtonsContainer>
 			<StyledPositionButton
 				fullWidth
 				$position={PositionSide.LONG}
 				$isActive={selected === 'long'}
-				onClick={() => setSelected(PositionSide.LONG)}
+				onClick={() => onSelect(PositionSide.LONG)}
 			>
 				Long
 			</StyledPositionButton>
@@ -23,7 +23,7 @@ const PositionButtons: React.FC<PositionButtonsProps> = ({ selected, setSelected
 				fullWidth
 				$position={PositionSide.SHORT}
 				$isActive={selected === 'short'}
-				onClick={() => setSelected(PositionSide.SHORT)}
+				onClick={() => onSelect(PositionSide.SHORT)}
 			>
 				Short
 			</StyledPositionButton>

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -39,13 +39,13 @@ const PositionCard: React.FC<PositionCardProps> = ({
 			<Container>
 				<DataCol>
 					<InfoCol>
-						<FlexDiv>
+						<CurrencyInfo>
 							<StyledCurrencyIcon currencyKey={currencyKey} />
 							<div>
 								<CurrencySubtitle>{currencyKey}/sUSD</CurrencySubtitle>
 								<StyledValue>Synthetic Bitcoin</StyledValue>
 							</div>
-						</FlexDiv>
+						</CurrencyInfo>
 					</InfoCol>
 					<PositionInfoCol>
 						<StyledSubtitle>Position</StyledSubtitle>
@@ -193,4 +193,8 @@ const PositionValue = styled.p<{ side: PositionSide }>`
 		css`
 			color: ${props.theme.colors.common.primaryRed};
 		`}
+`;
+
+const CurrencyInfo = styled(FlexDiv)`
+	align-items: flex-start;
 `;

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { wei } from '@synthetixio/wei';
 
 import { FlexDiv, FlexDivCol } from 'styles/common';
@@ -49,7 +49,9 @@ const PositionCard: React.FC<PositionCardProps> = ({
 					</InfoCol>
 					<PositionInfoCol>
 						<StyledSubtitle>Position</StyledSubtitle>
-						<StyledValue>LONG</StyledValue>
+						<PositionValue side={positionDetails?.side ?? PositionSide.LONG}>
+							{positionDetails?.side ?? PositionSide.LONG} ↗
+						</PositionValue>
 					</PositionInfoCol>
 				</DataCol>
 				<DataCol>
@@ -172,4 +174,23 @@ const CurrencySubtitle = styled(StyledSubtitle)`
 
 const PositionInfoCol = styled(InfoCol)`
 	padding-left: 38px;
+`;
+
+const PositionValue = styled.p<{ side: PositionSide }>`
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 12px;
+	text-transform: uppercase;
+	margin: 0;
+
+	${(props) =>
+		props.side === PositionSide.LONG &&
+		css`
+			color: ${props.theme.colors.common.primaryGreen};
+		`}
+
+	${(props) =>
+		props.side === PositionSide.SHORT &&
+		css`
+			color: ${props.theme.colors.common.primaryRed};
+		`}
 `;

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { wei } from '@synthetixio/wei';
 
-import { FlexDiv, FlexDivRow, FlexDivCol, FlexDivRowCentered, InfoTooltip } from 'styles/common';
+import { FlexDiv, FlexDivCol } from 'styles/common';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { useTranslation } from 'react-i18next';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
@@ -13,7 +13,6 @@ import { FuturesPosition, PositionSide } from 'queries/futures/types';
 import { formatNumber } from 'utils/formatters/number';
 import ClosePositionModal from './ClosePositionModal';
 import { useRouter } from 'next/router';
-import ROUTES from 'constants/routes';
 
 type PositionCardProps = {
 	currencyKey: string;
@@ -38,51 +37,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
 	return (
 		<>
 			<Container>
-				{/* <GraphicPosition>
-						<StyledGraphicRow>
-							<FlexDivCol>
-								<PositionSizeRow>
-									<StyledCurrencyIcon currencyKey={currencyKey} />
-									<PositionSizeCol>
-										<StyledPositionSize>
-											{formatCurrency(currencyKey, positionDetails?.size ?? zeroBN, {
-												currencyKey,
-											})}
-										</StyledPositionSize>
-										<StyledPositionSizeUSD>
-											{formatCurrency(
-												Synths.sUSD,
-												positionDetails?.size?.mul(wei(currencyKeyRate ?? 0)) ?? zeroBN,
-												{ sign: '$' }
-											)}
-										</StyledPositionSizeUSD>
-									</PositionSizeCol>
-								</PositionSizeRow>
-								<ROIContainer>
-									<InfoTooltip
-										placement="top"
-										content={<div>{t('futures.market.user.position.roi-tooltip')}</div>}
-									>
-										<StyledSubtitle>{t('futures.market.user.position.roi')}</StyledSubtitle>
-									</InfoTooltip>
-									<ROIValueContainer>
-										<StyledROIValue>
-											<div>
-												{formatCurrency(Synths.sUSD, positionDetails?.roi ?? zeroBN, { sign: '$' })}
-											</div>
-										</StyledROIValue>
-										<ChangePercent value={Number(positionDetails?.roiChange?.toString() ?? 0)} />
-									</ROIValueContainer>
-								</ROIContainer>
-							</FlexDivCol>
-							<FlexDivRow>
-								<Leverage>{`${formatNumber(positionDetails?.leverage ?? 0)}x |`}</Leverage>
-								<Side isLong={positionDetails?.side === PositionSide.LONG ?? true}>
-									{positionDetails?.side ?? PositionSide.LONG}
-								</Side>
-							</FlexDivRow>
-						</StyledGraphicRow>
-					</GraphicPosition> */}
 				<DataCol>
 					<InfoCol>
 						<FlexDiv>
@@ -93,10 +47,10 @@ const PositionCard: React.FC<PositionCardProps> = ({
 							</div>
 						</FlexDiv>
 					</InfoCol>
-					<InfoCol>
+					<PositionInfoCol>
 						<StyledSubtitle>Position</StyledSubtitle>
 						<StyledValue>LONG</StyledValue>
-					</InfoCol>
+					</PositionInfoCol>
 				</DataCol>
 				<DataCol>
 					<InfoCol>
@@ -115,76 +69,34 @@ const PositionCard: React.FC<PositionCardProps> = ({
 					</InfoCol>
 					<InfoCol>
 						<StyledSubtitle>Liq. Price</StyledSubtitle>
-						<StyledValue>$4,131.23</StyledValue>
-					</InfoCol>
-				</DataCol>
-				<DataCol>
-					<InfoCol>
-						<InfoTooltip
-							placement="top"
-							content={<div>{t('futures.market.user.position.entry-tooltip')}</div>}
-						>
-							<StyledSubtitle>{t('futures.market.user.position.entry')}</StyledSubtitle>
-						</InfoTooltip>
-						<StyledValue>
-							{positionDetails && positionDetails.lastPrice
-								? formatCurrency(Synths.sUSD, positionDetails?.lastPrice, { sign: '$' })
-								: '--'}
-						</StyledValue>
-					</InfoCol>
-					<InfoCol>
-						<InfoTooltip
-							placement="top"
-							content={<div>{t('futures.market.user.position.remaining-margin-tooltip')}</div>}
-						>
-							<StyledSubtitle>{t('futures.market.user.position.remaining-margin')}</StyledSubtitle>
-						</InfoTooltip>
-						<StyledValue>
-							{formatCurrency(Synths.sUSD, position?.remainingMargin ?? zeroBN, { sign: '$' })}
-						</StyledValue>
-					</InfoCol>
-				</DataCol>
-				<DataCol>
-					<InfoCol>
-						<InfoTooltip
-							placement="top"
-							content={<div>{t('futures.market.user.position.liquidation-tooltip')}</div>}
-						>
-							<StyledSubtitle>{t('futures.market.user.position.liquidation')}</StyledSubtitle>
-						</InfoTooltip>
 						<StyledValue>
 							{formatCurrency(Synths.sUSD, positionDetails?.liquidationPrice ?? zeroBN, {
 								sign: '$',
 							})}
 						</StyledValue>
 					</InfoCol>
+				</DataCol>
+				<DataCol>
 					<InfoCol>
-						<InfoTooltip
-							placement="top"
-							content={<div>{t('futures.market.user.position.margin-ratio-tooltip')}</div>}
-						>
-							<StyledSubtitle>{t('futures.market.user.position.margin-ratio')}</StyledSubtitle>
-						</InfoTooltip>
-
-						<StyledValue>
-							{formatCurrency(Synths.sUSD, positionDetails?.marginRatio ?? zeroBN)}
-						</StyledValue>
+						<StyledSubtitle>Average Open</StyledSubtitle>
+						<StyledValue>$4,131.23</StyledValue>
+					</InfoCol>
+					<InfoCol>
+						<StyledSubtitle>Average Close</StyledSubtitle>
+						<StyledValue>$4,131.23</StyledValue>
 					</InfoCol>
 				</DataCol>
 				<DataCol>
 					<InfoCol>
-						<InfoTooltip
-							placement="top"
-							content={<div>{t('futures.market.user.position.accrued-funding-tooltip')}</div>}
-						>
-							<StyledSubtitle>{t('futures.market.user.position.accrued-funding')}</StyledSubtitle>
-						</InfoTooltip>
-						<StyledValue>
-							{positionDetails && positionDetails.accruedFunding
-								? formatCurrency(Synths.sUSD, positionDetails.accruedFunding, { sign: '$' })
-								: '--'}
-						</StyledValue>
+						<StyledSubtitle>Realized P&amp;L</StyledSubtitle>
+						<StyledValue>-$10.83</StyledValue>
 					</InfoCol>
+					<InfoCol>
+						<StyledSubtitle>Net Funding</StyledSubtitle>
+						<StyledValue>-$10.83</StyledValue>
+					</InfoCol>
+				</DataCol>
+				<DataCol style={{ justifyContent: 'flex-end' }}>
 					{onPositionClose && (
 						<CloseButton
 							isRounded={true}
@@ -195,15 +107,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
 						>
 							{t('futures.market.user.position.close-position')}
 						</CloseButton>
-					)}
-					{dashboard && (
-						<ManageButton
-							isRounded={true}
-							variant="text"
-							onClick={() => router.push(ROUTES.Markets.MarketPair(currencyKey))}
-						>
-							{t('futures.market.user.position.manage-position')}
-						</ManageButton>
 					)}
 				</DataCol>
 			</Container>
@@ -230,69 +133,10 @@ const Container = styled.div`
 	border-radius: 16px;
 `;
 
-const StyledGraphicRow = styled(FlexDivRow)`
-	align-items: flex-start;
-`;
-
-const PositionSizeRow = styled(FlexDivRow)`
-	justify-content: flex-start;
-	align-items: center;
-`;
-
-const PositionSizeCol = styled(FlexDivCol)`
-	margin-left: 8px;
-`;
-
 const StyledCurrencyIcon = styled(CurrencyIcon)`
 	width: 30px;
 	height: 30px;
 	margin-right: 8px;
-`;
-
-const StyledPositionSize = styled.div`
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 20px;
-	color: ${(props) => props.theme.colors.white};
-	margin-bottom: 4px;
-`;
-
-const StyledPositionSizeUSD = styled.div`
-	font-family: ${(props) => props.theme.fonts.mono};
-	font-size: 12px;
-	color: ${(props) => props.theme.colors.silver};
-	text-transform: capitalize;
-`;
-
-const Leverage = styled.div`
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 14px;
-	color: ${(props) => props.theme.colors.white};
-`;
-
-const Side = styled.div<{ isLong: boolean }>`
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 14px;
-	color: ${(props) => (props.isLong ? props.theme.colors.green : props.theme.colors.red)};
-	margin-left: 4px;
-	text-transform: uppercase;
-`;
-
-const ROIContainer = styled.div`
-	margin-top: 16px;
-`;
-
-const ROIValueContainer = styled(FlexDivRow)`
-	justify-content: flex-start;
-`;
-
-const StyledROIValue = styled(FlexDivRowCentered)`
-	div {
-		font-family: ${(props) => props.theme.fonts.bold};
-		font-size: 16px;
-		color: ${(props) => props.theme.colors.white};
-		margin-right: 6px;
-		margin-top: 4px;
-	}
 `;
 
 const DataCol = styled(FlexDivCol)`
@@ -322,21 +166,10 @@ const CloseButton = styled(Button)`
 	font-size: 13px;
 `;
 
-const ManageButton = styled(Button)`
-	color: ${(props) => props.theme.colors.white};
-	background: ${(props) => props.theme.colors.navy};
-	padding: 0 10px;
-	&:disabled {
-		color: ${(props) => props.theme.colors.silver};
-		background: ${(props) => props.theme.colors.navy};
-		opacity: 0.5;
-	}
-	&:hover:not(:disabled) {
-		color: ${(props) => props.theme.colors.white};
-		opacity: 0.9;
-	}
-`;
-
 const CurrencySubtitle = styled(StyledSubtitle)`
 	text-transform: initial;
+`;
+
+const PositionInfoCol = styled(InfoCol)`
+	padding-left: 38px;
 `;

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -2,14 +2,11 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { wei } from '@synthetixio/wei';
 
-import SpiralLines from 'assets/svg/app/future-position-background.svg';
-
-import Card from 'components/Card';
 import { FlexDivRow, FlexDivCol, FlexDivRowCentered, InfoTooltip } from 'styles/common';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { useTranslation } from 'react-i18next';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
-import { CurrencyKey, Synths } from 'constants/currency';
+import { Synths } from 'constants/currency';
 import ChangePercent from 'components/ChangePercent';
 import Button from 'components/Button';
 import { FuturesPosition, PositionSide } from 'queries/futures/types';
@@ -40,7 +37,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 
 	return (
 		<>
-			<Card>
+			<Container>
 				<FlexDivRow>
 					<GraphicPosition>
 						<StyledGraphicRow>
@@ -181,7 +178,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 						</DataCol>
 					</RightHand>
 				</FlexDivRow>
-			</Card>
+			</Container>
 			{closePositionModalIsVisible && onPositionClose && (
 				<ClosePositionModal
 					position={positionDetails}
@@ -195,13 +192,19 @@ const PositionCard: React.FC<PositionCardProps> = ({
 };
 export default PositionCard;
 
+const Container = styled.div`
+	display: flex;
+	background-color: transparent;
+	border: ${(props) => props.theme.colors.selectedTheme.border};
+	padding: 22px;
+	border-radius: 16px;
+`;
+
 const GraphicPosition = styled.div`
 	width: 45%;
 	padding: 20px;
 	background-size: cover;
 	background-position: center center;
-	background-image: url(${SpiralLines.src});
-	background-color: ${(props) => props.theme.colors.vampire};
 `;
 
 const StyledGraphicRow = styled(FlexDivRow)`

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -38,8 +38,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 	return (
 		<>
 			<Container>
-				<FlexDivRow>
-					<GraphicPosition>
+				{/* <GraphicPosition>
 						<StyledGraphicRow>
 							<FlexDivCol>
 								<PositionSizeRow>
@@ -83,101 +82,105 @@ const PositionCard: React.FC<PositionCardProps> = ({
 								</Side>
 							</FlexDivRow>
 						</StyledGraphicRow>
-					</GraphicPosition>
-					<RightHand>
-						<DataCol>
-							<InfoCol>
-								<InfoTooltip
-									placement="top"
-									content={<div>{t('futures.market.user.position.entry-tooltip')}</div>}
-								>
-									<StyledSubtitle>{t('futures.market.user.position.entry')}</StyledSubtitle>
-								</InfoTooltip>
-								<StyledValue>
-									{positionDetails && positionDetails.lastPrice
-										? formatCurrency(Synths.sUSD, positionDetails?.lastPrice, { sign: '$' })
-										: '--'}
-								</StyledValue>
-							</InfoCol>
-							<InfoCol>
-								<InfoTooltip
-									placement="top"
-									content={<div>{t('futures.market.user.position.remaining-margin-tooltip')}</div>}
-								>
-									<StyledSubtitle>
-										{t('futures.market.user.position.remaining-margin')}
-									</StyledSubtitle>
-								</InfoTooltip>
-								<StyledValue>
-									{formatCurrency(Synths.sUSD, position?.remainingMargin ?? zeroBN, { sign: '$' })}
-								</StyledValue>
-							</InfoCol>
-						</DataCol>
-						<DataCol>
-							<InfoCol>
-								<InfoTooltip
-									placement="top"
-									content={<div>{t('futures.market.user.position.liquidation-tooltip')}</div>}
-								>
-									<StyledSubtitle>{t('futures.market.user.position.liquidation')}</StyledSubtitle>
-								</InfoTooltip>
-								<StyledValue>
-									{formatCurrency(Synths.sUSD, positionDetails?.liquidationPrice ?? zeroBN, {
-										sign: '$',
-									})}
-								</StyledValue>
-							</InfoCol>
-							<InfoCol>
-								<InfoTooltip
-									placement="top"
-									content={<div>{t('futures.market.user.position.margin-ratio-tooltip')}</div>}
-								>
-									<StyledSubtitle>{t('futures.market.user.position.margin-ratio')}</StyledSubtitle>
-								</InfoTooltip>
+					</GraphicPosition> */}
+				<DataCol>
+					<InfoCol>
+						<StyledSubtitle>sETH/sUSD</StyledSubtitle>
+						<StyledValue>Synthetic Ether</StyledValue>
+					</InfoCol>
+					<InfoCol>
+						<StyledSubtitle>Position</StyledSubtitle>
+						<StyledValue>LONG</StyledValue>
+					</InfoCol>
+				</DataCol>
+				<DataCol>
+					<InfoCol>
+						<InfoTooltip
+							placement="top"
+							content={<div>{t('futures.market.user.position.entry-tooltip')}</div>}
+						>
+							<StyledSubtitle>{t('futures.market.user.position.entry')}</StyledSubtitle>
+						</InfoTooltip>
+						<StyledValue>
+							{positionDetails && positionDetails.lastPrice
+								? formatCurrency(Synths.sUSD, positionDetails?.lastPrice, { sign: '$' })
+								: '--'}
+						</StyledValue>
+					</InfoCol>
+					<InfoCol>
+						<InfoTooltip
+							placement="top"
+							content={<div>{t('futures.market.user.position.remaining-margin-tooltip')}</div>}
+						>
+							<StyledSubtitle>{t('futures.market.user.position.remaining-margin')}</StyledSubtitle>
+						</InfoTooltip>
+						<StyledValue>
+							{formatCurrency(Synths.sUSD, position?.remainingMargin ?? zeroBN, { sign: '$' })}
+						</StyledValue>
+					</InfoCol>
+				</DataCol>
+				<DataCol>
+					<InfoCol>
+						<InfoTooltip
+							placement="top"
+							content={<div>{t('futures.market.user.position.liquidation-tooltip')}</div>}
+						>
+							<StyledSubtitle>{t('futures.market.user.position.liquidation')}</StyledSubtitle>
+						</InfoTooltip>
+						<StyledValue>
+							{formatCurrency(Synths.sUSD, positionDetails?.liquidationPrice ?? zeroBN, {
+								sign: '$',
+							})}
+						</StyledValue>
+					</InfoCol>
+					<InfoCol>
+						<InfoTooltip
+							placement="top"
+							content={<div>{t('futures.market.user.position.margin-ratio-tooltip')}</div>}
+						>
+							<StyledSubtitle>{t('futures.market.user.position.margin-ratio')}</StyledSubtitle>
+						</InfoTooltip>
 
-								<StyledValue>
-									{formatCurrency(Synths.sUSD, positionDetails?.marginRatio ?? zeroBN)}
-								</StyledValue>
-							</InfoCol>
-						</DataCol>
-						<DataCol>
-							<InfoCol>
-								<InfoTooltip
-									placement="top"
-									content={<div>{t('futures.market.user.position.accrued-funding-tooltip')}</div>}
-								>
-									<StyledSubtitle>
-										{t('futures.market.user.position.accrued-funding')}
-									</StyledSubtitle>
-								</InfoTooltip>
-								<StyledValue>
-									{positionDetails && positionDetails.accruedFunding
-										? formatCurrency(Synths.sUSD, positionDetails.accruedFunding, { sign: '$' })
-										: '--'}
-								</StyledValue>
-							</InfoCol>
-							{onPositionClose && (
-								<CloseButton
-									isRounded={true}
-									variant="text"
-									onClick={() => setClosePositionModalIsVisible(true)}
-									disabled={!positionDetails}
-								>
-									{t('futures.market.user.position.close-position')}
-								</CloseButton>
-							)}
-							{dashboard && (
-								<ManageButton
-									isRounded={true}
-									variant="text"
-									onClick={() => router.push(ROUTES.Markets.MarketPair(currencyKey))}
-								>
-									{t('futures.market.user.position.manage-position')}
-								</ManageButton>
-							)}
-						</DataCol>
-					</RightHand>
-				</FlexDivRow>
+						<StyledValue>
+							{formatCurrency(Synths.sUSD, positionDetails?.marginRatio ?? zeroBN)}
+						</StyledValue>
+					</InfoCol>
+				</DataCol>
+				<DataCol>
+					<InfoCol>
+						<InfoTooltip
+							placement="top"
+							content={<div>{t('futures.market.user.position.accrued-funding-tooltip')}</div>}
+						>
+							<StyledSubtitle>{t('futures.market.user.position.accrued-funding')}</StyledSubtitle>
+						</InfoTooltip>
+						<StyledValue>
+							{positionDetails && positionDetails.accruedFunding
+								? formatCurrency(Synths.sUSD, positionDetails.accruedFunding, { sign: '$' })
+								: '--'}
+						</StyledValue>
+					</InfoCol>
+					{onPositionClose && (
+						<CloseButton
+							isRounded={true}
+							size="sm"
+							variant="danger"
+							onClick={() => setClosePositionModalIsVisible(true)}
+							disabled={!positionDetails}
+						>
+							{t('futures.market.user.position.close-position')}
+						</CloseButton>
+					)}
+					{dashboard && (
+						<ManageButton
+							isRounded={true}
+							variant="text"
+							onClick={() => router.push(ROUTES.Markets.MarketPair(currencyKey))}
+						>
+							{t('futures.market.user.position.manage-position')}
+						</ManageButton>
+					)}
+				</DataCol>
 			</Container>
 			{closePositionModalIsVisible && onPositionClose && (
 				<ClosePositionModal
@@ -193,7 +196,8 @@ const PositionCard: React.FC<PositionCardProps> = ({
 export default PositionCard;
 
 const Container = styled.div`
-	display: flex;
+	display: grid;
+	grid-template-columns: repeat(6, 1fr);
 	background-color: transparent;
 	border: ${(props) => props.theme.colors.selectedTheme.border};
 	padding: 22px;
@@ -287,8 +291,8 @@ const InfoCol = styled(FlexDivCol)`
 
 const StyledSubtitle = styled.div`
 	font-family: ${(props) => props.theme.fonts.regular};
-	font-size: 12px;
-	color: ${(props) => props.theme.colors.blueberry};
+	font-size: 13px;
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 	text-transform: capitalize;
 	margin-bottom: 4px;
 `;
@@ -300,18 +304,8 @@ const StyledValue = styled.div`
 `;
 
 const CloseButton = styled(Button)`
-	color: ${(props) => props.theme.colors.red};
-	background: ${(props) => props.theme.colors.navy};
-	padding: 0 10px;
-	&:disabled {
-		color: ${(props) => props.theme.colors.silver};
-		background: ${(props) => props.theme.colors.navy};
-		opacity: 0.5;
-	}
-	&:hover:not(:disabled) {
-		color: ${(props) => props.theme.colors.red};
-		opacity: 0.9;
-	}
+	height: 36px;
+	font-size: 13px;
 `;
 
 const ManageButton = styled(Button)`

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { wei } from '@synthetixio/wei';
 
-import { FlexDivRow, FlexDivCol, FlexDivRowCentered, InfoTooltip } from 'styles/common';
+import { FlexDiv, FlexDivRow, FlexDivCol, FlexDivRowCentered, InfoTooltip } from 'styles/common';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { useTranslation } from 'react-i18next';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
@@ -85,12 +85,37 @@ const PositionCard: React.FC<PositionCardProps> = ({
 					</GraphicPosition> */}
 				<DataCol>
 					<InfoCol>
-						<StyledSubtitle>sETH/sUSD</StyledSubtitle>
-						<StyledValue>Synthetic Ether</StyledValue>
+						<FlexDiv>
+							<StyledCurrencyIcon currencyKey={currencyKey} />
+							<div>
+								<CurrencySubtitle>{currencyKey}/sUSD</CurrencySubtitle>
+								<StyledValue>Synthetic Bitcoin</StyledValue>
+							</div>
+						</FlexDiv>
 					</InfoCol>
 					<InfoCol>
 						<StyledSubtitle>Position</StyledSubtitle>
 						<StyledValue>LONG</StyledValue>
+					</InfoCol>
+				</DataCol>
+				<DataCol>
+					<InfoCol>
+						<StyledSubtitle>Size</StyledSubtitle>
+						<StyledValue>8.98 ($4,131.23)</StyledValue>
+					</InfoCol>
+					<InfoCol>
+						<StyledSubtitle>Unrealized P&amp;L</StyledSubtitle>
+						<StyledValue>$4,131.23 (1.53%)</StyledValue>
+					</InfoCol>
+				</DataCol>
+				<DataCol>
+					<InfoCol>
+						<StyledSubtitle>Leverage</StyledSubtitle>
+						<StyledValue>4.12x</StyledValue>
+					</InfoCol>
+					<InfoCol>
+						<StyledSubtitle>Liq. Price</StyledSubtitle>
+						<StyledValue>$4,131.23</StyledValue>
 					</InfoCol>
 				</DataCol>
 				<DataCol>
@@ -198,17 +223,11 @@ export default PositionCard;
 const Container = styled.div`
 	display: grid;
 	grid-template-columns: repeat(6, 1fr);
+	grid-gap: 16px;
 	background-color: transparent;
 	border: ${(props) => props.theme.colors.selectedTheme.border};
 	padding: 22px;
 	border-radius: 16px;
-`;
-
-const GraphicPosition = styled.div`
-	width: 45%;
-	padding: 20px;
-	background-size: cover;
-	background-position: center center;
 `;
 
 const StyledGraphicRow = styled(FlexDivRow)`
@@ -225,8 +244,9 @@ const PositionSizeCol = styled(FlexDivCol)`
 `;
 
 const StyledCurrencyIcon = styled(CurrencyIcon)`
-	width: 40px;
-	height: 40px;
+	width: 30px;
+	height: 30px;
+	margin-right: 8px;
 `;
 
 const StyledPositionSize = styled.div`
@@ -275,12 +295,6 @@ const StyledROIValue = styled(FlexDivRowCentered)`
 	}
 `;
 
-const RightHand = styled(FlexDivRow)`
-	width: 100%;
-	width: 75%;
-	padding: 20px;
-`;
-
 const DataCol = styled(FlexDivCol)`
 	justify-content: space-between;
 `;
@@ -321,4 +335,8 @@ const ManageButton = styled(Button)`
 		color: ${(props) => props.theme.colors.white};
 		opacity: 0.9;
 	}
+`;
+
+const CurrencySubtitle = styled(StyledSubtitle)`
+	text-transform: initial;
 `;

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -1,14 +1,17 @@
-import Select from 'components/Select';
 import React from 'react';
-import { useRouter } from 'next/router';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
-import { CurrencyKey } from '@synthetixio/contracts-interface';
-import ROUTES from 'constants/routes';
 import styled from 'styled-components';
+import { useRouter } from 'next/router';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
 import { useTranslation } from 'react-i18next';
+
+import Select from 'components/Select';
 import Connector from 'containers/Connector';
+import ROUTES from 'constants/routes';
+import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
+
 import MarketsDropdownSingleValue from './MarketsDropdownSingleValue';
 import MarketsDropdownOption from './MarketsDropdownOption';
+import MarketsDropdownIndicator from './MarketsDropdownIndicator';
 
 export type MarketsCurrencyOption = {
 	value: CurrencyKey;
@@ -71,7 +74,11 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 					assetToCurrencyOption(x.asset, getSynthDescription(x.asset), DUMMY_PRICE, DUMMY_CHANGE)
 				)}
 				isSearchable={false}
-				components={{ SingleValue: MarketsDropdownSingleValue, Option: MarketsDropdownOption }}
+				components={{
+					SingleValue: MarketsDropdownSingleValue,
+					Option: MarketsDropdownOption,
+					DropdownIndicator: MarketsDropdownIndicator,
+				}}
 			/>
 		</SelectContainer>
 	);
@@ -79,7 +86,7 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 
 const SelectContainer = styled.div`
 	margin-top: 5px;
-	margin-bottom: 24px;
+	margin-bottom: 16px;
 `;
 
 export default MarketsDropdown;

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -87,6 +87,10 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 const SelectContainer = styled.div`
 	margin-top: 5px;
 	margin-bottom: 16px;
+
+	.react-select__dropdown-indicator {
+		margin-right: 22px;
+	}
 `;
 
 export default MarketsDropdown;

--- a/sections/futures/Trade/MarketsDropdownIndicator.tsx
+++ b/sections/futures/Trade/MarketsDropdownIndicator.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { components, IndicatorProps } from 'react-select';
+import { Svg } from 'react-optimized-image';
+import dropdownArrow from '../../../assets/svg/app/dropdown-arrow.svg';
+
+const MarketsDropdownIndicator: React.FC<IndicatorProps<any>> = (props) => (
+	<components.DropdownIndicator {...props}>
+		<Svg src={dropdownArrow} />
+	</components.DropdownIndicator>
+);
+
+export default MarketsDropdownIndicator;

--- a/sections/futures/Trade/MarketsDropdownIndicator.tsx
+++ b/sections/futures/Trade/MarketsDropdownIndicator.tsx
@@ -5,7 +5,7 @@ import dropdownArrow from '../../../assets/svg/app/dropdown-arrow.svg';
 
 const MarketsDropdownIndicator: React.FC<IndicatorProps<any>> = (props) => (
 	<components.DropdownIndicator {...props}>
-		<Svg src={dropdownArrow} style={{ marginRight: 22 }} />
+		<Svg src={dropdownArrow} />
 	</components.DropdownIndicator>
 );
 

--- a/sections/futures/Trade/MarketsDropdownIndicator.tsx
+++ b/sections/futures/Trade/MarketsDropdownIndicator.tsx
@@ -5,7 +5,7 @@ import dropdownArrow from '../../../assets/svg/app/dropdown-arrow.svg';
 
 const MarketsDropdownIndicator: React.FC<IndicatorProps<any>> = (props) => (
 	<components.DropdownIndicator {...props}>
-		<Svg src={dropdownArrow} />
+		<Svg src={dropdownArrow} style={{ marginRight: 22 }} />
 	</components.DropdownIndicator>
 );
 

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -5,12 +5,11 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { useRecoilValue } from 'recoil';
 import Wei, { wei } from '@synthetixio/wei';
 
-import { FlexDivCol, FlexDivRow, FlexDivColCentered, FlexDivRowCentered } from 'styles/common';
 import { useState } from 'react';
 import { Synths } from 'constants/currency';
 
 import Button from 'components/Button';
-import { zeroBN, formatCurrency } from 'utils/formatters/number';
+import { zeroBN } from 'utils/formatters/number';
 import { PositionSide } from '../types';
 import { useRecoilState } from 'recoil';
 import { gasSpeedState } from 'store/wallet';
@@ -21,11 +20,7 @@ import { walletAddressState } from 'store/wallet';
 import Connector from 'containers/Connector';
 import TransactionNotifier from 'containers/TransactionNotifier';
 
-import TradeSizeInput from '../TradeSizeInput';
 import LeverageInput from '../LeverageInput';
-import GasPriceSelect from 'sections/shared/components/GasPriceSelect';
-import FeeCostSummary from 'sections/shared/components/FeeCostSummary';
-import MarginSection from './MarginSection';
 import EditMarginModal from './EditMarginModal';
 import TradeConfirmationModal from './TradeConfirmationModal';
 import { useRouter } from 'next/router';
@@ -35,6 +30,11 @@ import useGetFuturesPositionHistory from 'queries/futures/useGetFuturesMarketPos
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import { gasPriceInWei } from 'utils/network';
 import MarketsDropdown from './MarketsDropdown';
+import SegmentedControl from 'components/SegmentedControl';
+import PositionButtons from '../PositionButtons';
+import OrderSizing from '../OrderSizing';
+import MarketInfoBox from '../MarketInfoBox/MarketInfoBox';
+import FeeInfoBox from '../FeeInfoBox';
 
 type TradeProps = {};
 
@@ -228,86 +228,54 @@ const Trade: React.FC<TradeProps> = () => {
 
 	return (
 		<Panel>
-			<TopRow>
-				<FlexDivRow>
-					<Title>{t('futures.market.trade.market')}</Title>
-				</FlexDivRow>
-				<MarketsDropdown asset={marketAsset || Synths.sUSD} />
-				<FlexDivRow>
-					<Title>{t('futures.market.trade.title')}</Title>
-				</FlexDivRow>
-				<TradeSizeInput
-					amount={tradeSize}
-					assetRate={marketAssetRate}
-					onAmountChange={(value) => onTradeAmountChange(value)}
-					balance={futuresMarketsPosition?.remainingMargin ?? zeroBN}
-					asset={marketAsset || Synths.sUSD}
-					handleOnMax={() => onLeverageChange(maxLeverageValue.toNumber())}
-					balanceLabel={t('futures.market.trade.input.remaining-margin')}
-				/>
+			<MarketsDropdown asset={marketAsset || Synths.sUSD} />
+			<MarketActions>
+				<MarketActionButton onClick={() => setIsEditMarginModalOpen(true)}>
+					Deposit
+				</MarketActionButton>
+				<MarketActionButton>Withdraw</MarketActionButton>
+			</MarketActions>
 
-				<LeverageInput
-					currentLeverage={leverage}
-					maxLeverage={maxLeverageValue.toNumber()}
-					onSideChange={(side) => {
-						onLeverageChange(0);
-						setLeverageSide(side);
-					}}
-					onLeverageChange={(value) => onLeverageChange(value)}
-					side={leverageSide}
-					setIsLeverageValueCommitted={setIsLeverageValueCommitted}
-					currentPosition={futuresMarketsPosition}
-					assetRate={marketAssetRate}
-					currentTradeSize={tradeSize ? Number(tradeSize) : 0}
-				/>
-
-				<FlexDivCol>
-					<StyledFeeCostSummary feeCost={feeCost} />
-					<StyledGasPriceSelect {...{ gasPrices, transactionFee }} />
-					{futuresMarketsPosition && futuresMarketsPosition.remainingMargin.gt(zeroBN) ? (
-						<StyledButton
-							variant="primary"
-							disabled={!gasLimit || !!error || !tradeSize || competitionClosed}
-							isRounded
-							size="lg"
-							onClick={() => setIsTradeConfirmationModalOpen(true)}
-						>
-							{competitionClosed
-								? t('futures.market.trade.button.competition-closed')
-								: error
-								? error
-								: tradeSize
-								? t('futures.market.trade.button.open-trade')
-								: t('futures.market.trade.button.enter-amount')}
-						</StyledButton>
-					) : (
-						<CTAMargin>
-							<MarginTitle>{t('futures.market.trade.margin.deposit-susd')}</MarginTitle>
-							<MarginSubTitle>
-								{t('futures.market.trade.margin.min-initial-margin', {
-									minInitialMargin: formatCurrency(Synths.sUSD, market?.minInitialMargin ?? 0, {
-										currencyKey: Synths.sUSD,
-										minDecimals: 0,
-									}),
-								})}
-							</MarginSubTitle>
-							<DepositMarginButton
-								variant="primary"
-								isRounded
-								size="lg"
-								onClick={() => setIsEditMarginModalOpen(true)}
-							>
-								{t('futures.market.trade.button.deposit-margin')}
-							</DepositMarginButton>
-						</CTAMargin>
-					)}
-				</FlexDivCol>
-			</TopRow>
-			<MarginSection
-				remainingMargin={futuresMarketsPosition?.remainingMargin ?? zeroBN}
-				sUSDBalance={sUSDBalance}
-				onDeposit={() => setIsEditMarginModalOpen(true)}
+			<MarketInfoBox
+				availableMargin={futuresMarketsPosition?.remainingMargin ?? zeroBN}
+				buyingPower={sUSDBalance}
 			/>
+
+			<StyledSegmentedControl values={['Market', 'Limit']} selectedIndex={0} onChange={() => {}} />
+
+			<OrderSizing
+				amount={tradeSize}
+				assetRate={marketAssetRate}
+				onAmountChange={(value) => onTradeAmountChange(value)}
+				marketAsset={marketAsset || Synths.sUSD}
+			/>
+
+			<PositionButtons
+				selected={leverageSide}
+				onSelect={(position) => {
+					onLeverageChange(0);
+					setLeverageSide(position);
+				}}
+			/>
+
+			<LeverageInput
+				currentLeverage={leverage}
+				maxLeverage={maxLeverageValue.toNumber()}
+				onLeverageChange={(value) => onLeverageChange(value)}
+				side={leverageSide}
+				setIsLeverageValueCommitted={setIsLeverageValueCommitted}
+				currentPosition={futuresMarketsPosition}
+				assetRate={marketAssetRate}
+				currentTradeSize={tradeSize ? Number(tradeSize) : 0}
+			/>
+
+			<PlaceOrderButton fullWidth>Place Market Order</PlaceOrderButton>
+
+			<FeeInfoBox transactionFee={transactionFee} feeCost={feeCost} />
+
+			{/* <FlexDivCol>
+					<StyledGasPriceSelect {...{ gasPrices, transactionFee }} />
+				</FlexDivCol> */}
 			{isEditMarginModalOpen && (
 				<EditMarginModal
 					sUSDBalance={sUSDBalance}
@@ -338,73 +306,27 @@ const Trade: React.FC<TradeProps> = () => {
 };
 export default Trade;
 
-const Title = styled.div`
-	color: ${(props) => props.theme.colors.silver};
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 14px;
-	text-transform: capitalize;
-`;
-
-const StyledGasPriceSelect = styled(GasPriceSelect)`
-	padding: 5px 0;
-	display: flex;
-	justify-content: space-between;
-	width: auto;
-	border-bottom: 1px solid ${(props) => props.theme.colors.navy};
-	color: ${(props) => props.theme.colors.blueberry};
-	font-size: 12px;
-	font-family: ${(props) => props.theme.fonts.bold};
-	text-transform: capitalize;
-	margin-bottom: 8px;
-`;
-
-const StyledFeeCostSummary = styled(FeeCostSummary)`
-	padding: 5px 0;
-	display: flex;
-	justify-content: space-between;
-	width: auto;
-	border-bottom: 1px solid ${(props) => props.theme.colors.navy};
-	color: ${(props) => props.theme.colors.blueberry};
-	font-size: 12px;
-	font-family: ${(props) => props.theme.fonts.bold};
-	text-transform: capitalize;
-	margin-bottom: 8px;
-`;
-
-const StyledButton = styled(Button)`
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
-`;
-
-const TopRow = styled(FlexDivCol)`
-	margin-top: 12px;
-`;
-
-const Panel = styled(FlexDivCol)`
+const Panel = styled.div`
 	height: 100%;
-	justify-content: space-between;
 	padding-bottom: 48px;
 `;
 
-const CTAMargin = styled(FlexDivColCentered)`
-	margin-top: 40px;
+const MarketActions = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-gap: 15px;
+	margin-bottom: 16px;
 `;
 
-const MarginTitle = styled.h3`
-	color: ${(props) => props.theme.colors.white};
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 14px;
-	margin: 0;
+const MarketActionButton = styled(Button)`
+	font-size: 15px;
 `;
 
-const MarginSubTitle = styled.h4`
-	color: ${(props) => props.theme.colors.blueberry};
-	font-family: ${(props) => props.theme.fonts.regular};
-	font-size: 12px;
-	margin: 5px 0 10px 0;
+const PlaceOrderButton = styled(Button)`
+	margin-bottom: 16px;
+	height: 55px;
 `;
 
-const DepositMarginButton = styled(Button)`
-	width: 100%;
+const StyledSegmentedControl = styled(SegmentedControl)`
+	margin-bottom: 16px;
 `;

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -233,7 +233,9 @@ const Trade: React.FC<TradeProps> = () => {
 				<MarketActionButton onClick={() => setIsEditMarginModalOpen(true)}>
 					Deposit
 				</MarketActionButton>
-				<MarketActionButton>Withdraw</MarketActionButton>
+				<MarketActionButton onClick={() => setIsEditMarginModalOpen(true)}>
+					Withdraw
+				</MarketActionButton>
 			</MarketActions>
 
 			<MarketInfoBox

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
 import useSynthetixQueries from '@synthetixio/queries';
 
-import { TabList, TabPanel, TabButton } from 'components/Tab';
+import { TabPanel } from 'components/Tab';
+import TabButton from 'components/Button/TabButton';
 
 import PositionCard from '../PositionCard';
 import Trades from '../Trades';
@@ -65,30 +66,42 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 		() => [
 			{
 				name: FuturesTab.POSITION,
-				label: t('futures.market.user.position.tab'),
+				label: 'Open Positions',
+				badge: 3,
 				active: activeTab === FuturesTab.POSITION,
 				onClick: () => router.push(ROUTES.Markets.Position(marketAsset)),
 			},
-
 			{
 				name: FuturesTab.TRADES,
-				label: t('futures.market.user.trades.tab'),
+				label: 'Order History',
 				active: activeTab === FuturesTab.TRADES,
 				onClick: () => router.push(ROUTES.Markets.Trades(marketAsset)),
 			},
+			{
+				name: FuturesTab.ORDERS,
+				label: 'Open Orders',
+				disabled: true,
+				active: activeTab === FuturesTab.ORDERS,
+				onClick: () => router.push(ROUTES.Markets.Orders(marketAsset)),
+			},
 		],
-		[t, activeTab, router, marketAsset]
+		[activeTab, router, marketAsset]
 	);
 
 	return (
 		<>
-			<StyledTabList>
-				{TABS.map(({ name, label, active, onClick }) => (
-					<TabButton key={name} name={name} active={active} onClick={onClick}>
-						{label}
-					</TabButton>
+			<TabButtonsContainer>
+				{TABS.map(({ name, label, badge, active, disabled, onClick }) => (
+					<TabButton
+						key={name}
+						title={label}
+						badge={badge}
+						active={active}
+						disabled={disabled}
+						onClick={onClick}
+					/>
 				))}
-			</StyledTabList>
+			</TabButtonsContainer>
 			<TabPanel name={FuturesTab.POSITION} activeTab={activeTab}>
 				<PositionCard
 					position={futuresMarketsPosition ?? null}
@@ -114,6 +127,17 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 };
 export default UserInfo;
 
-const StyledTabList = styled(TabList)`
-	margin-bottom: 12px;
+const TabButtonsContainer = styled.div`
+	display: flex;
+	margin-top: 16px;
+	margin-bottom: 16px;
+
+	& > button {
+		height: 38px;
+		font-size: 13px;
+
+		&:not(:last-of-type) {
+			margin-right: 14px;
+		}
+	}
 `;

--- a/sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx
+++ b/sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx
@@ -101,13 +101,15 @@ const UserMenu: FC<UserMenuProps> = ({ isTextButton }) => {
 							{truncatedWalletAddress}
 						</WalletButton>
 					) : (
-						<Button
-							variant={isTextButton ? 'text' : 'primary'}
+						<ConnectButton
+							variant={isTextButton ? 'text' : undefined}
+							size="sm"
 							onClick={connectWallet}
 							data-testid="connect-wallet"
+							mono
 						>
 							{t('common.wallet.connect-wallet')}
-						</Button>
+						</ConnectButton>
 					)}
 				</FlexDivCentered>
 			</Container>
@@ -154,6 +156,10 @@ const MenuButton = styled.button<{ isActive: boolean }>`
 		color: ${(props) => props.theme.colors.goldColors.color1};
 	}
 	padding: 5px;
+`;
+
+const ConnectButton = styled(Button)`
+	font-size: 13px;
 `;
 
 export default UserMenu;

--- a/sections/shared/Layout/Layout.tsx
+++ b/sections/shared/Layout/Layout.tsx
@@ -54,7 +54,7 @@ const GlobalStyle = createGlobalStyle`
 	`};
 
 	body {
-		background-color: ${(props) => props.theme.colors.black};
+		background-color: ${(props) => props.theme.colors.selectedTheme.background};
 		color: ${(props) => props.theme.colors.blueberry};
 	}
 

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import styled from 'styled-components';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import Button from '../components/Button';
+import TabButton from 'components/Button/TabButton';
+
 import PositionButtons from 'sections/futures/PositionButtons';
 import { PositionSide } from 'queries/futures/types';
 
@@ -85,3 +88,23 @@ export const Position = () => {
 
 	return <PositionButtons selected={selected} onSelect={setSelected} />;
 };
+
+export const Tab = () => {
+	return (
+		<TabGroup>
+			<TabButton title="Futures Positions" detail="$12,392.92" badge={3} active />
+			<TabButton title="Shorts" detail="$0" disabled />
+			<TabButton title="Spot Balances" detail="$0" disabled />
+		</TabGroup>
+	);
+};
+
+const TabGroup = styled.div`
+	display: flex;
+
+	button {
+		&:not(:last-of-type) {
+			margin-right: 15px;
+		}
+	}
+`;

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -83,5 +83,5 @@ Monospace.args = {
 export const Position = () => {
 	const [selected, setSelected] = React.useState<PositionSide>(PositionSide.LONG);
 
-	return <PositionButtons selected={selected} setSelected={setSelected} />;
+	return <PositionButtons selected={selected} onSelect={setSelected} />;
 };

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import Button from '../components/Button';
 import PositionButtons from 'sections/futures/PositionButtons';
-import { MarketPosition } from 'sections/futures/PositionButtons/PositionButtons';
+import { PositionSide } from 'queries/futures/types';
 
 export default {
 	title: 'Components/Button',
@@ -81,7 +81,7 @@ Monospace.args = {
 };
 
 export const Position = () => {
-	const [selected, setSelected] = React.useState<MarketPosition>('long');
+	const [selected, setSelected] = React.useState<PositionSide>(PositionSide.LONG);
 
 	return <PositionButtons selected={selected} setSelected={setSelected} />;
 };

--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -304,7 +304,6 @@ export const RightSideContent = styled(FlexDivCol)`
 	margin-right: -20px;
 	flex-shrink: 0;
 	position: relative;
-	margin-left: 20px;
 	height: 100%;
 `;
 

--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -299,7 +299,7 @@ export const MainContent = styled(FlexDivCol)`
 
 export const RightSideContent = styled(FlexDivCol)`
 	width: 380px;
-	background-color: ${(props) => props.theme.colors.elderberry};
+	background-color: transparent;
 	padding: ${SPACING_FROM_HEADER} 0 5px 0;
 	margin-right: -20px;
 	flex-shrink: 0;

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -39,7 +39,7 @@ const darkTheme = {
 		},
 	},
 	input: {
-		background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.75) 100%)',
+		background: 'linear-gradient(180deg, rgba(27, 27, 27, 0.1) 0%, rgba(27, 27, 27, 0.075) 100%)',
 		secondary: {
 			background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.3) 100%)',
 		},
@@ -47,9 +47,9 @@ const darkTheme = {
 		shadow: '0px 0.5px 0px rgba(255, 255, 255, 0.08)',
 	},
 	segmented: {
-		background: 'linear-gradient(180deg, #1B1B1B 0%, #212121 100%)',
+		background: 'linear-gradient(180deg, rgba(27, 27, 27, 0.1) 0%, rgba(33, 33, 33, 0.1) 100%)',
 		button: {
-			background: 'linear-gradient(180deg, #262322 0%, #39332D 100%)',
+			background: 'linear-gradient(180deg, rgba(36, 36, 36, 0.08) 0%, rgba(88, 88, 88, 0.1) 100%)',
 			shadow:
 				'0px 4px 4px rgba(0, 0, 0, 0.25), 0px 1px 2px rgba(0, 0, 0, 0.5), inset 0px 0px 20px rgba(255, 255, 255, 0.03), inset 0px 1px 0px rgba(255, 255, 255, 0.09)',
 			inactive: { color: '#787878' },

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -36,7 +36,7 @@ const darkTheme = {
 			background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.3) 100%)',
 		},
 		placeholder: '#787878',
-		shadow: 'box-shadow: 0px 0.5px 0px rgba(255, 255, 255, 0.08)',
+		shadow: '0px 0.5px 0px rgba(255, 255, 255, 0.08)',
 	},
 	segmented: {
 		background: 'linear-gradient(180deg, #1B1B1B 0%, #212121 100%)',
@@ -44,21 +44,13 @@ const darkTheme = {
 			background: 'linear-gradient(180deg, #262322 0%, #39332D 100%)',
 			shadow:
 				'0px 4px 4px rgba(0, 0, 0, 0.25), 0px 1px 2px rgba(0, 0, 0, 0.5), inset 0px 0px 20px rgba(255, 255, 255, 0.03), inset 0px 1px 0px rgba(255, 255, 255, 0.09)',
-			inactive: {
-				color: '#787878',
-			},
+			inactive: { color: '#787878' },
 		},
 	},
 	slider: {
 		label: '#787878',
-		thumb: {
-			hover: {
-				shadow: 'inset 0px 1px 0px rgba(255, 255, 255, 0.5)',
-			},
-		},
-		track: {
-			shadow: 'inset 0px 0.5px 0px rgba(255, 255, 255, 0.5)',
-		},
+		thumb: { shadow: 'inset 0px 1px 0px rgba(255, 255, 255, 0.5)' },
+		track: { shadow: 'inset 0px 0.5px 0px rgba(255, 255, 255, 0.5)' },
 	},
 	select: {
 		control: {

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -29,6 +29,14 @@ const darkTheme = {
 			},
 		},
 		disabled: { text: '#555555', background: '#272727' },
+		tab: {
+			badge: {
+				background: '#E4B378',
+				text: '#282626',
+				shadow: 'inset 0px 0.8px 0px rgba(255, 255, 255, 0.6)',
+			},
+			disabled: { border: '1px solid #353333', text: '#353333' },
+		},
 	},
 	input: {
 		background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.75) 100%)',

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -41,7 +41,7 @@ const darkTheme = {
 	input: {
 		background: 'linear-gradient(180deg, rgba(27, 27, 27, 0.1) 0%, rgba(27, 27, 27, 0.075) 100%)',
 		secondary: {
-			background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.3) 100%)',
+			background: 'linear-gradient(180deg, rgba(27, 27, 27, 0.1) 0%, rgba(27, 27, 27, 0.075) 100%)',
 		},
 		placeholder: '#787878',
 		shadow: '0px 0.5px 0px rgba(255, 255, 255, 0.08)',

--- a/styles/theme/colors/elite.ts
+++ b/styles/theme/colors/elite.ts
@@ -51,9 +51,7 @@ const eliteTheme = {
 	slider: {
 		label: '#787878',
 		thumb: {
-			hover: {
-				shadow: 'inset 0px 1px 0px rgba(255, 255, 255, 0.5)',
-			},
+			shadow: 'inset 0px 1px 0px rgba(255, 255, 255, 0.5)',
 		},
 		track: {
 			shadow: 'inset 0px 0.5px 0px rgba(255, 255, 255, 0.5)',

--- a/styles/theme/colors/elite.ts
+++ b/styles/theme/colors/elite.ts
@@ -1,3 +1,5 @@
+import common from './common';
+
 const eliteTheme = {
 	background: '#474747',
 	border: '1px solid rgba(255, 255, 255, 0.1)',
@@ -24,9 +26,14 @@ const eliteTheme = {
 				dangerBorder: 'rgba(239, 104, 104, 0.2)',
 			},
 		},
-		disabled: {
-			text: '#544F4D',
-			background: '#2A2827',
+		disabled: { text: '#544F4D', background: '#2A2827' },
+		tab: {
+			badge: {
+				background: '#E4B378',
+				text: common.secondaryGray,
+				shadow: 'inset 0px 0.8px 0px rgba(255, 255, 255, 0.6)',
+			},
+			disabled: { border: '1px solid #353333', text: '#353333' },
 		},
 	},
 	input: {

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -1,3 +1,5 @@
+import common from './common';
+
 const lightTheme = {
 	background: '#F9F9F9',
 	border: '1px solid rgba(0, 0, 0, 0.1)',
@@ -28,6 +30,14 @@ const lightTheme = {
 			},
 		},
 		disabled: { text: '#555555', background: '#272727' },
+		tab: {
+			badge: {
+				background: '#E4B378',
+				text: common.secondaryGray,
+				shadow: 'inset 0px 0.8px 0px rgba(255, 255, 255, 0.6)',
+			},
+			disabled: { border: '1px solid #353333', text: '#353333' },
+		},
 	},
 	input: {
 		background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.75) 100%)',

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -35,7 +35,7 @@ const lightTheme = {
 			background: 'linear-gradient(180deg, #1B1B1B 0%, rgba(27, 27, 27, 0.3) 100%)',
 		},
 		placeholder: '#787878',
-		shadow: 'box-shadow: 0px 0.5px 0px rgba(255, 255, 255, 0.08)',
+		shadow: '0px 0.5px 0px rgba(255, 255, 255, 0.08)',
 	},
 	segmented: {
 		background: 'linear-gradient(180deg, #1B1B1B 0%, #212121 100%)',
@@ -43,21 +43,13 @@ const lightTheme = {
 			background: 'linear-gradient(180deg, #262322 0%, #39332D 100%)',
 			shadow:
 				'0px 4px 4px rgba(0, 0, 0, 0.25), 0px 1px 2px rgba(0, 0, 0, 0.5), inset 0px 0px 20px rgba(255, 255, 255, 0.03), inset 0px 1px 0px rgba(255, 255, 255, 0.09)',
-			inactive: {
-				color: '#787878',
-			},
+			inactive: { color: '#787878' },
 		},
 	},
 	slider: {
 		label: '#787878',
-		thumb: {
-			hover: {
-				shadow: 'inset 0px 1px 0px rgba(255, 255, 255, 0.5)',
-			},
-		},
-		track: {
-			shadow: 'inset 0px 0.5px 0px rgba(255, 255, 255, 0.5)',
-		},
+		thumb: { shadow: 'inset 0px 1px 0px rgba(255, 255, 255, 0.5)' },
+		track: { shadow: 'inset 0px 0.5px 0px rgba(255, 255, 255, 0.5)' },
 	},
 	select: {
 		control: {


### PR DESCRIPTION
## Description
This PR begins the changes to the new design on the futures screen. It uses the new components to implement most of the designs for the new futures screen. These changes include:
- New trade sidebar
- New market info box

What this PR does not include:
- Changes to the translation files (these will be made in a separate PR).
- Implementation of the new `PositionCard`
- New navigation bar (including theme toggle).
- Complete application logic and data.

It is important to note the following:
- This screen currently defaults to the 'dark' theme.
- Many of the constituent parts of this screen are either partly or non-functional. i.e. This PR is intended for entirely visual purposes.

## Related issue
N/A

## Motivation and Context
This PR is part of the Kwenta UI refresh.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15985212/153079305-a9229485-53b1-40cb-863d-e80ec8540ba1.png">