### PR TITLE
issue #341 - fix Exchange Fee Cost for sUSD

### DIFF
--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -554,12 +554,24 @@ const useExchange = ({
 		return null;
 	}, [baseCurrencyAmount, exchangeFeeRate]);
 
+	const feeAmountInQuoteCurrency = useMemo(() => {
+		if (exchangeFeeRate != null && quoteCurrencyAmount) {
+			return wei(quoteCurrencyAmount).mul(exchangeFeeRate);
+		}
+
+		return null;
+	}, [quoteCurrencyAmount, exchangeFeeRate]);
+
 	const feeCost = useMemo(() => {
+		if (quoteCurrencyKey?.toString() === 'sUSD') {
+			return feeAmountInQuoteCurrency;
+		}
+
 		if (feeAmountInBaseCurrency != null) {
 			return feeAmountInBaseCurrency.mul(basePriceRate);
 		}
 		return null;
-	}, [feeAmountInBaseCurrency, basePriceRate]);
+	}, [feeAmountInBaseCurrency, basePriceRate, feeAmountInQuoteCurrency, quoteCurrencyKey]);
 
 	useEffect(() => {
 		setCurrencyPair({

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -547,13 +547,6 @@ const useExchange = ({
 		[gasPrice, gasInfo?.limit, ethPriceRate, gasInfo?.l1Fee]
 	);
 
-	const feeAmountInBaseCurrency = useMemo(() => {
-		if (exchangeFeeRate != null && baseCurrencyAmount) {
-			return wei(baseCurrencyAmount).mul(exchangeFeeRate);
-		}
-		return null;
-	}, [baseCurrencyAmount, exchangeFeeRate]);
-
 	const feeAmountInQuoteCurrency = useMemo(() => {
 		if (exchangeFeeRate != null && quoteCurrencyAmount) {
 			return wei(quoteCurrencyAmount).mul(exchangeFeeRate);
@@ -563,15 +556,11 @@ const useExchange = ({
 	}, [quoteCurrencyAmount, exchangeFeeRate]);
 
 	const feeCost = useMemo(() => {
-		if (quoteCurrencyKey?.toString() === 'sUSD') {
-			return feeAmountInQuoteCurrency;
-		}
-
-		if (feeAmountInBaseCurrency != null) {
-			return feeAmountInBaseCurrency.mul(basePriceRate);
+		if (feeAmountInQuoteCurrency != null) {
+			return feeAmountInQuoteCurrency.mul(quotePriceRate);
 		}
 		return null;
-	}, [feeAmountInBaseCurrency, basePriceRate, feeAmountInQuoteCurrency, quoteCurrencyKey]);
+	}, [feeAmountInQuoteCurrency, quotePriceRate]);
 
 	useEffect(() => {
 		setCurrencyPair({

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -33,17 +33,28 @@ export const getDecimalPlaces = (value: WeiSource) => (value.toString().split('.
 
 export const zeroBN = wei(0);
 
-const zeroOutCommifiedDecimals = (value: string, decimals: number) => {
-	const comps = value.split('.');
+/**
+ * ethers utils.commify method will reduce the decimals of a number to one digit if those decimals are zero.
+ * This helper is used to reverse this behavior in or do display the specified decmials in the output.
+ *
+ * ex: utils.commify('10000', 2) => '10,000.0'
+ * ex: zeroOutCommifiedDecimals('10000', 2)) => '10,000.00'
+ * @param value - commified value from utils.commify
+ * @param decimals - number of decimals to display on commified value.
+ * @returns string
+ */
+export const zeroOutCommifiedDecimals = (value: string, decimals: number) => {
+	let formatted = utils.commify(value);
+	const comps = formatted.split('.');
 
 	if (comps.length === 2 && comps[1].length !== decimals) {
 		const zeros = '0'.repeat(decimals - comps[1].length);
 
-		const suffix = '.' + (comps[1] + zeros);
-		return comps[0] + suffix;
+		const decimalSuffix = `${comps[1]}${zeros}`;
+		formatted = `${comps[0]}.${decimalSuffix}`;
 	}
 
-	return value;
+	return formatted;
 };
 
 // TODO: implement max decimals
@@ -68,7 +79,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 	);
 
 	const withCommas = zeroOutCommifiedDecimals(
-		utils.commify(weiAsStringWithDecimals),
+		weiAsStringWithDecimals,
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);
 

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -35,15 +35,15 @@ export const zeroBN = wei(0);
 
 /**
  * ethers utils.commify method will reduce the decimals of a number to one digit if those decimals are zero.
- * This helper is used to reverse this behavior in or do display the specified decmials in the output.
+ * This helper is used to reverse this behavior in order to display the specified decmials in the output.
  *
  * ex: utils.commify('10000', 2) => '10,000.0'
- * ex: padDecimals('10000', 2)) => '10,000.00'
+ * ex: commifyAndPadDecimals('10000', 2)) => '10,000.00'
  * @param value - commified value from utils.commify
  * @param decimals - number of decimals to display on commified value.
  * @returns string
  */
-export const padDecimals = (value: string, decimals: number) => {
+export const commifyAndPadDecimals = (value: string, decimals: number) => {
 	let formatted = utils.commify(value);
 	const comps = formatted.split('.');
 
@@ -78,7 +78,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);
 
-	const withCommas = padDecimals(
+	const withCommas = commifyAndPadDecimals(
 		weiAsStringWithDecimals,
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -33,6 +33,20 @@ export const getDecimalPlaces = (value: WeiSource) => (value.toString().split('.
 
 export const zeroBN = wei(0);
 
+const formatCommifiedDecimalZeros = (value: string, decimals: number) => {
+	let suffix;
+	const comps = value.split('.');
+
+	if (comps.length === 2 && comps[1].length !== decimals) {
+		const zeros = '0'.repeat(decimals - comps[1].length);
+
+		suffix = '.' + (comps[1] + zeros);
+		return comps[0] + suffix;
+	}
+
+	return value;
+};
+
 // TODO: implement max decimals
 export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) => {
 	const prefix = options?.prefix;
@@ -49,10 +63,16 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 	if (prefix) {
 		formattedValue.push(prefix);
 	}
+
 	const weiAsStringWithDecimals = weiValue.toString(
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);
-	const withCommas = utils.commify(weiAsStringWithDecimals);
+
+	const withCommas = formatCommifiedDecimalZeros(
+		utils.commify(weiAsStringWithDecimals),
+		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
+	);
+
 	formattedValue.push(withCommas);
 
 	if (suffix) {

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -33,14 +33,13 @@ export const getDecimalPlaces = (value: WeiSource) => (value.toString().split('.
 
 export const zeroBN = wei(0);
 
-const formatCommifiedDecimalZeros = (value: string, decimals: number) => {
-	let suffix;
+const zeroOutCommifiedDecimals = (value: string, decimals: number) => {
 	const comps = value.split('.');
 
 	if (comps.length === 2 && comps[1].length !== decimals) {
 		const zeros = '0'.repeat(decimals - comps[1].length);
 
-		suffix = '.' + (comps[1] + zeros);
+		const suffix = '.' + (comps[1] + zeros);
 		return comps[0] + suffix;
 	}
 
@@ -68,7 +67,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);
 
-	const withCommas = formatCommifiedDecimalZeros(
+	const withCommas = zeroOutCommifiedDecimals(
 		utils.commify(weiAsStringWithDecimals),
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -38,12 +38,12 @@ export const zeroBN = wei(0);
  * This helper is used to reverse this behavior in or do display the specified decmials in the output.
  *
  * ex: utils.commify('10000', 2) => '10,000.0'
- * ex: zeroOutCommifiedDecimals('10000', 2)) => '10,000.00'
+ * ex: padDecimals('10000', 2)) => '10,000.00'
  * @param value - commified value from utils.commify
  * @param decimals - number of decimals to display on commified value.
  * @returns string
  */
-export const zeroOutCommifiedDecimals = (value: string, decimals: number) => {
+export const padDecimals = (value: string, decimals: number) => {
 	let formatted = utils.commify(value);
 	const comps = formatted.split('.');
 
@@ -78,7 +78,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);
 
-	const withCommas = zeroOutCommifiedDecimals(
+	const withCommas = padDecimals(
 		weiAsStringWithDecimals,
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);


### PR DESCRIPTION
## Description
the core issue comes from the `feeCost` calculation in the `useExchange` hook. The current implementation is calculating fees based off of `baseCurrencyAmount`, which already has the fees subtracted. Instead, we should use the `quoteCurrencyAmount` too calculate the fees. solution is as follows:

1. added a calculation called `feeAmountInQuoteCurrency` that gets memoized on its own
2. exchange `feeCost` calculation from baseCurrency and baseRate to quoteCurrency and quoteRate.

```
const feeCost = useMemo(() => {
  if (feeAmountInBaseCurrency != null) {
    return feeAmountInBaseCurrency.mul(basePriceRate);
  }
  return null;
}, [feeAmountInBaseCurrency, basePriceRate]);
```

**vs**

```
const feeCost = useMemo(() => {
	if (feeAmountInQuoteCurrency != null) {
		return feeAmountInQuoteCurrency.mul(quotePriceRate);
	}
	return null;
}, [feeAmountInQuoteCurrency, quotePriceRate]);
```

**This fix applies the correct calculation across all synths, inlcuding sUSD**

## Related issue
https://github.com/Kwenta/kwenta/issues/341

## Motivation and Context
- when trading against the synth pair, the fee cost should be applied to the `quoteCurrencyAmount` and `quoteRate` 
- when trading against the synth pair, the formatting of different values across the exchange only displays 1 decimal places when the decimals result in a `.00` value.

## How Has This Been Tested?

google chrome on a mac OS laptop
node v14.17.1
npm v8.4.0

1. I tested this by loading the app as per the README:

```bash
> npm i
...
> npm run dev
...
```

From the localhost setup I connected to `optimism mainnet` and tested against my own wallet balances (tried to grab some from the optimism kovan faucet but was having trouble there). I was able to confirm the fix by comparing my localhost connected to `optimism mainnet` with https://kwenta.io/exchange/sETH-sUSD and differentiating the formatting and fee cost amounts.

2. I have noticed a formatting issue that is applied to several spots when sUSD (and sETH) are selected, see screen shots for references there.

There are some e2e tests for the exchange, I have not tried those as yet.

## Screenshots (if appropriate):

##### after changes:
![Screen Shot 2022-02-08 at 3 51 59 PM](https://user-images.githubusercontent.com/5998100/153098295-4636246f-12d7-4bed-896a-b18039cdafa9.png)

##### comparison of formatting against sUSD

![Screen Shot 2022-02-08 at 2 53 38 PM](https://user-images.githubusercontent.com/5998100/153098242-75dda445-df60-4cf2-87ea-1c415d097a42.png)
![Screen Shot 2022-02-08 at 4 01 11 PM](https://user-images.githubusercontent.com/5998100/153098249-522ceca6-5794-4e71-9f7c-5db1b37d5c8d.png)
