### PR TITLE
Add manual refresh of open interest

### DIFF
--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -224,6 +224,7 @@ const Trade: React.FC<TradeProps> = () => {
 						setTimeout(() => {
 							futuresMarketPositionQuery.refetch();
 							futuresPositionHistoryQuery.refetch();
+							marketQuery.refetch();
 						}, 5 * 1000);
 					},
 				});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When opening or modifying a position, `Open Interest` under `MarketDetails`does not refresh immediately in order to reflect the recently updated position. This PR is fixing this issue.

## Related issue
#498 

## Motivation and Context
Add a manual refresh of `marketQuery` after the confirmation of the order. 

## How Has This Been Tested?
Case 1:
1. Open a position 
2. Confirm the order and `Open Interest` is refreshed automatically.

Case 2:
1. Modify the position open in Case 1
2. Confirm the order and `Open Interest` is refreshed automatically.

## Screenshots (if appropriate):
N/A