### PR TITLE
Comment out exchange page in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,9 +31,9 @@ module.exports = {
 			'/dashboard': {
 				page: '/dashboard/[[...tab]]',
 			},
-			'/exchange': {
-				page: '/exchange/[[...market]]',
-			},
+			// '/exchange': {
+			// 	page: '/exchange/[[...market]]',
+			// },
 		};
 	},
 	async redirects() {


### PR DESCRIPTION
## Description
This PR disables the portion of the Next.js config that references the exchange page, since it does not exist on this branch yet.

## Related issue
N/A

## Motivation and Context
This PR aims to enable the v2 branch to build on Fleek.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
