### PR TITLE
Market Dropdown Price Change

### DIFF
--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -9,13 +9,16 @@ import Select from 'components/Select';
 import Connector from 'containers/Connector';
 import ROUTES from 'constants/routes';
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
+import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
 
 import MarketsDropdownSingleValue from './MarketsDropdownSingleValue';
 import MarketsDropdownOption from './MarketsDropdownOption';
 import MarketsDropdownIndicator from './MarketsDropdownIndicator';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import { formatCurrency } from 'utils/formatters/number';
+import { formatCurrency, formatPercent, zeroBN } from 'utils/formatters/number';
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { Price } from 'queries/rates/types';
+import { wei } from '@synthetixio/wei';
 
 export type MarketsCurrencyOption = {
 	value: CurrencyKey;
@@ -23,38 +26,46 @@ export type MarketsCurrencyOption = {
 	description: string;
 	price: string;
 	change: string;
+	negativeChange: boolean;
 };
 
 const assetToCurrencyOption = (
 	asset: string,
 	description: string,
 	price: string,
-	change: string
+	change: string,
+	negativeChange: boolean
 ): MarketsCurrencyOption => ({
 	value: asset as CurrencyKey,
 	label: `${asset}/sUSD`,
 	description,
 	price,
 	change,
+	negativeChange
 });
 
 type Props = {
 	asset: string;
 };
 
-const DUMMY_PRICE = '42,977.23';
-const DUMMY_CHANGE = '+0.68%';
+const DUMMY_PRICE = '';
+const DUMMY_CHANGE = '';
 
 const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const futuresMarketsQuery = useGetFuturesMarkets();
 	const exchangeRatesQuery = useExchangeRatesQuery();
+	const dailyPriceChangesQuery = useLaggedDailyPrice(
+		futuresMarketsQuery?.data?.map(({ asset }) => asset) ?? []
+	);
+
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const router = useRouter();
 	const { synthsMap } = Connector.useContainer();
 	const { t } = useTranslation();
 
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const dailyPriceChanges = dailyPriceChangesQuery?.data ?? [];
 
 	const getSynthDescription = React.useCallback(
 		(synth: string) => {
@@ -69,6 +80,8 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 		const markets = futuresMarketsQuery?.data ?? [];
 
 		return markets.map((market) => {
+			const pastPrice = dailyPriceChanges.find((price: Price) => price.synth === market.asset);
+			
 			const basePriceRate = getExchangeRatesForCurrencies(
 				exchangeRates,
 				market.asset,
@@ -79,10 +92,17 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 				market.asset,
 				getSynthDescription(market.asset),
 				formatCurrency(selectedPriceCurrency.name, basePriceRate, { sign: '$' }),
-				DUMMY_CHANGE
+				formatPercent(
+					basePriceRate && pastPrice?.price ?
+						wei(basePriceRate).sub(pastPrice?.price).div(basePriceRate)
+						: zeroBN
+				),
+				basePriceRate && pastPrice?.price ?
+					wei(basePriceRate).lt(pastPrice?.price) ? true : false
+					: false
 			);
 		});
-	}, [getSynthDescription, selectedPriceCurrency.name, exchangeRates, futuresMarketsQuery?.data]);
+	}, [getSynthDescription, selectedPriceCurrency.name, exchangeRates, futuresMarketsQuery?.data, dailyPriceChangesQuery?.data]);
 
 	return (
 		<SelectContainer>
@@ -96,7 +116,7 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 						router.push(ROUTES.Markets.MarketPair(x.value));
 					}
 				}}
-				value={assetToCurrencyOption(asset, getSynthDescription(asset), DUMMY_PRICE, DUMMY_CHANGE)}
+				value={assetToCurrencyOption(asset, getSynthDescription(asset), DUMMY_PRICE, DUMMY_CHANGE, false)}
 				options={options}
 				isSearchable={false}
 				components={{

--- a/sections/futures/Trade/MarketsDropdownOption.tsx
+++ b/sections/futures/Trade/MarketsDropdownOption.tsx
@@ -16,7 +16,7 @@ const MarketsDropdownOption: React.FC<OptionProps<any>> = (props) => (
 			</CurrencyMeta>
 			<div>
 				<p className="price">{props.data.price}</p>
-				<p className="change">{props.data.change}</p>
+				<p className={props.data.negativeChange ? `change red` : 'change green'}>{props.data.change}</p>
 			</div>
 		</OptionDetailsContainer>
 	</components.Option>
@@ -56,7 +56,6 @@ const OptionDetailsContainer = styled(SingleValueContainer)<{ $isSelected: boole
 	.change {
 		font-family: ${(props) => props.theme.fonts.mono};
 		font-size: 11.5px;
-		color: ${(props) => props.theme.colors.common.primaryGreen};
 		text-align: right;
 	}
 
@@ -66,6 +65,14 @@ const OptionDetailsContainer = styled(SingleValueContainer)<{ $isSelected: boole
 
 	&:hover {
 		background-color: rgba(255, 255, 255, 0.05);
+	}
+
+	.green {
+		color: ${(props) => props.theme.colors.common.primaryGreen};
+	}
+
+	.red {
+		color: ${(props) => props.theme.colors.common.primaryRed};
 	}
 `;
 


### PR DESCRIPTION
Add back % price change on market dropdown

## Description
* Added % change to prices on the markets dropdown

## Related issue
[Issue #424](https://github.com/Kwenta/kwenta/issues/424)

## Motivation and Context
N/A

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="348" alt="image" src="https://user-images.githubusercontent.com/10401554/159345786-b846dfcc-582e-4feb-af47-171d656e161e.png">

