### PR TITLE
Flip Funding Rate

### DIFF
--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -42,7 +42,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 					market: market,
 					asset: utils.parseBytes32String(asset),
 					assetHex: asset,
-					currentFundingRate: wei(currentFundingRate),
+					currentFundingRate: wei(currentFundingRate).mul(-1),
 					feeRates: {
 						makerFee: wei(feeRates.makerFee),
 						takerFee: wei(feeRates.takerFee),


### PR DESCRIPTION
Simple PR to flip the funding rate. Right now we show positive when longs pay shorts (and vice versa) which is incorrect.

Issue #463 