### PR TITLE
Add Banner with community raise info

### DIFF
--- a/assets/svg/app/futures-borders.svg
+++ b/assets/svg/app/futures-borders.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="671px" height="39" viewBox="0 0 671 41" fill="none" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" >
+  <path d="M624.854 19.5L651.18 0.5H1267.84L1294.15 19.5L1267.84 38.5H651.18L624.854 19.5Z" stroke="url(#paint0_linear_1239:7505)" transform="matrix(1.0016118986708322, 0, 0, 1, -625.458650242129, 1.0631424188613892)" style="" />
+  <defs>
+    <linearGradient id="paint0_linear_1239:7505" x1="959.5" y1="0" x2="959.5" y2="39" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E4B378"/>
+      <stop offset="1" stop-color="#B98C55"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/assets/svg/app/link-white.svg
+++ b/assets/svg/app/link-white.svg
@@ -1,0 +1,17 @@
+<svg width="14" height="14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g filter="url(#a)">
+    <path d="M9.244 3.208H4.812V1.656h7.072V8.84h-1.552V4.312l-6.448 6.48-1.12-1.12 6.48-6.464Z" fill="#fff"/>
+  </g>
+  <defs>
+    <filter id="a" x=".764" y=".656" width="13.121" height="13.136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="1"/>
+      <feGaussianBlur stdDeviation="1"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_1239:7498"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow_1239:7498" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
+import Img, { Svg } from 'react-optimized-image';
 
 import { HEADER_HEIGHT } from 'constants/ui';
 import ROUTES from 'constants/routes';
@@ -20,6 +21,8 @@ import { GridDivCenteredCol, TextButton } from 'styles/common';
 import SmoothScroll from 'sections/homepage/containers/SmoothScroll';
 import { useRecoilValue } from 'recoil';
 import { isL2State } from 'store/wallet';
+import FuturesBordersSvg from 'assets/svg/app/futures-borders.svg';
+import LinkWhiteIcon from 'assets/svg/app/link-white.svg';
 
 const KIPS_LINK = 'https://github.com/Kwenta/KIPs';
 
@@ -56,6 +59,19 @@ const Header: FC = () => {
 
 	return (
 		<>
+			<FuturesBannerContainer>
+				<FuturesBannerLinkWrapper>
+					<>
+						<FuturesLink href="https://raise.kwenta.io" target="_blank">
+							Kwenta Community Raise now live on Aelin
+						</FuturesLink>
+						<Img src={LinkWhiteIcon} />
+					</>
+				</FuturesBannerLinkWrapper>
+				<DivBorder />
+				<Svg src={FuturesBordersSvg} />
+				<DivBorder />
+			</FuturesBannerContainer>
 			<MobileHiddenView>
 				<Container>
 					<Logo isL2={isL2} />
@@ -99,6 +115,39 @@ const Container = styled.header`
 	${media.lessThan('md')`
 		grid-template-columns: auto auto;
 	`}
+`;
+const FuturesBannerContainer = styled.div`
+	height: 65px;
+	width: 100%;
+	display: flex;
+	align-items: center;
+	background: linear-gradient(
+		180deg,
+		${(props) => props.theme.colors.goldColors.color1} 0%,
+		${(props) => props.theme.colors.goldColors.color2} 100%
+	);
+`;
+
+const FuturesBannerLinkWrapper = styled.div`
+	width: 100%;
+	text-align: center;
+	position: absolute;
+	text-shadow: 0px 1px 2px ${(props) => props.theme.colors.transparentBlack};
+	color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 16px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+const DivBorder = styled.div`
+	height: 2px;
+	background: ${(props) => props.theme.colors.goldColors.color1};
+	flex-grow: 1;
+`;
+const FuturesLink = styled.a`
+	margin-right: 5px;
 `;
 
 const Links = styled.div`


### PR DESCRIPTION
## Description
This PR adds a banner with the community raise info.

## Related issue
N/A

## Motivation and Context
This change is part of the community raise launch.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15985212/153907082-fed73ab8-1ce2-4926-9db7-d963fb99e771.png">
