### PR TITLE
Fix order button disabled false positive

### DIFF
--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -297,7 +297,7 @@ const Trade: React.FC<TradeProps> = () => {
 					!leverage ||
 					Number(leverage) < 0 ||
 					Number(leverage) > maxLeverageValue.toNumber() ||
-					(futuresMarketsPosition?.accessibleMargin ?? zeroBN).lt(wei(100))
+					!!error
 				}
 				onClick={() => {
 					setIsTradeConfirmationModalOpen(true);


### PR DESCRIPTION
## Description
This PR removes the margin check from the `disabled` prop on the `PlaceOrderButton`, and adds one that checks if the `error` value is truthy instead.

## Related issue
N/A

## Motivation and Context
This fixes an issue reported on the v2 beta.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
