### PR TITLE
clean: gold top border

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -49,8 +49,6 @@ const Container = styled.header<{ isL2: boolean }>`
 		box-shadow: 0 8px 8px 0 ${(props) => props.theme.colors.black};
 	`};
 	> div {
-		border-top: ${(props) =>
-			`2px solid ${props.isL2 ? props.theme.colors.goldColors.color2 : 'transparent'}`};
 		box-sizing: border-box;
 		height: ${HEADER_HEIGHT};
 		line-height: ${HEADER_HEIGHT};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed gold top border CSS on `v2` branch

## Related issue
Fixes #354 

## Motivation and Context
Left over css styling that was meant to be removed

## How Has This Been Tested?
- Took a screenshot to confirm border has been removed on every page
- Minimal diff possible

## Screenshots (if appropriate):
<img width="1024" alt="Screen Shot 2022-02-17 at 2 30 05 PM" src="https://user-images.githubusercontent.com/99768011/154581849-9dde531a-5a56-402a-a185-1d965fcfa805.png">
<img width="1024" alt="Screen Shot 2022-02-17 at 2 30 38 PM" src="https://user-images.githubusercontent.com/99768011/154581922-d388ada5-de28-4471-9831-444164671951.png">
<img width="1024" alt="Screen Shot 2022-02-17 at 2 31 13 PM" src="https://user-images.githubusercontent.com/99768011/154581998-9d397093-7765-42bc-aaec-c2cc29db3894.png">
