### PR TITLE
Connector.tsx blocknative ENS support started

### DIFF
--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -35,6 +35,8 @@ const useConnector = () => {
 	const [onboard, setOnboard] = useState<ReturnType<typeof initOnboard> | null>(null);
 	const [isAppReady, setAppReady] = useRecoilState(appReadyState);
 	const [walletAddress, setWalletAddress] = useRecoilState(walletAddressState);
+	const [ensName, setEns] = useState<string | undefined>();
+	const [ensAvatar, setAvatar] = useState<string | undefined>();
 	const setOrders = useSetRecoilState(ordersState);
 	const setHasOrdersNotification = useSetRecoilState(hasOrdersNotificationState);
 	const [selectedWallet, setSelectedWallet] = useLocalStorage<string | null>(
@@ -90,6 +92,14 @@ const useConnector = () => {
 					if (address) {
 						setWalletAddress(address);
 					}
+				},
+				ens: async (ens) => {
+					const ensName = ens?.name;
+					const ensAvatar = ens?.avatar;
+					setEns(ensName);
+					setAvatar(ensAvatar);
+					console.log(ensName);
+					console.log(ensAvatar);
 				},
 				network: (networkId: number) => {
 					const isSupportedNetwork =
@@ -163,10 +173,10 @@ const useConnector = () => {
 	// load previously saved wallet
 	useEffect(() => {
 		// disables caching if in IFrame allow parent to set wallet address
-		if (onboard && selectedWallet && !walletAddress && !isIFrame()) {
+		if (onboard && selectedWallet && !walletAddress && !ensName && !ensAvatar && !isIFrame()) {
 			onboard.walletSelect(selectedWallet);
 		}
-	}, [onboard, selectedWallet, walletAddress]);
+	}, [onboard, selectedWallet, walletAddress, ensName, ensAvatar]);
 
 	const isIFrame = () => {
 		try {
@@ -189,11 +199,26 @@ const useConnector = () => {
 				const success = await onboard.walletSelect();
 				if (success) {
 					await onboard.walletCheck();
+					await displayENS();
 					resetCachedUI();
 				}
 			}
 		} catch (e) {
 			console.log(e);
+		}
+	};
+
+	const displayENS = async () => {
+		if (onboard) {
+			setEns(ensName);
+			setAvatar(ensAvatar);
+			console.log(ensName);
+			console.log(ensAvatar);
+			if (ensAvatar && ensName) {
+				return ensAvatar && ensName;
+			} else {
+				return ensName;
+			}
 		}
 	};
 
@@ -252,6 +277,7 @@ const useConnector = () => {
 		isHardwareWallet,
 		transactionNotifier,
 		getTokenAddress,
+		displayENS,
 	};
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "kwenta",
 			"version": "2.45.2",
 			"hasInstallScript": true,
 			"dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In kwenta/containers/Connector/Connector.tsx, I added the `ens` subscription from Blocknative. I set the ENS to a `useState` hook in line's 38 and 39 for both ENS name and ENS avatar to be set. 

Then I created a `displayENS` function on line 211 and tried calling the hooks that were set in the `ens` subscription above, and inserting the function into `connectWallet` so that way once the Connect Wallet button is used, it retrieves the ENS related to the wallet address.

I had a lot of trouble with trying to display this ENS and think that I was heading in the right direction but couldn't quite figure it out. 
## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
