### PR TITLE
Remove ROI from portfolio value

### DIFF
--- a/queries/futures/useGetCurrentPortfolioValue.ts
+++ b/queries/futures/useGetCurrentPortfolioValue.ts
@@ -42,7 +42,7 @@ const useGetCurrentPortfolioValue = (
 				const portfolioValue = positionsForMarkets
 					.map(([position], i) => {
 						const mappedPosition = mapFuturesPosition(position, false, markets[i]);
-						return mappedPosition.remainingMargin.add(mappedPosition?.position?.roi || 0);
+						return mappedPosition.remainingMargin;
 					})
 					.reduce((sum: Wei, val) => sum.add(val), wei(0));
 				return !!portfolioValue ? portfolioValue : wei(0);


### PR DESCRIPTION
"Futures portfolio value" is currently double counting PnL since it is included in the `remainingMargin` calculation.

## Description
* Remove `roi` addition to portfolio value

## Related issue
[Issue #510](https://github.com/Kwenta/kwenta/issues/510)

## Motivation and Context
It's wrong.

## How Has This Been Tested?
Checked the portfolio value against all "total margin" values on the markets page

