### PR TITLE
Margin Data Fixes

### DIFF
--- a/components/BaseModal/BaseModal.tsx
+++ b/components/BaseModal/BaseModal.tsx
@@ -94,7 +94,7 @@ const DismissButton = styled.button`
 	${resetButtonCSS};
 	position: absolute;
 	right: 20px;
-	color: ${(props) => props.theme.colors.blueberry};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 	&:hover {
 		color: ${(props) => props.theme.colors.white};
 	}

--- a/sections/futures/MarketInfoBox/MarketInfoBox.tsx
+++ b/sections/futures/MarketInfoBox/MarketInfoBox.tsx
@@ -6,6 +6,7 @@ import { formatCurrency, formatNumber, formatPercent } from 'utils/formatters/nu
 import { Synths } from '@synthetixio/contracts-interface';
 
 type MarketInfoBoxProps = {
+	totalMargin: Wei;
 	availableMargin: Wei;
 	buyingPower: Wei;
 	marginUsage: Wei;
@@ -14,6 +15,7 @@ type MarketInfoBoxProps = {
 };
 
 const MarketInfoBox: React.FC<MarketInfoBoxProps> = ({
+	totalMargin,
 	availableMargin,
 	buyingPower,
 	marginUsage,
@@ -23,6 +25,7 @@ const MarketInfoBox: React.FC<MarketInfoBoxProps> = ({
 	return (
 		<StyledInfoBox
 			details={{
+				'Total Margin': `${formatCurrency(Synths.sUSD, totalMargin, { sign: '$' })}`,
 				'Available Margin': `${formatCurrency(Synths.sUSD, availableMargin, { sign: '$' })}`,
 				'Buying Power': `${formatCurrency(Synths.sUSD, buyingPower, { sign: '$' })}`,
 				'Margin Usage': `${formatPercent(marginUsage)}`,

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -139,11 +139,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 				details={{
 					'Gas Fee': transactionFee
 						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
-						: NO_VALUE,
-					Total: formatCurrency(Synths.sUSD, zeroBN?.add(transactionFee ?? 0) ?? zeroBN, {
-						sign: '$',
-						minDecimals: zeroBN.lt(0.01) ? 4 : 2,
-					}),
+						: NO_VALUE
 				}}
 			/>
 			<DepositMarginButton fullWidth onClick={handleDeposit}>

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -39,7 +39,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { useEthGasPriceQuery, useExchangeRatesQuery } = useSynthetixQueries();
-	const [amount, setAmount] = React.useState<string>('');
+	const [amount, setAmount] = React.useState<string>('0');
 	const [error, setError] = React.useState<string | null>(null);
 	const [gasLimit, setGasLimit] = React.useState<number | null>(null);
 
@@ -76,8 +76,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 			if (!market || !synthetixjs) return;
 			try {
 				setError(null);
-				setGasLimit(null);
-				if (!amount || Number(amount) === 0) return;
+				if (!amount) return;
 				const FuturesMarketContract = getFuturesMarketContract(market, synthetixjs!.contracts);
 				const marginAmount = wei(amount).toBN();
 				const estimate = await FuturesMarketContract.estimateGas.transferMargin(
@@ -141,7 +140,6 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 					'Gas Fee': transactionFee
 						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
 						: NO_VALUE,
-					Fee: '',
 					Total: formatCurrency(Synths.sUSD, zeroBN?.add(transactionFee ?? 0) ?? zeroBN, {
 						sign: '$',
 						minDecimals: zeroBN.lt(0.01) ? 4 : 2,

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -270,15 +270,22 @@ const Trade: React.FC<TradeProps> = () => {
 			</MarketActions>
 
 			<MarketInfoBox
-				availableMargin={futuresMarketsPosition?.remainingMargin ?? zeroBN}
-				buyingPower={sUSDBalance}
+				totalMargin={futuresMarketsPosition?.remainingMargin ?? zeroBN}
+				availableMargin={futuresMarketsPosition?.accessibleMargin ?? zeroBN}
+				buyingPower={
+					futuresMarketsPosition && futuresMarketsPosition?.remainingMargin.gt(zeroBN) ?
+						futuresMarketsPosition?.remainingMargin.mul(
+							market?.maxLeverage
+						)
+						: zeroBN
+				}
 				marginUsage={
-					futuresMarketsPosition?.position?.size?.gt(zeroBN)
-						? (futuresMarketsPosition?.position?.size).div(
-								(futuresMarketsPosition?.position?.size).add(
-									futuresMarketsPosition?.remainingMargin ?? zeroBN
-								)
-						  )
+					futuresMarketsPosition && futuresMarketsPosition?.remainingMargin.gt(zeroBN) ?
+						futuresMarketsPosition?.remainingMargin.sub(
+							futuresMarketsPosition?.accessibleMargin
+						).div(
+							futuresMarketsPosition?.remainingMargin
+						)
 						: zeroBN
 				}
 				liquidationPrice={futuresMarketsPosition?.position?.liquidationPrice ?? zeroBN}

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -274,14 +274,14 @@ const Trade: React.FC<TradeProps> = () => {
 				availableMargin={futuresMarketsPosition?.accessibleMargin ?? zeroBN}
 				buyingPower={
 					futuresMarketsPosition && futuresMarketsPosition?.remainingMargin.gt(zeroBN) ?
-						futuresMarketsPosition?.remainingMargin.mul(
+						futuresMarketsPosition?.remainingMargin?.mul(
 							market?.maxLeverage
 						)
 						: zeroBN
 				}
 				marginUsage={
 					futuresMarketsPosition && futuresMarketsPosition?.remainingMargin.gt(zeroBN) ?
-						futuresMarketsPosition?.remainingMargin.sub(
+						futuresMarketsPosition?.remainingMargin?.sub(
 							futuresMarketsPosition?.accessibleMargin
 						).div(
 							futuresMarketsPosition?.remainingMargin

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -149,7 +149,6 @@ const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
 		onConfirmOrder();
 		onDismiss();
 	};
-	console.log(synthsMap)
 
 	return (
 		<StyledBaseModal
@@ -209,8 +208,8 @@ const StyledGasPriceSelect = styled(GasPriceSelect)`
 	display: flex;
 	justify-content: space-between;
 	width: auto;
-	border-bottom: 1px solid ${(props) => props.theme.colors.navy};
-	color: ${(props) => props.theme.colors.blueberry};
+	border-bottom: 1px solid ${(props) => props.theme.colors.selectedTheme.border};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 	font-size: 12px;
 	font-family: ${(props) => props.theme.fonts.bold};
 	text-transform: capitalize;

--- a/sections/futures/Trade/WithdrawMarginModal.tsx
+++ b/sections/futures/Trade/WithdrawMarginModal.tsx
@@ -38,7 +38,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { useEthGasPriceQuery, useExchangeRatesQuery } = useSynthetixQueries();
-	const [amount, setAmount] = React.useState<string>('');
+	const [amount, setAmount] = React.useState<string>('0');
 	const [error, setError] = React.useState<string | null>(null);
 	const [gasLimit, setGasLimit] = React.useState<number | null>(null);
 
@@ -81,8 +81,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 			if (!market || !synthetixjs) return;
 			try {
 				setError(null);
-				setGasLimit(null);
-				if (!amount || Number(amount) === 0) return;
+				if (!amount) return;
 				const FuturesMarketContract = getFuturesMarketContract(market, synthetixjs!.contracts);
 				const marginAmount = computeAmount();
 				const estimate = await FuturesMarketContract.estimateGas.transferMargin(
@@ -146,7 +145,6 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 					'Gas Fee': transactionFee
 						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$' })
 						: NO_VALUE,
-					Fee: '-',
 					Total: formatCurrency(Synths.sUSD, zeroBN?.add(transactionFee ?? 0) ?? zeroBN, {
 						sign: '$',
 						minDecimals: zeroBN.lt(0.01) ? 4 : 2,

--- a/sections/futures/Trade/WithdrawMarginModal.tsx
+++ b/sections/futures/Trade/WithdrawMarginModal.tsx
@@ -144,11 +144,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 				details={{
 					'Gas Fee': transactionFee
 						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$' })
-						: NO_VALUE,
-					Total: formatCurrency(Synths.sUSD, zeroBN?.add(transactionFee ?? 0) ?? zeroBN, {
-						sign: '$',
-						minDecimals: zeroBN.lt(0.01) ? 4 : 2,
-					}),
+						: NO_VALUE
 				}}
 			/>
 			<DepositMarginButton fullWidth onClick={handleWithdraw}>


### PR DESCRIPTION
Correcting the data displayed about margin on the markets page

## Description
* Display "total" and "available" margin separately
* Correct the buying power calculation
* Correct the margin usage calculation
* Calculate gas price on deposit/withdraw modal open
* Avoid setting gas to null before resetting on modal changes

## Related issue
[Issue](https://github.com/Kwenta/kwenta/issues/412)

## Screenshots (if appropriate):
<img width="345" alt="image" src="https://user-images.githubusercontent.com/10401554/158882309-756ce187-cf35-465d-9131-eaae7e1dd811.png">
