### PR TITLE
Add support for Optimism Infura API (wallet connect)

### DIFF
--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -1,11 +1,11 @@
-import { NetworkIdByName, NetworkNameById } from '@synthetixio/contracts-interface';
+import { NetworkIdByName } from '@synthetixio/contracts-interface';
 import onboard from 'bnc-onboard';
 import { Subscriptions } from 'bnc-onboard/dist/src/interfaces';
 import { getInfuraRpcURL } from 'utils/infura';
 import { Network } from 'store/wallet';
 
 export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
-	const infuraRpc = getInfuraRpcURL(network);
+	const infuraRpc = getInfuraRpcURL(network.id);
 
 	return onboard({
 		dappId: process.env.NEXT_PUBLIC_BN_ONBOARD_API_KEY,
@@ -51,15 +51,10 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 				},
 				{
 					walletName: 'walletConnect',
-					rpc: {
-						'1': getInfuraRpcURL({ id: NetworkIdByName.mainnet, name: NetworkNameById[1] }),
-						'10': getInfuraRpcURL({
-							id: NetworkIdByName['mainnet-ovm'],
-							name: NetworkNameById[10],
-						}),
-						'42': getInfuraRpcURL({ id: NetworkIdByName.kovan, name: NetworkNameById[42] }),
-						'69': getInfuraRpcURL({ id: NetworkIdByName['kovan-ovm'], name: NetworkNameById[69] }),
-					},
+					rpc: Object.values(NetworkIdByName).reduce((acc, id) => {
+						acc[id] = getInfuraRpcURL(id);
+						return acc;
+					}, {} as Record<string, string>),
 					preferred: true,
 				},
 				{ walletName: 'imToken', rpcUrl: infuraRpc, preferred: true },

--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -1,7 +1,7 @@
+import { NetworkIdByName, NetworkNameById } from '@synthetixio/contracts-interface';
 import onboard from 'bnc-onboard';
 import { Subscriptions } from 'bnc-onboard/dist/src/interfaces';
 import { getInfuraRpcURL } from 'utils/infura';
-
 import { Network } from 'store/wallet';
 
 export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
@@ -51,7 +51,15 @@ export const initOnboard = (network: Network, subscriptions: Subscriptions) => {
 				},
 				{
 					walletName: 'walletConnect',
-					rpc: { [network.id]: infuraRpc },
+					rpc: {
+						'1': getInfuraRpcURL({ id: NetworkIdByName.mainnet, name: NetworkNameById[1] }),
+						'10': getInfuraRpcURL({
+							id: NetworkIdByName['mainnet-ovm'],
+							name: NetworkNameById[10],
+						}),
+						'42': getInfuraRpcURL({ id: NetworkIdByName.kovan, name: NetworkNameById[42] }),
+						'69': getInfuraRpcURL({ id: NetworkIdByName['kovan-ovm'], name: NetworkNameById[69] }),
+					},
 					preferred: true,
 				},
 				{ walletName: 'imToken', rpcUrl: infuraRpc, preferred: true },

--- a/utils/infura.ts
+++ b/utils/infura.ts
@@ -1,6 +1,19 @@
+import { NetworkId } from '@synthetixio/contracts-interface';
 import { Network } from 'store/wallet';
 
 export const GWEI_UNIT = 1000000000;
 
-export const getInfuraRpcURL = (network: Network) =>
-	`https://${network.name}.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_PROJECT_ID}`;
+export const INFURA_SUPPORTED_NETWORKS: Record<NetworkId, string> = {
+	1: 'mainnet',
+	5: 'goerli',
+	10: 'optimism-mainnet',
+	42: 'kovan',
+	69: 'optimism-kovan',
+	31337: 'mainnet-fork',
+};
+
+export const getInfuraRpcURL = (network: Network) => {
+	return `https://${INFURA_SUPPORTED_NETWORKS[network.id]}.infura.io/v3/${
+		process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
+	}`;
+};

--- a/utils/infura.ts
+++ b/utils/infura.ts
@@ -1,5 +1,4 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
-import { Network } from 'store/wallet';
 
 export const GWEI_UNIT = 1000000000;
 
@@ -12,8 +11,6 @@ export const INFURA_SUPPORTED_NETWORKS: Record<NetworkId, string> = {
 	31337: 'mainnet-fork',
 };
 
-export const getInfuraRpcURL = (network: Network) => {
-	return `https://${INFURA_SUPPORTED_NETWORKS[network.id]}.infura.io/v3/${
-		process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
-	}`;
+export const getInfuraRpcURL = (networkId: NetworkId) => {
+	return `https://${INFURA_SUPPORTED_NETWORKS[networkId]}.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_PROJECT_ID}`;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wallet Connect doesn't work with Optimism because the Infura endpoints of Optimism (both mainnet and kovan) are incorrect.

## Related issue
#344 

## Motivation and Context
Wallet Connect is a popular choice so the fix will help onboard new users.

## How Has This Been Tested?
1. Visit Kwenta (local dev)
2. Connect using Wallet Connect
3. Scan the QR code by [TokenPocket](https://www.tokenpocket.pro/en/). The wallet is connected to the right network and shows the correct balance of synths.
The results have been verified from mainnet, kovan, optimism, and optimism-kovan.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/158079186-45d1c70d-6352-45e7-ac84-9eab8930d448.png)
