### PR TITLE
Leaderboard volume

### DIFF
--- a/components/Tab/Tab.tsx
+++ b/components/Tab/Tab.tsx
@@ -63,7 +63,6 @@ const StyledTabButton = styled.button<TabProps>`
 	${resetButtonCSS};
 	font-family: ${(props) => props.theme.fonts.bold};
 	padding: 0;
-	background-color: ${(props) => props.theme.colors.black};
 	color: ${(props) => (props.active ? props.theme.colors.white : props.theme.colors.blueberry)};
 	border-bottom: 2px solid
 		${(props) => (props.active ? props.theme.colors.goldColors.color1 : 'transparent')};

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -143,9 +143,10 @@ export const QUERY_KEYS = {
 		Participant: (walletAddress: string) => ['futures', 'participant', walletAddress],
 		Stats: ['futures', 'stats'],
 		AverageLeverage: ['futures', 'averageLeverage'],
-		CumulativeVolume: ['futurs', 'cumulativeVolume'],
+		CumulativeVolume: ['futures', 'cumulativeVolume'],
 		TotalLiquidations: ['futures', 'totalLiquidations'],
 		TotalTrades: ['futures', 'totalTrades'],
+		TotalVolume: ['futures', 'totalVolume'],
 	},
 };
 

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -1,4 +1,4 @@
 export const FUTURES_ENDPOINT =
-	'https://api.thegraph.com/subgraphs/name/kmeraz/optimism-kovan-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-kovan-futures';
 
 export const DAY_PERIOD = 24 * 3600;

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -137,6 +137,7 @@ export type FuturesStat = {
 	pnlWithFeesPaid: string;
 	liquidations: number;
 	totalTrades: number;
+	totalVolume: number;
 };
 
 export type FuturesCumulativeStats = {

--- a/queries/futures/useGetStats.ts
+++ b/queries/futures/useGetStats.ts
@@ -23,6 +23,7 @@ const useGetStats = (options?: UseQueryOptions<any>) => {
 						pnlWithFeesPaid
 						liquidations
 						totalTrades
+						totalVolume
 					}
 				}
 			`,

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -26,6 +26,7 @@ type Stat = {
 	pnl: Wei;
 	liquidations: Wei;
 	totalTrades: Wei;
+	totalVolume: Wei;
 };
 
 const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
@@ -43,6 +44,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 			pnl: wei(stat.pnlWithFeesPaid ?? 0, 18, true),
 			liquidations: new Wei(stat.liquidations ?? 0),
 			totalTrades: new Wei(stat.totalTrades ?? 0),
+			totalVolume: wei(stat.totalVolume ?? 0, 18, true),
 		};
 		return acc;
 	}, {});
@@ -59,6 +61,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 				address: stat.account,
 				trader: truncateAddress(stat.account),
 				totalTrades: (pnlMap[stat.account]?.totalTrades ?? wei(0)).toNumber(),
+				totalVolume: (pnlMap[stat.account]?.totalVolume ?? wei(0)).toNumber(),
 				liquidations: (pnlMap[stat.account]?.liquidations ?? wei(0)).toNumber(),
 				'24h': 80000,
 				pnl: (pnlMap[stat.account]?.pnl ?? wei(0)).toNumber(),
@@ -158,6 +161,21 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 								accessor: 'liquidations',
 								sortType: 'basic',
 								width: 175,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-volume')}</TableHeader>,
+								accessor: 'totalVolume',
+								sortType: 'basic',
+								Cell: (cellProps: CellProps<any>) => (
+									<Currency.Price
+										currencyKey={Synths.sUSD}
+										price={cellProps.row.original.totalVolume}
+										sign={'$'}
+										conversionRate={1}
+									/>
+								),
+								width: compact ? 'auto' : 175,
 								sortable: true,
 							},
 							{

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -7,6 +7,7 @@ import { useRecoilValue } from 'recoil';
 import Wei, { wei } from '@synthetixio/wei';
 
 import Currency from 'components/Currency';
+import ChangePercent from 'components/ChangePercent';
 import { Synths } from 'constants/currency';
 import useGetStats from 'queries/futures/useGetStats';
 import { walletAddressState } from 'store/wallet';
@@ -65,6 +66,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 				liquidations: (pnlMap[stat.account]?.liquidations ?? wei(0)).toNumber(),
 				'24h': 80000,
 				pnl: (pnlMap[stat.account]?.pnl ?? wei(0)).toNumber(),
+				pnlPct: (pnlMap[stat.account]?.pnl.div(pnlMap[stat.account]?.totalVolume) ?? wei(0)).toNumber(),
 			}))
 			.filter((i: {trader: string}) => (searchTerm?.length ? i.trader.toLowerCase().includes(searchTerm) : true));
 	}, [stats, searchTerm]);
@@ -175,7 +177,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 										conversionRate={1}
 									/>
 								),
-								width: compact ? 'auto' : 175,
+								width: compact ? 'auto' : 125,
 								sortable: true,
 							},
 							{
@@ -190,7 +192,19 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 										conversionRate={1}
 									/>
 								),
-								width: compact ? 'auto' : 175,
+								width: compact ? 'auto' : 100,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.percent-pnl')}</TableHeader>,
+								accessor: 'pnlPct',
+								sortType: 'basic',
+								Cell: (cellProps: CellProps<any>) => (
+									<ChangePercent
+										value={cellProps.row.original.pnlPct}
+									/>
+								),
+								width: compact ? 'auto' : 100,
 								sortable: true,
 							},
 						]

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -109,7 +109,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 				isLoading={statsQuery.isLoading}
 				data={data}
 				hideHeaders={compact}
-				hiddenColumns={compact ? ['rank', 'totalTrades', 'liquidations'] : undefined}
+				hiddenColumns={compact ? ['rank', 'totalTrades', 'liquidations', 'totalVolume', 'pnl'] : undefined}
 				columns = {[
 					{
 						Header:

--- a/translations/en.json
+++ b/translations/en.json
@@ -693,6 +693,7 @@
 				"rank": "Rank",
 				"trader": "Trader",
 				"total-trades": "Total Trades",
+				"total-volume": "Total Volume",
 				"liquidations": "Liquidations",
 				"24h-pnl": "24H PnL",
 				"total-pnl": "Total PnL"

--- a/translations/en.json
+++ b/translations/en.json
@@ -696,7 +696,8 @@
 				"total-volume": "Total Volume",
 				"liquidations": "Liquidations",
 				"24h-pnl": "24H PnL",
-				"total-pnl": "Total PnL"
+				"total-pnl": "PnL ($)",
+				"percent-pnl": "PnL (%)"
 			}
 		},
 		"statistics": {

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -78,7 +78,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 		formattedValue.push(prefix);
 	}
 
-	const weiAsStringWithDecimals = weiValue.toString(
+	const weiAsStringWithDecimals = weiValue.abs().toString(
 		options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS
 	);
 


### PR DESCRIPTION
Adding total volume and PnL as a %

## Description
Add new metrics to the leaderboard. These new metrics will allow us to measure performance during the upcoming futures trading competition

## Related issue
[Issue #365](https://github.com/Kwenta/kwenta/issues/365)

## How Has This Been Tested?
* Submitted new futures transactions

## Screenshots (if appropriate):
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/10401554/155607570-8a2e2da8-07ae-4901-b2f6-58b435af2b42.png">
