### PR TITLE
Add gas buffer

### DIFF
--- a/sections/futures/MarketInfoBox/MarketInfoBox.tsx
+++ b/sections/futures/MarketInfoBox/MarketInfoBox.tsx
@@ -25,8 +25,10 @@ const MarketInfoBox: React.FC<MarketInfoBoxProps> = ({
 	return (
 		<StyledInfoBox
 			details={{
-				'Total Margin': `${formatCurrency(Synths.sUSD, totalMargin, { sign: '$' })}`,
-				'Available Margin': `${formatCurrency(Synths.sUSD, availableMargin, { sign: '$' })}`,
+				'Total Margin': `${formatCurrency(Synths.sUSD, totalMargin, { currencyKey: Synths.sUSD })}`,
+				'Available Margin': `${formatCurrency(Synths.sUSD, availableMargin, {
+					currencyKey: Synths.sUSD,
+				})}`,
 				'Buying Power': `${formatCurrency(Synths.sUSD, buyingPower, { sign: '$' })}`,
 				'Margin Usage': `${formatPercent(marginUsage)}`,
 				Leverage: `${formatNumber(leverage)}x`,

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -135,11 +135,14 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 				onChange={(_, v) => setAmount(v)}
 				right={<MaxButton onClick={handleSetMax}>Max</MaxButton>}
 			/>
+			<MinimumAmountDisclaimer>
+				Note: Placing an order requires a minimum deposit of 100 sUSD.
+			</MinimumAmountDisclaimer>
 			<StyledInfoBox
 				details={{
 					'Gas Fee': transactionFee
 						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
-						: NO_VALUE
+						: NO_VALUE,
 				}}
 			/>
 			<DepositMarginButton fullWidth onClick={handleDeposit}>
@@ -195,6 +198,12 @@ const MaxButton = styled.button`
 	border: ${(props) => props.theme.colors.selectedTheme.border};
 	color: ${(props) => props.theme.colors.common.primaryWhite};
 	cursor: pointer;
+`;
+
+const MinimumAmountDisclaimer = styled.div`
+	font-size: 12px;
+	margin-top: 8px;
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 `;
 
 export default DepositMarginModal;

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -268,13 +268,7 @@ const Trade: React.FC<TradeProps> = () => {
 
 			{/* <StyledSegmentedControl values={['Market', 'Limit']} selectedIndex={0} onChange={() => {}} /> */}
 
-			<PositionButtons
-				selected={leverageSide}
-				onSelect={(position) => {
-					onLeverageChange('');
-					setLeverageSide(position);
-				}}
-			/>
+			<PositionButtons selected={leverageSide} onSelect={setLeverageSide} />
 
 			<OrderSizing
 				amount={tradeSize}

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -300,7 +300,10 @@ const Trade: React.FC<TradeProps> = () => {
 				variant="primary"
 				fullWidth
 				disabled={
-					!leverage || Number(leverage) < 0 || Number(leverage) > maxLeverageValue.toNumber()
+					!leverage ||
+					Number(leverage) < 0 ||
+					Number(leverage) > maxLeverageValue.toNumber() ||
+					(futuresMarketsPosition?.accessibleMargin ?? zeroBN).lt(wei(100))
 				}
 				onClick={() => {
 					setIsTradeConfirmationModalOpen(true);
@@ -381,9 +384,10 @@ const PlaceOrderButton = styled(Button)`
 	height: 55px;
 `;
 
-const ErrorMessage = styled.p`
+const ErrorMessage = styled.div`
 	color: ${(props) => props.theme.colors.common.secondaryGray};
 	font-size: 12px;
+	margin-bottom: 16px;
 `;
 
 // const StyledSegmentedControl = styled(SegmentedControl)`

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -268,6 +268,14 @@ const Trade: React.FC<TradeProps> = () => {
 
 			{/* <StyledSegmentedControl values={['Market', 'Limit']} selectedIndex={0} onChange={() => {}} /> */}
 
+			<PositionButtons
+				selected={leverageSide}
+				onSelect={(position) => {
+					onLeverageChange('');
+					setLeverageSide(position);
+				}}
+			/>
+
 			<OrderSizing
 				amount={tradeSize}
 				amountSUSD={tradeSizeSUSD}
@@ -275,14 +283,6 @@ const Trade: React.FC<TradeProps> = () => {
 				onAmountChange={onTradeAmountChange}
 				onAmountSUSDChange={onTradeAmountSUSDChange}
 				marketAsset={marketAsset || Synths.sUSD}
-			/>
-
-			<PositionButtons
-				selected={leverageSide}
-				onSelect={(position) => {
-					onLeverageChange('');
-					setLeverageSide(position);
-				}}
 			/>
 
 			<LeverageInput

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -26,7 +26,7 @@ import useGetFuturesPositionForMarket from 'queries/futures/useGetFuturesPositio
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesPositionHistory from 'queries/futures/useGetFuturesMarketPositionHistory';
 import { getFuturesMarketContract } from 'queries/futures/utils';
-import { gasPriceInWei } from 'utils/network';
+import { gasPriceInWei, normalizeGasLimit } from 'utils/network';
 import MarketsDropdown from './MarketsDropdown';
 // import SegmentedControl from 'components/SegmentedControl';
 import PositionButtons from '../PositionButtons';
@@ -188,7 +188,7 @@ const Trade: React.FC<TradeProps> = () => {
 					FuturesMarketContract.estimateGas.modifyPosition(sizeDelta.toBN()),
 					FuturesMarketContract.orderFee(sizeDelta.toBN()),
 				]);
-				setGasLimit(Number(gasEstimate));
+				setGasLimit(normalizeGasLimit(gasEstimate.toNumber()));
 				setFeeCost(wei(orderFee.fee));
 			} catch (e) {
 				console.log(e);


### PR DESCRIPTION
## Description

This PR makes a few changes to the market page. These include:
- Use gas normalization function to prevent gas limit issues.
- Moving the position buttons above the order sizing inputs.
- Adding a disclaimer regarding minimum order amounts to the deposit modal.
- Replacing dollar sign with `sUSD` prefix for margin values.

## Related issue
N/A

## Motivation and Context
This PR fixes issues raised in the soft launch of Kwenta v2.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="368" alt="image" src="https://user-images.githubusercontent.com/15985212/159217665-d8542aff-7e72-4457-bd31-1a915ac1457a.png">

<img width="466" alt="image" src="https://user-images.githubusercontent.com/15985212/159218158-1700dcc6-903f-4439-bc1e-e77f46e23142.png">
