### PR TITLE
Update @synthetixio package links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ENS link: [kwenta.eth](https://app.ens.domains/name/kwenta.eth).
 
 - ethers.js v5 - Ethereum wallet implementation.
 - Blocknative Onboard - for ethereum wallet connectivity.
-- [@synthetixio/contracts-interface](https://github.com/Synthetixio/js-monorepo) - for interactions with the Synthetix protocol.
+- [@synthetixio/contracts-interface](https://github.com/Synthetixio/js-monorepo/tree/master/packages/contracts-interface) - for interactions with the Synthetix protocol.
 - [@synthetixio/queries](https://github.com/Synthetixio/js-monorepo/tree/master/packages/queries) - for historical data (powered by [TheGraph](https://thegraph.com/))
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ENS link: [kwenta.eth](https://app.ens.domains/name/kwenta.eth).
 - ethers.js v5 - Ethereum wallet implementation.
 - Blocknative Onboard - for ethereum wallet connectivity.
 - [@synthetixio/contracts-interface](https://github.com/Synthetixio/js-monorepo) - for interactions with the Synthetix protocol.
-- [@synthetixio/data](https://github.com/Synthetixio/js-monorepo/tree/master/packages/data) - for historical data (powered by [TheGraph](https://thegraph.com/))
+- [@synthetixio/queries](https://github.com/Synthetixio/js-monorepo/tree/master/packages/queries) - for historical data (powered by [TheGraph](https://thegraph.com/))
 
 ## Development
 


### PR DESCRIPTION
## Description
- I updated the [@synthetixio/contracts-interface](https://github.com/Synthetixio/js-monorepo) link to point to the [contracts-interface](https://github.com/Synthetixio/js-monorepo/tree/master/packages/contracts-interface) page.
- I also updated the [@synthetixio/data](https://github.com/Synthetixio/js-monorepo/tree/master/packages/data) broken link to point to [@synthetixio/queries](https://github.com/Synthetixio/js-monorepo/blob/master/packages/queries), however I'm not 100% sure about this last change. Can someone confirm that the @synthetixio/data packaged has been renamed to @synthetixio/queries ?

## Related issue
#393 

## Motivation and Context
It's cool to have access to updated links when you want to know a little more about the project :)
