### PR TITLE
Add new synths to short assets list

### DIFF
--- a/sections/shorting/constants.ts
+++ b/sections/shorting/constants.ts
@@ -1,4 +1,12 @@
 import { CurrencyKey, Synths } from 'constants/currency';
 
 export const SYNTHS_TO_SHORT_L1: CurrencyKey[] = [Synths.sBTC, Synths.sETH, Synths.sLINK];
-export const SYNTHS_TO_SHORT: CurrencyKey[] = [Synths.sBTC, Synths.sETH, Synths.sLINK, Synths.sSOL];
+export const SYNTHS_TO_SHORT: CurrencyKey[] = [
+	Synths.sBTC,
+	Synths.sETH,
+	Synths.sLINK,
+	Synths.sSOL,
+	Synths.sAVAX,
+	Synths.sMATIC,
+	Synths.sEUR,
+];


### PR DESCRIPTION
## Description
This PR adds `sAVAX`, `sMATIC` and `sEUR` to the list of synths that can be shorted on L2.

## Related issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
