### PR TITLE
Add TradingView chart to futures screen

### DIFF
--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import styled from 'styled-components';
+import styled, { ThemeContext } from 'styled-components';
 import { ChartBody } from 'sections/exchange/TradeCard/Charts/common/styles';
-import colors from 'styles/theme/colors';
 
 import {
 	IChartingLibraryWidget,
@@ -30,12 +29,10 @@ export function TVChart({
 	fullscreen = false,
 	autosize = true,
 	studiesOverrides = {},
-	overrides = {
-		'paneProperties.background': colors.elderberry,
-		'paneProperties.backgroundType': 'solid',
-	},
+	overrides,
 }: Props) {
 	const _widget = React.useRef<IChartingLibraryWidget | null>(null);
+	const { colors } = React.useContext(ThemeContext);
 
 	React.useEffect(() => {
 		const widgetOptions = {
@@ -54,9 +51,13 @@ export function TVChart({
 			theme: 'dark',
 			custom_css_url: './theme.css',
 			loading_screen: {
-				backgroundColor: colors.vampire,
+				backgroundColor: colors.selectedTheme.background,
 			},
-			overrides: overrides,
+			overrides: overrides ?? {
+				'paneProperties.background': colors.selectedTheme.background,
+				'paneProperties.backgroundType': 'solid',
+			},
+			toolbar_bg: colors.selectedTheme.background,
 			time_frames: [
 				{ text: '3y', resolution: '1W', description: '3 Years' },
 				{ text: '1y', resolution: '1D', description: '1 Year' },
@@ -83,6 +84,7 @@ export function TVChart({
 			clearExistingWidget();
 		};
 	}, [baseCurrencyKey, quoteCurrencyKey]);
+
 	return (
 		<Container>
 			<ChartBody id={containerId} />
@@ -92,6 +94,6 @@ export function TVChart({
 
 const Container = styled.div`
 	border-radius: 4px;
-	background: ${colors.elderberry};
+	background: ${(props) => props.theme.colors.selectedTheme.background};
 	padding: 4px;
 `;

--- a/public/static/charting_library/theme.css
+++ b/public/static/charting_library/theme.css
@@ -15,17 +15,17 @@
 }
 
 .theme-dark:root {
-    --tv-color-platform-background: #10101E;
-    --tv-color-pane-background: #10101E;
+    --tv-color-platform-background: #131212;
+    --tv-color-pane-background: #131212;
     --tv-color-pane-background-secondary: #08080F;
-    --tv-color-toolbar-button-background-hover: #2F2F48;
-    --tv-color-toolbar-button-background-secondary-hover: #2F2F48;
-    --tv-color-toolbar-button-background-expanded: #9F9EC5;
-    --tv-color-toolbar-button-text: #9F9EC5;
-    --tv-color-toolbar-button-text-hover: #9F9EC5;
-    --tv-color-toolbar-button-text-active: #9F9EC5;
-    --tv-color-toolbar-button-text-active-hover: #9F9EC5;
-    --tv-color-item-active-text: #9F9EC5;
+    --tv-color-toolbar-button-background-hover: #3A3A3A;
+    --tv-color-toolbar-button-background-secondary-hover: #3A3A3A;
+    --tv-color-toolbar-button-background-expanded: #787878;
+    --tv-color-toolbar-button-text: #787878;
+    --tv-color-toolbar-button-text-hover: #787878;
+    --tv-color-toolbar-button-text-active: #787878;
+    --tv-color-toolbar-button-text-active-hover: #787878;
+    --tv-color-item-active-text: #787878;
     --tv-color-toolbar-toggle-button-background-active: #2F2F48;
-    --tv-color-toolbar-toggle-button-background-active-hover: #9F9EC5;
+    --tv-color-toolbar-toggle-button-background-active-hover: #787878;
 }

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -1,8 +1,7 @@
-import { FC, useMemo, useContext } from 'react';
+import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Head from 'next/head';
 import useSynthetixQueries from '@synthetixio/queries';
-import { ThemeContext } from 'styled-components';
 
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
@@ -27,8 +26,6 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const baseCurrencyKey = market as CurrencyKey;
 
-	const { colors } = useContext(ThemeContext);
-
 	const basePriceRate = useMemo(
 		() => getExchangeRatesForCurrencies(exchangeRates, baseCurrencyKey, selectedPriceCurrency.name),
 		[exchangeRates, baseCurrencyKey, selectedPriceCurrency]
@@ -49,14 +46,7 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 				</title>
 			</Head>
 			<MarketDetails baseCurrencyKey={baseCurrencyKey} />
-			<TVChart
-				baseCurrencyKey={baseCurrencyKey}
-				quoteCurrencyKey={Synths.sUSD}
-				overrides={{
-					'paneProperties.background': colors.selectedTheme.background,
-					'paneProperties.backgroundType': 'solid',
-				}}
-			/>
+			<TVChart baseCurrencyKey={baseCurrencyKey} quoteCurrencyKey={Synths.sUSD} />
 			<UserInfo marketAsset={baseCurrencyKey} />
 		</>
 	);

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -1,22 +1,18 @@
-import { FC, useMemo } from 'react';
+import { FC, useMemo, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import Head from 'next/head';
 import useSynthetixQueries from '@synthetixio/queries';
+import { ThemeContext } from 'styled-components';
 
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
 import { formatCurrency } from 'utils/formatters/number';
 
-import PriceChartCard from 'sections/exchange/TradeCard/Charts/PriceChartCard';
-
 import UserInfo from '../UserInfo';
-import { ChartType } from 'constants/chartType';
-import { Period } from 'constants/period';
-import { singleChartTypeState, singleChartPeriodState } from 'store/app';
-import usePersistedRecoilState from 'hooks/usePersistedRecoilState';
-import { CurrencyKey } from 'constants/currency';
+import { CurrencyKey, Synths } from 'constants/currency';
 import MarketDetails from '../MarketDetails';
+import TVChart from 'components/TVChart';
 
 type MarketInfoProps = {
 	market: string;
@@ -31,8 +27,7 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const baseCurrencyKey = market as CurrencyKey;
 
-	const [chartType, setChartType] = usePersistedRecoilState<ChartType>(singleChartTypeState);
-	const [chartPeriod, setChartPeriod] = usePersistedRecoilState<Period>(singleChartPeriodState);
+	const { colors } = useContext(ThemeContext);
 
 	const basePriceRate = useMemo(
 		() => getExchangeRatesForCurrencies(exchangeRates, baseCurrencyKey, selectedPriceCurrency.name),
@@ -54,14 +49,13 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 				</title>
 			</Head>
 			<MarketDetails baseCurrencyKey={baseCurrencyKey} />
-			<PriceChartCard
-				side="base"
-				currencyKey={baseCurrencyKey}
-				priceRate={basePriceRate}
-				selectedChartType={chartType}
-				setSelectedChartType={setChartType}
-				selectedChartPeriod={chartPeriod}
-				setSelectedChartPeriod={setChartPeriod}
+			<TVChart
+				baseCurrencyKey={baseCurrencyKey}
+				quoteCurrencyKey={Synths.sUSD}
+				overrides={{
+					'paneProperties.background': colors.selectedTheme.background,
+					'paneProperties.backgroundType': 'solid',
+				}}
 			/>
 			<UserInfo marketAsset={baseCurrencyKey} />
 		</>


### PR DESCRIPTION
## Description
This PR replaces the custom chart on the futures screen with TradingView one. It also adjusts some of the color settings on the chart to better match the current designs.

Please note, this PR does not include the following as initially expected:
- Chart fonts matching site font.
- Color changes responsive to current theme.

These will be added in a separate PR in the future, because they require quite a bit more work to get going, and are generally not hard requirements for the futures soft launch.

## Related issue
N/A

## Motivation and Context
This is part of the Kwenta v2 soft launch.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15985212/158816204-1ac60de0-5ca2-4f8a-a182-99d035c2c042.png">