### PR TITLE
Add MaxLeverage to MarketDetails

### DIFF
--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -45,7 +45,7 @@ const LeverageInput: FC<LeverageInputProps> = ({
 		<LeverageInputWrapper>
 			<LeverageRow>
 				<LeverageTitle>
-					{t('futures.market.trade.input.leverage.title')} <span>— Up to 10x</span>
+					{t('futures.market.trade.input.leverage.title')} <span>— Up to {maxLeverage}x</span>
 				</LeverageTitle>
 				{modeButton}
 			</LeverageRow>

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -156,7 +156,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 					: undefined,
 			},
 			'Max Leverage': {
-				value: marketSummary?.maxLeverage ? marketSummary?.maxLeverage.toString(0) : NO_VALUE,
+				value: marketSummary?.maxLeverage ? `${marketSummary?.maxLeverage.toString(0)}x` : NO_VALUE,
 			},
 		};
 	}, [

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -155,6 +155,9 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 					? 'red'
 					: undefined,
 			},
+			'Max Leverage': {
+				value: marketSummary?.maxLeverage ? marketSummary?.maxLeverage.toString(0) : NO_VALUE,
+			},
 		};
 	}, [
 		baseCurrencyKey,


### PR DESCRIPTION
## Description
max leverage for current assets is 10x, this could change going forward for current and new assets. Adding the maxLeverage from the `FuturesMarket` to the Futures `MarketDetails`.

## Related issue
https://github.com/Kwenta/kwenta/issues/435

## Motivation and Context
UI improvement

## How Has This Been Tested?
1) started local environment
2) loaded the futures page
3) I can see the maxLeverage category in the Market Details
4) I can see the max leverage in the leverage options
5) switch synths - can still see max leverage

## Screenshots (if appropriate):

![Screen Shot 2022-03-18 at 12 09 40 PM](https://user-images.githubusercontent.com/5998100/159059581-499f927e-2e46-4869-ae61-9c5c3a423f41.png)
