### PR TITLE
Implement leaderboard

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -19,6 +19,7 @@ const MAX_PAGE_ROWS = 100;
 type ColumnWithSorting<D extends object = {}> = Column<D> & {
 	sortType?: string | ((rowA: Row<any>, rowB: Row<any>) => -1 | 1);
 	sortable?: boolean;
+	columns?: Column[];
 };
 
 type TableProps = {

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -1,4 +1,4 @@
 export const FUTURES_ENDPOINT =
-	'https://api.thegraph.com/subgraphs/name/jchiaramonte7/futurescompetition';
+	'https://api.thegraph.com/subgraphs/name/kmeraz/optimism-kovan-futures';
 
 export const DAY_PERIOD = 24 * 3600;

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -15,6 +15,8 @@ import { FuturesStat } from 'queries/futures/types';
 import Search from 'components/Table/Search';
 import Loader from 'components/Loader';
 import { ethers } from 'ethers';
+import { GridDivCenteredCol, TextButton } from 'styles/common';
+import { Period, PERIOD_LABELS_MAP, PERIOD_LABELS } from 'constants/period';
 
 type LeaderboardProps = {
 	compact?: boolean;
@@ -103,60 +105,78 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 				data={data}
 				hideHeaders={compact}
 				hiddenColumns={compact ? ['rank', 'totalTrades', 'liquidations'] : undefined}
-				columns={[
+				columns = {[
 					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.rank')}</TableHeader>,
-						accessor: 'rank',
-						Cell: (cellProps: CellProps<any>) => (
-							<StyledOrderType>{cellProps.row.original.rank}</StyledOrderType>
-						),
-						width: compact ? 40 : 100,
-					},
-					{
-						Header: !compact ? (
-							<TableHeader>{t('leaderboard.leaderboard.table.trader')}</TableHeader>
-						) : (
-							<></>
-						),
-						accessor: 'trader',
-						Cell: (cellProps: CellProps<any>) => (
-							<StyledOrderType>
-								{compact && cellProps.row.original.rank + '. '}
-								{cellProps.row.original.trader}
-								{getMedal(cellProps.row.index + 1)}
-							</StyledOrderType>
-						),
-						width: 175,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>,
-						accessor: 'totalTrades',
-						sortType: 'basic',
-						width: 175,
-						sortable: true,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>,
-						accessor: 'liquidations',
-						sortType: 'basic',
-						width: 175,
-						sortable: true,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.total-pnl')}</TableHeader>,
-						accessor: 'pnl',
-						sortType: 'basic',
-						Cell: (cellProps: CellProps<any>) => (
-							<ColorCodedPrice
-								currencyKey={Synths.sUSD}
-								price={cellProps.row.original.pnl}
-								sign={'$'}
-								conversionRate={1}
-							/>
-						),
-						width: compact ? 'auto' : 175,
-						sortable: true,
-					},
+						Header:
+							<TableTitle>
+								<TitleText>{t('leaderboard.leaderboard.table.title')}</TitleText>
+								<PeriodSelector>
+									{PERIOD_LABELS.map((period) => (
+										<StyledTextButton
+											key={period.period}
+										>
+											{t(period.i18nLabel)}
+										</StyledTextButton>
+									))}
+								</PeriodSelector>
+							</TableTitle>,
+						accessor: 'title',
+						columns: [
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.rank')}</TableHeader>,
+								accessor: 'rank',
+								Cell: (cellProps: CellProps<any>) => (
+									<StyledOrderType>{cellProps.row.original.rank}</StyledOrderType>
+								),
+								width: compact ? 40 : 100,
+							},
+							{
+								Header: !compact ? (
+									<TableHeader>{t('leaderboard.leaderboard.table.trader')}</TableHeader>
+								) : (
+									<></>
+								),
+								accessor: 'trader',
+								Cell: (cellProps: CellProps<any>) => (
+									<StyledOrderType>
+										{compact && cellProps.row.original.rank + '. '}
+										{cellProps.row.original.trader}
+										{getMedal(cellProps.row.index + 1)}
+									</StyledOrderType>
+								),
+								width: 175,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>,
+								accessor: 'totalTrades',
+								sortType: 'basic',
+								width: 175,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>,
+								accessor: 'liquidations',
+								sortType: 'basic',
+								width: 175,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-pnl')}</TableHeader>,
+								accessor: 'pnl',
+								sortType: 'basic',
+								Cell: (cellProps: CellProps<any>) => (
+									<ColorCodedPrice
+										currencyKey={Synths.sUSD}
+										price={cellProps.row.original.pnl}
+										sign={'$'}
+										conversionRate={1}
+									/>
+								),
+								width: compact ? 'auto' : 175,
+								sortable: true,
+							},
+						]
+					}
 				]}
 			/>
 		</TableContainer>
@@ -192,9 +212,31 @@ const TableHeader = styled.div`
 	color: ${(props) => props.theme.colors.blueberry};
 `;
 
+const TableTitle = styled.div`
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+`;
+
+const TitleText = styled.div`
+	font-family: ${(props) => props.theme.fonts.bold};
+	color: ${(props) => props.theme.colors.blueberry};
+`;
+
 const StyledOrderType = styled.div`
 	color: ${(props) => props.theme.colors.white};
 	display: flex;
+`;
+
+const PeriodSelector = styled(GridDivCenteredCol)`
+	grid-gap: 8px;
+`;
+
+const StyledTextButton = styled(TextButton)`
+	color: ${(props) => props.theme.colors.blueberry};
+	&:hover {
+		color: ${(props) => props.theme.colors.white};
+	}
 `;
 
 export default Leaderboard;

--- a/translations/en.json
+++ b/translations/en.json
@@ -687,6 +687,7 @@
 		},
 		"leaderboard": {
 			"table": {
+				"title": "All Traders",
 				"rank": "Rank",
 				"trader": "Trader",
 				"total-trades": "Total Trades",


### PR DESCRIPTION
Edited the leaderboard to pull from the updated [subgraph](https://thegraph.com/hosted-service/subgraph/kmeraz/optimism-kovan-futures)

## Description
* Remove the old participants query that pulled Twitter handles
* Replace that query with one that queries the updated subgraph
* Add a header to the table including selection of time periods (functionality not implemented)

## Related issue
[Issue #326](https://github.com/Kwenta/kwenta/issues/326)

## How Has This Been Tested?
I tested by comparing the output on this table to the data directly from the subgraph. It pulls 1 account, as expected.

## Screenshots (if appropriate):
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/10401554/153061351-35abc9eb-a95a-45f8-8e7a-c3ebee70ea0d.png">

