### PR TITLE
EIP 1559 support for transactions - mainnet

### DIFF
--- a/hooks/useGas.ts
+++ b/hooks/useGas.ts
@@ -65,6 +65,12 @@ const useGas = () => {
 	}, []);
 
 	useEffect(() => {
+		if (!isMainnet) {
+			setCustomGasPrice('');
+		}
+	}, [isMainnet, setCustomGasPrice]);
+
+	useEffect(() => {
 		const maxPriorityFeePerGas = selectedGas.maxPriorityFeePerGas;
 		const maxFeePerGasValue = isCustomGasPrice ? gasPriceWei : selectedGas.maxFeePerGas;
 

--- a/hooks/useGas.ts
+++ b/hooks/useGas.ts
@@ -22,8 +22,8 @@ export const parseGasPriceObject = (gasPriceObject: GasPrice): number | null => 
 const useGas = () => {
 	const { useEthGasPriceQuery } = useSynthetixQueries();
 	const ethGasPriceQuery = useEthGasPriceQuery();
-	const [customGasPrice, setCustomGasPrice] = useRecoilState(customGasPriceState);
 	const gasSpeed = useRecoilValue(gasSpeedState);
+	const [customGasPrice, setCustomGasPrice] = useRecoilState(customGasPriceState);
 	const [isCustomGasPrice, setIsCustomGasPrice] = useState(false);
 
 	const gasPrice = useMemo(() => {

--- a/hooks/useGas.ts
+++ b/hooks/useGas.ts
@@ -79,6 +79,7 @@ const useGas = () => {
 		isCustomGasPrice,
 		isMainnet,
 		selectedGas.baseFeePerGas,
+		selectedGas.maxFeePerGas,
 		selectedGas.maxPriorityFeePerGas,
 	]);
 

--- a/hooks/useGas.ts
+++ b/hooks/useGas.ts
@@ -1,8 +1,8 @@
-import { useMemo, useCallback } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useMemo, useCallback, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { BigNumber } from 'ethers';
 
-import useSynthetixQueries, { GasPrice } from '@synthetixio/queries';
+import useSynthetixQueries, { GasPrice, GasPrices } from '@synthetixio/queries';
 import { customGasPriceState, gasSpeedState } from 'store/wallet';
 import { normalizeGasLimit, gasPriceInWei } from 'utils/network';
 import { wei } from '@synthetixio/wei';
@@ -22,18 +22,22 @@ export const parseGasPriceObject = (gasPriceObject: GasPrice): number | null => 
 const useGas = () => {
 	const { useEthGasPriceQuery } = useSynthetixQueries();
 	const ethGasPriceQuery = useEthGasPriceQuery();
-	const customGasPrice = useRecoilValue(customGasPriceState);
+	const [customGasPrice, setCustomGasPrice] = useRecoilState(customGasPriceState);
 	const gasSpeed = useRecoilValue(gasSpeedState);
+	const [isCustomGasPrice, setIsCustomGasPrice] = useState(false);
 
-	const gasPrice = useMemo(
-		() =>
-			customGasPrice !== ''
-				? Number(customGasPrice)
-				: ethGasPriceQuery.data != null
-				? parseGasPriceObject(ethGasPriceQuery.data[gasSpeed])
-				: null,
-		[customGasPrice, ethGasPriceQuery.data, gasSpeed]
-	);
+	const gasPrice = useMemo(() => {
+		if (customGasPrice !== '') {
+			setIsCustomGasPrice(true);
+			return Number(customGasPrice);
+		} else {
+			setIsCustomGasPrice(false);
+		}
+
+		return ethGasPriceQuery.data != null
+			? parseGasPriceObject(ethGasPriceQuery.data[gasSpeed])
+			: null;
+	}, [customGasPrice, ethGasPriceQuery.data, gasSpeed]);
 
 	const getGasLimitEstimate = useCallback(async (getGasEstimate: () => Promise<BigNumber>): Promise<
 		number | null
@@ -48,8 +52,11 @@ const useGas = () => {
 
 	return {
 		gasPrice,
-		gasPriceWei: !gasPrice ? 0 : gasPriceInWei(gasPrice),
 		getGasLimitEstimate,
+		isCustomGasPrice,
+		customGasPrice,
+		setCustomGasPrice,
+		gasPriceWei: !gasPrice ? 0 : gasPriceInWei(gasPrice),
 	};
 };
 

--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import Tippy from '@tippyjs/react';
-import { isL2State } from 'store/wallet';
+import { isL2State, isMainnetState } from 'store/wallet';
 import { useRecoilValue } from 'recoil';
 import { Svg } from 'react-optimized-image';
 
@@ -38,6 +38,7 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 	const { t } = useTranslation();
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const isL2 = useRecoilValue(isL2State);
+	const isMainnet = useRecoilValue(isMainnetState);
 	const {
 		gasPrice,
 		gasSpeed,
@@ -57,19 +58,29 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 
 	return (
 		<SummaryItem {...rest}>
-			<SummaryItemLabel>{t('exchange.summary-info.gas-price-gwei')}</SummaryItemLabel>
+			<SummaryItemLabel>
+				{isMainnet || !isCustomGasPrice
+					? t('exchange.summary-info.max-fee-gwei')
+					: t('exchange.summary-info.gas-price-gwei')}
+			</SummaryItemLabel>
 			<SummaryItemValue>
 				{gasPrice != null ? (
 					<>
 						{transactionFee != null ? (
 							<GasPriceCostTooltip
 								content={
-									<span>
-										{formatCurrency(selectedPriceCurrency.name as CurrencyKey, transactionFee, {
-											sign: selectedPriceCurrency.sign,
-											maxDecimals: 1,
-										})}
-									</span>
+									<GasEstimateUSD>
+										<GasEstimateUSDAmount>
+											{formatCurrency(selectedPriceCurrency.name as CurrencyKey, transactionFee, {
+												sign: selectedPriceCurrency.sign,
+												maxDecimals: 1,
+											})}
+										</GasEstimateUSDAmount>
+										<GasEstimateInfo>
+											It is recommended to not edit the Max Fee. The difference between Max Fee and
+											Current Gas Price will be refunded to the user
+										</GasEstimateInfo>
+									</GasEstimateUSD>
 								}
 								arrow={false}
 							>
@@ -153,6 +164,18 @@ export const GasSelectContainer = styled.div`
 
 export const CustomGasPriceContainer = styled.div`
 	margin: 0 10px 5px 10px;
+`;
+
+export const GasEstimateUSD = styled.span`
+	text-align: center;
+`;
+
+export const GasEstimateUSDAmount = styled.p`
+	color: #ffdf6d;
+`;
+
+export const GasEstimateInfo = styled.p`
+	text-align: left;
 `;
 
 export const CustomGasPrice = styled(NumericInput)`

--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -2,8 +2,8 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import Tippy from '@tippyjs/react';
-import { gasSpeedState, isL2State } from 'store/wallet';
-import { useRecoilValue, useRecoilState } from 'recoil';
+import { isL2State } from 'store/wallet';
+import { useRecoilValue } from 'recoil';
 import { Svg } from 'react-optimized-image';
 
 import { NO_VALUE, ESTIMATE_VALUE } from 'constants/placeholder';
@@ -36,10 +36,16 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 	...rest
 }) => {
 	const { t } = useTranslation();
-	const [gasSpeed, setGasSpeed] = useRecoilState<keyof GasPrices>(gasSpeedState);
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const isL2 = useRecoilValue(isL2State);
-	const { gasPrice, isCustomGasPrice, customGasPrice, setCustomGasPrice } = useGas();
+	const {
+		gasPrice,
+		gasSpeed,
+		setGasSpeed,
+		isCustomGasPrice,
+		customGasPrice,
+		setCustomGasPrice,
+	} = useGas();
 
 	const gasPriceItem = isCustomGasPrice ? (
 		<span data-testid="gas-price">{formatNumber(customGasPrice, { minDecimals: 4 })}</span>

--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -78,7 +78,7 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 										</GasEstimateUSDAmount>
 										<GasEstimateInfo>
 											It is recommended to not edit the Max Fee. The difference between Max Fee and
-											Current Gas Price will be refunded to the user
+											Current Gas Price will be refunded to the user.
 										</GasEstimateInfo>
 									</GasEstimateUSD>
 								}
@@ -175,7 +175,7 @@ export const GasEstimateUSDAmount = styled.p`
 `;
 
 export const GasEstimateInfo = styled.p`
-	text-align: left;
+	text-align: center;
 `;
 
 export const CustomGasPrice = styled(NumericInput)`

--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import Tippy from '@tippyjs/react';
-import { customGasPriceState, gasSpeedState, isL2State } from 'store/wallet';
+import { gasSpeedState, isL2State } from 'store/wallet';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import { Svg } from 'react-optimized-image';
 
@@ -22,7 +22,7 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { SummaryItem, SummaryItemValue, SummaryItemLabel } from '../common';
 import { GasPrices, GAS_SPEEDS } from '@synthetixio/queries';
 import { CurrencyKey } from 'constants/currency';
-import { parseGasPriceObject } from 'hooks/useGas';
+import useGas, { parseGasPriceObject } from 'hooks/useGas';
 
 type GasPriceSummaryItemProps = {
 	gasPrices: GasPrices | undefined;
@@ -37,14 +37,11 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 }) => {
 	const { t } = useTranslation();
 	const [gasSpeed, setGasSpeed] = useRecoilState<keyof GasPrices>(gasSpeedState);
-	const [customGasPrice, setCustomGasPrice] = useRecoilState(customGasPriceState);
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const isL2 = useRecoilValue(isL2State);
+	const { gasPrice, isCustomGasPrice, customGasPrice, setCustomGasPrice } = useGas();
 
-	const hasCustomGasPrice = customGasPrice !== '';
-	const gasPrice = gasPrices ? parseGasPriceObject(gasPrices[gasSpeed]) : null;
-
-	const gasPriceItem = hasCustomGasPrice ? (
+	const gasPriceItem = isCustomGasPrice ? (
 		<span data-testid="gas-price">{formatNumber(customGasPrice, { minDecimals: 4 })}</span>
 	) : (
 		<span data-testid="gas-price">
@@ -99,7 +96,7 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 													setCustomGasPrice('');
 													setGasSpeed(speed);
 												}}
-												isActive={hasCustomGasPrice ? false : gasSpeed === speed}
+												isActive={isCustomGasPrice ? false : gasSpeed === speed}
 											>
 												<span>{t(`common.gas-prices.${speed}`)}</span>
 												<NumericValue>

--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -48,6 +48,13 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 		setCustomGasPrice,
 	} = useGas();
 
+	const gasEstimateInfo = isMainnet ? (
+		<GasEstimateInfo>
+			It is recommended to not edit the Max Fee. The difference between Max Fee and Current Gas
+			Price will be refunded to the user
+		</GasEstimateInfo>
+	) : null;
+
 	const gasPriceItem = isCustomGasPrice ? (
 		<span data-testid="gas-price">{formatNumber(customGasPrice, { minDecimals: 4 })}</span>
 	) : (
@@ -76,10 +83,7 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 												maxDecimals: 1,
 											})}
 										</GasEstimateUSDAmount>
-										<GasEstimateInfo>
-											It is recommended to not edit the Max Fee. The difference between Max Fee and
-											Current Gas Price will be refunded to the user.
-										</GasEstimateInfo>
+										{gasEstimateInfo}
 									</GasEstimateUSD>
 								}
 								arrow={false}

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -729,7 +729,7 @@ const useExchange = ({
 				);
 
 				const gas = {
-					gasPrice: gasPriceInWei(gasPrice),
+					gasPrice: gasPriceWei,
 					gasLimit: normalizeGasLimit(Number(gasEstimate)),
 				};
 

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -64,14 +64,7 @@ import {
 	baseChartTypeState,
 	quoteChartTypeState,
 } from 'store/app';
-import {
-	customGasPriceState,
-	gasSpeedState,
-	isWalletConnectedState,
-	walletAddressState,
-	isL2State,
-	networkState,
-} from 'store/wallet';
+import { isWalletConnectedState, walletAddressState, isL2State, networkState } from 'store/wallet';
 import { ordersState } from 'store/orders';
 
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
@@ -85,13 +78,12 @@ import L2Gas from 'containers/L2Gas';
 
 import { NoTextTransform } from 'styles/common';
 import useZapperTokenList from 'queries/tokenLists/useZapperTokenList';
-import { GasPrices } from '@synthetixio/queries';
 
 import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import Connector from 'containers/Connector';
 import { useGetL1SecurityFee } from 'hooks/useGetL1SecurityGasFee';
-import { parseGasPriceObject } from 'hooks/useGas';
+import useGas from 'hooks/useGas';
 
 type ExchangeCardProps = {
 	defaultBaseCurrencyKey?: string | null;
@@ -167,10 +159,9 @@ const useExchange = ({
 	const [txApproveModalOpen, setTxApproveModalOpen] = useState<boolean>(false);
 	const setOrders = useSetRecoilState(ordersState);
 	const setHasOrdersNotification = useSetRecoilState(hasOrdersNotificationState);
-	const gasSpeed = useRecoilValue<keyof GasPrices>(gasSpeedState);
-	const customGasPrice = useRecoilValue(customGasPriceState);
 	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
 	const network = useRecoilValue(networkState);
+	const { gasPrice } = useGas();
 	// const cmcQuotesQuery = useCMCQuotesQuery([SYNTHS_MAP.sUSD, CRYPTO_CURRENCY_MAP.ETH], {
 	// 	enabled: txProvider === '1inch',
 	// });
@@ -553,16 +544,6 @@ const useExchange = ({
 		setQuoteCurrencyAmount('');
 		setBaseCurrencyAmount('');
 	}
-
-	const gasPrice = useMemo(
-		() =>
-			customGasPrice !== ''
-				? Number(customGasPrice)
-				: ethGasPriceQuery.data != null
-				? parseGasPriceObject(ethGasPriceQuery.data[gasSpeed])
-				: null,
-		[customGasPrice, ethGasPriceQuery.data, gasSpeed, isL2]
-	);
 
 	const transactionFee = useMemo(
 		() => getTransactionPrice(gasPrice, gasInfo?.limit, ethPriceRate, gasInfo?.l1Fee),

--- a/sections/shorting/ManageShort/ManageShortAction.tsx
+++ b/sections/shorting/ManageShort/ManageShortAction.tsx
@@ -37,12 +37,7 @@ import CurrencyCard from 'sections/exchange/TradeCard/CurrencyCard';
 
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
-import {
-	customGasPriceState,
-	gasSpeedState,
-	isWalletConnectedState,
-	walletAddressState,
-} from 'store/wallet';
+import { isWalletConnectedState, walletAddressState } from 'store/wallet';
 import { NoTextTransform } from 'styles/common';
 import media from 'styles/media';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
@@ -66,7 +61,7 @@ import TransactionNotifier from 'containers/TransactionNotifier';
 import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import { isL2State } from 'store/wallet';
-import { parseGasPriceObject } from 'hooks/useGas';
+import useGas from 'hooks/useGas';
 
 type ManageShortActionProps = {
 	short: ShortPosition;
@@ -108,8 +103,7 @@ const ManageShortAction: FC<ManageShortActionProps> = ({
 	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const ethGasPriceQuery = useEthGasPriceQuery();
-	const customGasPrice = useRecoilValue(customGasPriceState);
-	const gasSpeed = useRecoilValue(gasSpeedState);
+	const { gasPrice } = useGas();
 	const walletAddress = useRecoilValue(walletAddressState);
 	const synthsWalletBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const collateralShortDataQuery = useCollateralShortContractInfoQuery();
@@ -183,16 +177,6 @@ const ManageShortAction: FC<ManageShortActionProps> = ({
 		}
 		return { method, params, onSuccess };
 	}, [inputAmountBN, short.id, tab, walletAddress, redirectToShortingHome, isL2]);
-
-	const gasPrice = useMemo(
-		() =>
-			customGasPrice !== ''
-				? Number(customGasPrice)
-				: ethGasPriceQuery.data != null
-				? parseGasPriceObject(ethGasPriceQuery.data[gasSpeed])
-				: null,
-		[customGasPrice, ethGasPriceQuery.data, gasSpeed]
-	);
 
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
 

--- a/sections/shorting/ShortingRewards/ShortingRewards.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewards.tsx
@@ -25,18 +25,12 @@ const ShortingRewards: FC = () => {
 	const isL2 = useRecoilValue(isL2State);
 
 	const [gasInfo, setGasInfo] = useState<GasInfo | null>(null);
+	const { gasPrice, gasPrices } = useGas();
 
-	const { gasPrice } = useGas();
-	const { useEthGasPriceQuery, useExchangeRatesQuery } = useSynthetixQueries();
+	const { useExchangeRatesQuery } = useSynthetixQueries();
 
-	const ethGasPriceQuery = useEthGasPriceQuery();
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const exchangeRatesQuery = useExchangeRatesQuery();
-
-	const gasPrices = useMemo(
-		() => (ethGasPriceQuery.isSuccess ? ethGasPriceQuery?.data ?? undefined : undefined),
-		[ethGasPriceQuery.isSuccess, ethGasPriceQuery.data]
-	);
 
 	const exchangeRates = useMemo(
 		() => (exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null),

--- a/sections/shorting/ShortingRewards/ShortingRewards.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewards.tsx
@@ -1,9 +1,9 @@
 import { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import { gasSpeedState, isL2State } from 'store/wallet';
+import { isL2State } from 'store/wallet';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
 import { CRYPTO_CURRENCY_MAP, Synths } from 'constants/currency';
@@ -18,7 +18,7 @@ import GasPriceSummaryItem from 'sections/exchange/FooterCard/TradeSummaryCard/G
 
 import { Title } from '../common';
 import useSynthetixQueries from '@synthetixio/queries';
-import { parseGasPriceObject } from 'hooks/useGas';
+import useGas from 'hooks/useGas';
 
 const ShortingRewards: FC = () => {
 	const { t } = useTranslation();
@@ -26,8 +26,7 @@ const ShortingRewards: FC = () => {
 
 	const [gasInfo, setGasInfo] = useState<GasInfo | null>(null);
 
-	const [gasSpeed] = useRecoilState(gasSpeedState);
-
+	const { gasPrice } = useGas();
 	const { useEthGasPriceQuery, useExchangeRatesQuery } = useSynthetixQueries();
 
 	const ethGasPriceQuery = useEthGasPriceQuery();
@@ -37,16 +36,6 @@ const ShortingRewards: FC = () => {
 	const gasPrices = useMemo(
 		() => (ethGasPriceQuery.isSuccess ? ethGasPriceQuery?.data ?? undefined : undefined),
 		[ethGasPriceQuery.isSuccess, ethGasPriceQuery.data]
-	);
-
-	const gasPrice = useMemo(
-		() =>
-			ethGasPriceQuery.isSuccess
-				? ethGasPriceQuery?.data != null
-					? parseGasPriceObject(ethGasPriceQuery.data[gasSpeed])
-					: null
-				: null,
-		[ethGasPriceQuery.isSuccess, ethGasPriceQuery.data, gasSpeed]
 	);
 
 	const exchangeRates = useMemo(

--- a/sections/shorting/hooks/useShort.tsx
+++ b/sections/shorting/hooks/useShort.tsx
@@ -34,7 +34,7 @@ import { getExchangeRatesForCurrencies, synthToContractName } from 'utils/curren
 import useMarketClosed from 'hooks/useMarketClosed';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
-import { getTransactionPrice, normalizeGasLimit, gasPriceInWei } from 'utils/network';
+import { getTransactionPrice, normalizeGasLimit } from 'utils/network';
 
 import { zeroBN, formatNumber } from 'utils/formatters/number';
 
@@ -72,11 +72,7 @@ const useShort = ({
 		defaultQuoteCurrencyKey,
 	});
 
-	const {
-		useEthGasPriceQuery,
-		useSynthsBalancesQuery,
-		useExchangeRatesQuery,
-	} = useSynthetixQueries();
+	const { useSynthsBalancesQuery, useExchangeRatesQuery } = useSynthetixQueries();
 
 	const { base: baseCurrencyKey, quote: quoteCurrencyKey } = currencyPair;
 
@@ -93,7 +89,7 @@ const useShort = ({
 	const [txApproveModalOpen, setTxApproveModalOpen] = useState<boolean>(false);
 	const [selectShortCurrencyModalOpen, setSelectShortCurrencyModalOpen] = useState<boolean>(false);
 	const [txError, setTxError] = useState<string | null>(null);
-	const { gasPrice, gasPriceWei, getGasLimitEstimate } = useGas();
+	const { gasPrice, gasPriceWei, gasPrices } = useGas();
 	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
 	const selectedShortCRatio = useRecoilValue(shortCRatioState);
 	const customShortCRatio = useRecoilValue(customShortCRatioState);
@@ -108,7 +104,6 @@ const useShort = ({
 	const [gasInfo, setGasInfo] = useState<GasInfo | null>(null);
 
 	const synthsWalletBalancesQuery = useSynthsBalancesQuery(walletAddress);
-	const ethGasPriceQuery = useEthGasPriceQuery();
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const collateralShortContractInfoQuery = useCollateralShortContractInfoQuery();
 	const collateralShortRateQuery = useCollateralShortRate(baseCurrencyKey);
@@ -363,7 +358,6 @@ const useShort = ({
 
 				const collateralContract = contracts[synthToContractName(quoteCurrencyKey)];
 
-				const gasPriceWei = gasPriceInWei(gasPrice);
 				const gasEstimate = !isL2
 					? await collateralContract.estimateGas.approve(
 							contracts.CollateralShort.address,
@@ -443,8 +437,6 @@ const useShort = ({
 				setIsSubmitting(true);
 
 				let tx: ethers.ContractTransaction | null = null;
-
-				const gasPriceWei = gasPriceInWei(gasPrice);
 
 				const gasEstimate = await getGasEstimateForShort();
 
@@ -568,7 +560,7 @@ const useShort = ({
 					baseCurrencyAmount={baseCurrencyAmount}
 					basePriceRate={basePriceRate}
 					baseCurrency={baseCurrency || null}
-					gasPrices={ethGasPriceQuery.data}
+					gasPrices={gasPrices}
 					feeReclaimPeriodInSeconds={0}
 					quoteCurrencyKey={quoteCurrencyKey}
 					totalFeeRate={issueFeeRate ?? null}

--- a/translations/en.json
+++ b/translations/en.json
@@ -215,6 +215,7 @@
 		},
 		"summary-info": {
 			"gas-price-gwei": "gas price (GWEI)",
+			"max-fee-gwei": "Max Fee  (GWEI)",
 			"fee": "fee",
 			"fee-cost": "fee cost",
 			"button": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -215,7 +215,7 @@
 		},
 		"summary-info": {
 			"gas-price-gwei": "gas price (GWEI)",
-			"max-fee-gwei": "Max Fee  (GWEI)",
+			"max-fee-gwei": "Max Fee (GWEI)",
 			"fee": "fee",
 			"fee-cost": "fee cost",
 			"button": {


### PR DESCRIPTION
## Description
In order to support eip 1559 transactions on mainnet, the gas configuration should take in an object that includes the following:

```
{
    maxPriorityFeePerGas,
    maxFeePerGas
}
```

on all other networks (ie optimism) the gas object should take the following configuration:

```
{
    gasPrice
}
```

by adding this functionality to the `useGas` hook, the transactions that get queued in the app should be able to support both 1559 and non 1559 transactions. Keep in mind that users can set their own `customGasPrice` in the app.

## Related issue
https://github.com/Kwenta/kwenta/issues/361

## Motivation and Context

refactoring gas logic into a `useGas` hook and setting up kwenta transactions to support EIP-1559.

I have created an object that can be used for gas configurations called `gasConfig`. you can see this being swapped in the transactions across these Kwenta components:

- [ManageShort](https://github.com/Kwenta/kwenta/pull/377/files#diff-eb24848c2ea707e624eaa2197451034fd73182e74674eef499cf6dabcf60f09bR369)
- [useExchange#1](https://github.com/Kwenta/kwenta/pull/377/files#diff-775118eccd3373aaed2a2ec3d37976b257a4fea20f41dc649d70b962b253674dR674)
- [useExchange#2](https://github.com/Kwenta/kwenta/pull/377/files#diff-775118eccd3373aaed2a2ec3d37976b257a4fea20f41dc649d70b962b253674dR723)
- [ManageShortAction](https://github.com/Kwenta/kwenta/pull/377/files#diff-eb24848c2ea707e624eaa2197451034fd73182e74674eef499cf6dabcf60f09bR369)

the main changes for this pr are in the `useGas` hook [here](https://github.com/Kwenta/kwenta/pull/377/files#diff-9b34fa921e4ee318e5ee18c3c3da462935b3f3a00188ce46bc41c66f5585d60aR31-R61). I refactored all the consistent gas related items into the following object for useGas:

```
const useGas = () => {
  ...
  return {
    gasPrice,
    gasPriceWei,
    getGasLimitEstimate,
    maxFeePerGas,
    maxPriorityFeePerGas,
    gasPrices,
    gasSpeed,
    setGasSpeed,
    isCustomGasPrice,
    customGasPrice,
    setCustomGasPrice,
    gasConfig,
  }
}
```

## How Has This Been Tested?

** I repeated the same process described below on `dev` and this branch.

- on mainnet:
1) visit the exchange
2) select two currencies to exchange and input a value
3) select `Submit Order`
4) inspected the transaction to make sure a relatively appropriate `Max Base Fee` and `Max Priority Fee` are set

## Screenshots (if appropriate):

### BEFORE changes on `dev` branch(mainnet):

![Screen Shot 2022-03-02 at 8 38 43 AM](https://user-images.githubusercontent.com/5998100/156395039-72e8311b-8cb1-40ae-ba66-b262eced24c0.png)
![Screen Shot 2022-03-02 at 8 38 59 AM](https://user-images.githubusercontent.com/5998100/156395046-11bd1751-5a00-4b55-a424-19af1a1b2e52.png)

### AFTER changes on this branch(mainnet):

![Screen Shot 2022-03-02 at 8 40 47 AM](https://user-images.githubusercontent.com/5998100/156395444-4fdfe187-f8fb-4908-bdd9-8b9ea7d17b10.png)
![Screen Shot 2022-03-02 at 8 40 57 AM](https://user-images.githubusercontent.com/5998100/156395450-babc9a2e-c9d7-43f0-a2ac-9dc9f50b412c.png)

### BEFORE changes on `dev` branch(optimism):

![Screen Shot 2022-03-02 at 8 37 07 AM](https://user-images.githubusercontent.com/5998100/156395678-2368d7e5-10ae-4ad0-8c32-0049b248b45f.png)

### AFTER changes on this branch(optimism):
![Screen Shot 2022-03-02 at 8 43 43 AM](https://user-images.githubusercontent.com/5998100/156395975-f7766938-caee-4032-924e-97efb3057024.png)
![Screen Shot 2022-03-02 at 8 43 51 AM](https://user-images.githubusercontent.com/5998100/156395980-c3a576af-d70d-4bd6-b278-037cb54bc5c9.png)
