### PR TITLE
Fix sSOL chart on L2

### DIFF
--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -32,83 +32,91 @@ const splitBaseQuote = (symbolName: string) => {
 	return { base, quote };
 };
 
-const fetchCombinedCandleSticks = async (base: string, quote: string, from: number, to: number) => {
+const fetchCombinedCandleSticks = async (
+	base: string,
+	quote: string,
+	from: number,
+	to: number,
+	isL2: boolean
+) => {
 	const baseCurrencyIsSUSD = base === Synths.sUSD;
 	const quoteCurrencyIsSUSD = quote === Synths.sUSD;
-	const baseData = await requestCandlesticks(base, from, to);
-	const quoteData = await requestCandlesticks(quote, from, to);
+	const baseData = await requestCandlesticks(base, from, to, isL2);
+	const quoteData = await requestCandlesticks(quote, from, to, isL2);
 	return combineDataToPair(baseData, quoteData, baseCurrencyIsSUSD, quoteCurrencyIsSUSD);
 };
 
-const DataFeed: IBasicDataFeed = {
-	onReady: (cb: OnReadyCallback) => {
-		setTimeout(() => cb(config), 0);
-	},
-	resolveSymbol: (symbolName: string, onSymbolResolvedCallback: (val: any) => any) => {
-		const { base, quote } = splitBaseQuote(symbolName);
+const DataFeedFactory = (isL2: boolean = false): IBasicDataFeed => {
+	return {
+		onReady: (cb: OnReadyCallback) => {
+			setTimeout(() => cb(config), 0);
+		},
+		resolveSymbol: (symbolName: string, onSymbolResolvedCallback: (val: any) => any) => {
+			const { base, quote } = splitBaseQuote(symbolName);
 
-		var symbol_stub = {
-			name: symbolName,
-			description: base + ' / ' + quote,
-			type: 'crypto',
-			session: '24x7',
-			timezone: 'Etc/UTC',
-			ticker: symbolName,
-			exchange: '',
-			minmov: 1,
-			pricescale: 10000,
-			has_intraday: true,
-			intraday_multipliers: ['1', '60'],
-			supported_resolution: supportedResolutions,
-			volume_precision: 8,
-			data_status: 'streaming',
-		};
+			var symbol_stub = {
+				name: symbolName,
+				description: base + ' / ' + quote,
+				type: 'crypto',
+				session: '24x7',
+				timezone: 'Etc/UTC',
+				ticker: symbolName,
+				exchange: '',
+				minmov: 1,
+				pricescale: 10000,
+				has_intraday: true,
+				intraday_multipliers: ['1', '60'],
+				supported_resolution: supportedResolutions,
+				volume_precision: 8,
+				data_status: 'streaming',
+			};
 
-		setTimeout(function () {
-			onSymbolResolvedCallback(symbol_stub);
-		}, 0);
-	},
-	getBars: function (
-		symbolInfo: LibrarySymbolInfo,
-		_resolution: ResolutionString,
-		{ from, to, countBack }: PeriodParams,
-		onHistoryCallback: HistoryCallback,
-		onErrorCallback: (error: any) => any
-	) {
-		const { base, quote } = splitBaseQuote(symbolInfo.name);
+			setTimeout(function () {
+				onSymbolResolvedCallback(symbol_stub);
+			}, 0);
+		},
+		getBars: function (
+			symbolInfo: LibrarySymbolInfo,
+			_resolution: ResolutionString,
+			{ from, to, countBack }: PeriodParams,
+			onHistoryCallback: HistoryCallback,
+			onErrorCallback: (error: any) => any
+		) {
+			const { base, quote } = splitBaseQuote(symbolInfo.name);
 
-		try {
-			fetchCombinedCandleSticks(base, quote, from, to).then((bars) => {
-				const chartBars = bars.map((b) => {
-					return {
-						...b,
-						high: formatWei(b.high),
-						low: formatWei(b.low),
-						open: formatWei(b.open),
-						close: formatWei(b.close),
-						time: Number(b.timestamp) * 1000,
-					};
+			try {
+				fetchCombinedCandleSticks(base, quote, from, to, isL2).then((bars) => {
+					const chartBars = bars.map((b) => {
+						return {
+							...b,
+							high: formatWei(b.high),
+							low: formatWei(b.low),
+							open: formatWei(b.open),
+							close: formatWei(b.close),
+							time: Number(b.timestamp) * 1000,
+						};
+					});
+					onHistoryCallback(chartBars, { noData: !chartBars.length });
 				});
-				onHistoryCallback(chartBars, { noData: chartBars.length ? false : true });
-			});
-		} catch (err) {
-			onErrorCallback(err);
-		}
-	},
-	subscribeBars: () => {
-		console.log('=====subscribeBars runnning');
-	},
-	unsubscribeBars: (subscriberUID) => {
-		console.log('=====unsubscribeBars running');
-	},
-	searchSymbols: (
-		userInput: string,
-		exchange: string,
-		symbolType: string,
-		onResult: SearchSymbolsCallback
-	) => {
-		onResult([]);
-	},
+			} catch (err) {
+				onErrorCallback(err);
+			}
+		},
+		subscribeBars: () => {
+			console.log('=====subscribeBars runnning');
+		},
+		unsubscribeBars: (subscriberUID) => {
+			console.log('=====unsubscribeBars running');
+		},
+		searchSymbols: (
+			userInput: string,
+			exchange: string,
+			symbolType: string,
+			onResult: SearchSymbolsCallback
+		) => {
+			onResult([]);
+		},
+	};
 };
 
-export default DataFeed;
+export default DataFeedFactory;

--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -7,7 +7,9 @@ import {
 	IChartingLibraryWidget,
 	widget,
 } from '../../public/static/charting_library/charting_library';
-import DataFeed from './DataFeed';
+import DataFeedFactory from './DataFeed';
+import { useRecoilValue } from 'recoil';
+import { isL2State } from 'store/wallet';
 
 type Props = {
 	baseCurrencyKey: string;
@@ -36,11 +38,12 @@ export function TVChart({
 	},
 }: Props) {
 	const _widget = React.useRef<IChartingLibraryWidget | null>(null);
+	let isL2 = useRecoilValue(isL2State);
 
 	React.useEffect(() => {
 		const widgetOptions = {
 			symbol: baseCurrencyKey + ':' + quoteCurrencyKey,
-			datafeed: DataFeed,
+			datafeed: DataFeedFactory(isL2),
 			interval: interval,
 			container_id: containerId,
 			library_path: libraryPath,

--- a/queries/rates/useCandlesticksQuery.ts
+++ b/queries/rates/useCandlesticksQuery.ts
@@ -1,15 +1,17 @@
 import request, { gql } from 'graphql-request';
 import { Candle } from './types';
 
-const RATES_ENDPOINT =
-	'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix-exchanges';
-
 export const requestCandlesticks = async (
 	currencyKey: string | null,
 	minTimestamp: number,
 	maxTimestamp = Math.floor(Date.now() / 1000),
+	isL2 = false,
 	resolution = 'daily'
 ) => {
+	const RATES_ENDPOINT = isL2
+		? 'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main'
+		: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/mainnet-main';
+
 	const response = (await request(
 		RATES_ENDPOINT,
 		gql`


### PR DESCRIPTION
This PR fixes #357 to show sSOL chart on L2. I've added an argument to data fetching function to switch the API endpoint regarding the network layer.