### PR TITLE
Refetch daily trades without page refresh

### DIFF
--- a/components/TransactionNotification/TransactionNotification.tsx
+++ b/components/TransactionNotification/TransactionNotification.tsx
@@ -49,7 +49,10 @@ const NotificationError = ({ failureReason }: NotificationProps) => {
 	);
 };
 
-const NotificationContainer = styled(FlexDivCentered)``;
+const NotificationContainer = styled(FlexDivCentered)`
+	background-color: ${(props) => props.theme.colors.selectedTheme.background};
+`;
+
 const IconContainer = styled(FlexDivRowCentered)`
 	width: 35px;
 	margin-right: 12px;

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -116,7 +116,7 @@ export const QUERY_KEYS = {
 		TokenPrices: (tokenAddresses: string[]) => ['cg', 'prices', tokenAddresses.join('|')],
 	},
 	Futures: {
-		DayTradeStats: ['futures', 'dayTradeStats'],
+		DayTradeStats: (currencyKey: string | null) => ['futures', 'dayTradeStats', currencyKey],
 		Markets: ['futures', 'marketsSummaries'],
 		OpenInterest: (currencyKeys: string[]) => ['futures', 'openInterest', currencyKeys],
 		TradingVolume: (currencyKey: string | null) => ['futures', 'tradingVolume', currencyKey],
@@ -143,7 +143,7 @@ export const QUERY_KEYS = {
 		AccountPositions: (walletAddress: string | null) => [
 			'futures',
 			'accountPositions',
-			walletAddress
+			walletAddress,
 		],
 		Participants: () => ['futures', 'participants'],
 		Participant: (walletAddress: string) => ['futures', 'participant', walletAddress],

--- a/queries/futures/useGetFuturesDailyTradeStats.ts
+++ b/queries/futures/useGetFuturesDailyTradeStats.ts
@@ -55,7 +55,7 @@ const useGetFuturesDailyTradeStats = (options?: UseQueryOptions<FuturesDailyTrad
 	};
 
 	return useQuery<FuturesDailyTradeStats | null>(
-		QUERY_KEYS.Futures.DayTradeStats,
+		QUERY_KEYS.Futures.DayTradeStats(null),
 		async () => {
 			const trades = await queryTrades(0, []);
 

--- a/queries/futures/useGetFuturesDailyTrades.ts
+++ b/queries/futures/useGetFuturesDailyTrades.ts
@@ -20,7 +20,7 @@ const useGetFuturesDailyTradeStatsForMarket = (
 	const walletAddress = useRecoilValue(walletAddressState);
 
 	return useQuery<number | null>(
-		QUERY_KEYS.Futures.DayTradeStats,
+		QUERY_KEYS.Futures.DayTradeStats(currencyKey),
 		async () => {
 			if (!currencyKey) return null;
 

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -9,7 +9,6 @@ import { FuturesMarket } from 'queries/futures/types';
 import Currency from 'components/Currency';
 import ChangePercent from 'components/ChangePercent';
 import { Synths } from 'constants/currency';
-import { DEFAULT_DATA } from './constants';
 import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
 import useGetFuturesTradingVolumeForAllMarkets from 'queries/futures/useGetFuturesTradingVolumeForAllMarkets';
 import { Price } from 'queries/rates/types';
@@ -60,9 +59,19 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 				fundingRate: market.currentFundingRate.toNumber(),
 				openInterest: market.marketSize.mul(market.price).toNumber(),
 				openInterestNative: market.marketSize.toNumber(),
-				longInterest: market.marketSize.add(market.marketSkew).div("2").abs().mul(market.price).toNumber(),
-				shortInterest: market.marketSize.sub(market.marketSkew).div("2").abs().mul(market.price).toNumber(),
-				marketSkew: market.marketSkew
+				longInterest: market.marketSize
+					.add(market.marketSkew)
+					.div('2')
+					.abs()
+					.mul(market.price)
+					.toNumber(),
+				shortInterest: market.marketSize
+					.sub(market.marketSkew)
+					.div('2')
+					.abs()
+					.mul(market.price)
+					.toNumber(),
+				marketSkew: market.marketSkew,
 			};
 		});
 	}, [
@@ -76,7 +85,7 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 	return (
 		<TableContainer>
 			<StyledTable
-				data={data.length > 0 ? data : DEFAULT_DATA}
+				data={data}
 				pageSize={5}
 				showPagination={true}
 				onTableRowClick={(row) => {
@@ -106,7 +115,9 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 					},
 					{
 						Header: (
-							<TableHeader>{t('dashboard.overview.futures-markets-table.oracle-price')}</TableHeader>
+							<TableHeader>
+								{t('dashboard.overview.futures-markets-table.oracle-price')}
+							</TableHeader>
 						),
 						accessor: 'oraclePrice',
 						Cell: (cellProps: CellProps<any>) => {

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -11,7 +11,6 @@ import PositionType from 'components/Text/PositionType';
 import ChangePercent from 'components/ChangePercent';
 import { Synths } from 'constants/currency';
 import { PositionHistory, FuturesMarket } from 'queries/futures/types';
-import { DEFAULT_DATA } from './constants';
 import { formatNumber } from 'utils/formatters/number';
 
 type FuturesPositionTableProps = {
@@ -57,7 +56,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 	return (
 		<TableContainer>
 			<StyledTable
-				data={data.length > 0 ? data : DEFAULT_DATA}
+				data={data}
 				pageSize={5}
 				showPagination={true}
 				onTableRowClick={(row) => {

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { wei } from '@synthetixio/wei';
@@ -98,40 +98,52 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 				value: !!futuresDailyTradeStats ? `${futuresDailyTradeStats ?? 0}` : NO_VALUE,
 			},
 			'Open Interest': {
-				value: 
-					marketSummary?.marketSize?.mul(wei(basePriceRate ?? 0)) ?
-						(
-						<StyledTooltip
-							placement="bottom"
-							content={
-									<>
-										<div className="green">
-											Long: {formatCurrency(
-												selectedPriceCurrency.name,
-												marketSummary.marketSize.add(marketSummary.marketSkew).div("2").abs().mul(basePriceRate ?? 0).toNumber(),
-												{sign: '$' }
-											)}
-										</div>
-										<div className="red">
-											Short: {formatCurrency(
-												selectedPriceCurrency.name,
-												marketSummary.marketSize.sub(marketSummary.marketSkew).div("2").abs().mul(basePriceRate ?? 0).toNumber(),
-												{sign: '$' }
-											)}
-										</div>
-									</>
-							}
-							arrow={false}
-						>
-							<span>
-								{formatCurrency(
-									selectedPriceCurrency.name,
-									marketSummary?.marketSize?.mul(wei(basePriceRate ?? 0)).toNumber(),
-									{sign: '$' }
-								)}
-							</span>
-						</StyledTooltip>
-						) : NO_VALUE,
+				value: marketSummary?.marketSize?.mul(wei(basePriceRate ?? 0)) ? (
+					<StyledTooltip
+						placement="bottom"
+						content={
+							<>
+								<div className="green">
+									Long:{' '}
+									{formatCurrency(
+										selectedPriceCurrency.name,
+										marketSummary.marketSize
+											.add(marketSummary.marketSkew)
+											.div('2')
+											.abs()
+											.mul(basePriceRate ?? 0)
+											.toNumber(),
+										{ sign: '$' }
+									)}
+								</div>
+								<div className="red">
+									Short:{' '}
+									{formatCurrency(
+										selectedPriceCurrency.name,
+										marketSummary.marketSize
+											.sub(marketSummary.marketSkew)
+											.div('2')
+											.abs()
+											.mul(basePriceRate ?? 0)
+											.toNumber(),
+										{ sign: '$' }
+									)}
+								</div>
+							</>
+						}
+						arrow={false}
+					>
+						<span>
+							{formatCurrency(
+								selectedPriceCurrency.name,
+								marketSummary?.marketSize?.mul(wei(basePriceRate ?? 0)).toNumber(),
+								{ sign: '$' }
+							)}
+						</span>
+					</StyledTooltip>
+				) : (
+					NO_VALUE
+				),
 			},
 			'Funding Rate': {
 				value: marketSummary?.currentFundingRate
@@ -212,6 +224,6 @@ const StyledTooltip = styled(Tooltip)`
 	font-family: ${(props) => props.theme.fonts.mono};
 	border: ${(props) => props.theme.colors.selectedTheme.border};
 	background: #131212;
-`
+`;
 
 export default MarketDetails;


### PR DESCRIPTION
## Description
This PR make the daily trades update correctly when switching markets, without having to refresh the page.

## Related issue
N/A

## Motivation and Context
This PR is part of the v2 beta soft launch.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
