### PR TITLE
Bug: Negative position size

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -48,7 +48,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 				asset: position.asset,
 				market: position.asset.slice(1) + '-PERP',
 				description: description,
-				notionalValue: position?.position?.notionalValue,
+				notionalValue: position?.position?.notionalValue.abs(),
 				position: position?.position?.side,
 				lastPrice: position?.position?.lastPrice,
 				liquidationPrice: position?.position?.liquidationPrice,


### PR DESCRIPTION
Short position sizes show as negative on the dashboard

## Screenshots (if appropriate):
<img width="511" alt="image" src="https://user-images.githubusercontent.com/10401554/159583122-2bb0c1a4-5906-4a60-8cd5-787a272b532b.png">
