### PR TITLE
hide unused tab elements for beta launch

### DIFF
--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -70,7 +70,7 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 				active: activeTab === FuturesTab.POSITION,
 				onClick: () => router.push(ROUTES.Markets.Position(marketAsset)),
 			},
-			{
+			/*{
 				name: FuturesTab.TRADES,
 				label: 'Order History',
 				badge: positionHistory?.length,
@@ -84,7 +84,7 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 				disabled: true,
 				active: activeTab === FuturesTab.ORDERS,
 				onClick: () => router.push(ROUTES.Markets.Orders(marketAsset)),
-			},
+			},*/
 		],
 		[activeTab, router, marketAsset, positionHistory]
 	);
@@ -92,13 +92,11 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 	return (
 		<>
 			<TabButtonsContainer>
-				{TABS.map(({ name, label, badge, active, disabled, onClick }) => (
+				{TABS.map(({ name, label, active, onClick }) => (
 					<TabButton
 						key={name}
 						title={label}
-						badge={badge}
 						active={active}
-						disabled={disabled}
 						onClick={onClick}
 					/>
 				))}

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -70,21 +70,6 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 				active: activeTab === FuturesTab.POSITION,
 				onClick: () => router.push(ROUTES.Markets.Position(marketAsset)),
 			},
-			/*{
-				name: FuturesTab.TRADES,
-				label: 'Order History',
-				badge: positionHistory?.length,
-				disabled: true,
-				active: activeTab === FuturesTab.TRADES,
-				onClick: () => router.push(ROUTES.Markets.Trades(marketAsset)),
-			},
-			{
-				name: FuturesTab.ORDERS,
-				label: 'Open Orders',
-				disabled: true,
-				active: activeTab === FuturesTab.ORDERS,
-				onClick: () => router.push(ROUTES.Markets.Orders(marketAsset)),
-			},*/
 		],
 		[activeTab, router, marketAsset, positionHistory]
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hides `Open History` and `Open Orders` tabs for beta launch as those are not available yet.

## Related issue
#428 

## Screenshots (if appropriate):

![Screen Shot 2022-03-17 at 17 52 25](https://user-images.githubusercontent.com/548702/158893144-eee1e2d2-6e27-48d9-a347-3f75c5a51533.png)

