### PR TITLE
Fixed gnosisSafe wallet connect option for mobile

### DIFF
--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -59,7 +59,7 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 					walletName: 'portis',
 					apiKey: process.env.NEXT_PUBLIC_PORTIS_APP_ID,
 				},
-				{ walletName: 'gnosis' },
+				{ walletName: 'gnosis', rpcUrl: infuraRpc },
 				{ walletName: 'trust', rpcUrl: infuraRpc },
 				{ walletName: 'walletLink', rpcUrl: infuraRpc, preferred: true },
 				{ walletName: 'torus' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "kwenta",
 			"version": "2.45.2",
 			"hasInstallScript": true,
 			"dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The gnosis wallet connect option was not working for mobile, it would automatically disconnect a user. I noticed that the wallet connect modal actually didn't even show gnosis when you switched to mobile. I went to the wallet connector config.ts and found that 'gnosis' was missing the `rpcUrl: infuraRpc` option. After adding this, Gnosis then appeared in the modal when on mobile. I was able to connect to the wallet and/or stay connected after that. 

## Related issue
(https://github.com/Kwenta/kwenta/issues/343)

## Motivation and Context
GnosisSafe is a popular, more secure, wallet that any major application should support. 

## How Has This Been Tested?
On gnosisSafe.io, I used ngrok.io to forward the provided URL to my local host 3000. I used npm run build and run dev, then copied the ngrok URL into gnosisSafe's custom app (example = https://4286-104-54-248-129.ngrok.io ). I then switched the chrome dev tool inspector to mobile. 
Ngrok.io loaded slow and often failed to load in gnosisSafe, but I was able to notice that added the `rpcUrl: infuraRpc` to the gnosis wallet config, solved the problem.
I did not notice any changes to others areas of the code since this was a minor change.

## Screenshots (if appropriate):
BEFORE the fix:
<img width="1176" alt="Screen Shot 2022-02-19 at 3 49 24 PM" src="https://user-images.githubusercontent.com/83140889/154820712-609bc4ee-e045-4362-90f7-a0474f235174.png">

AFTER the fix:
<img width="1121" alt="Screen Shot 2022-02-19 at 3 48 33 PM" src="https://user-images.githubusercontent.com/83140889/154820733-b1899dbc-8b7f-4675-86fb-777eeba77ac0.png">

