### PR TITLE
gas price summary component update re status l1/l2

### DIFF
--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -66,7 +66,9 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 	return (
 		<SummaryItem {...rest}>
 			<SummaryItemLabel>
-				{isL2 ? t('exchange.summary-info.gas-price-gwei') : t('exchange.summary-info.max-fee-gwei')}
+				{isMainnet
+					? t('exchange.summary-info.max-fee-gwei')
+					: t('exchange.summary-info.gas-price-gwei')}
 			</SummaryItemLabel>
 			<SummaryItemValue>
 				{gasPrice != null ? (

--- a/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem.tsx
@@ -66,9 +66,7 @@ const GasPriceSummaryItem: FC<GasPriceSummaryItemProps> = ({
 	return (
 		<SummaryItem {...rest}>
 			<SummaryItemLabel>
-				{isMainnet || !isCustomGasPrice
-					? t('exchange.summary-info.max-fee-gwei')
-					: t('exchange.summary-info.gas-price-gwei')}
+				{isL2 ? t('exchange.summary-info.gas-price-gwei') : t('exchange.summary-info.max-fee-gwei')}
 			</SummaryItemLabel>
 			<SummaryItemValue>
 				{gasPrice != null ? (

--- a/translations/en.json
+++ b/translations/en.json
@@ -214,8 +214,8 @@
 			"no-data": "No data"
 		},
 		"summary-info": {
-			"gas-price-gwei": "gas price (GWEI)",
-			"max-fee-gwei": "Max Fee (GWEI)",
+			"gas-price-gwei": "gas price (Gwei)",
+			"max-fee-gwei": "Max Fee (Gwei)",
 			"fee": "fee",
 			"fee-cost": "fee cost",
 			"button": {


### PR DESCRIPTION
the component showing the gas fee text does a Logical OR check on `isMainnet` and `!isCustomGasPrice`  followed by a ternary operation `?:`

```
<SummaryItemLabel>
                {isMainnet || !isCustomGasPrice
                    ? t('exchange.summary-info.max-fee-gwei')
                    : t('exchange.summary-info.gas-price-gwei')}
            </SummaryItemLabel>
```


The reason the text is not updating with L2, is that the !isCustomGasPrice value returns true. This triggers the true ternary ? statement of Max Fee (GWEI).

I have updated the component with a simple ternary using `isL2`, and if true return the specified text, and if false return the specified text.

I have also updated the `en.json` file to change GWEI to Gwei, as requested.

## Related issue
While testing in local, running the ternary with `isMainnet` rather than `isL2` did not trigger the changes in the component necessary. I am not sure why this is, or if it had something to do with my local setup.


## How Has This Been Tested?
Visual testing to confirm the 

## Screenshots (if appropriate):

<img width="1608" alt="image" src="https://user-images.githubusercontent.com/100385397/159975940-96f9fae4-3065-4d45-bd33-fe906664a492.png">

<img width="1686" alt="image" src="https://user-images.githubusercontent.com/100385397/159976105-f1a01e38-3bda-439f-82ae-68e2d5f3dea1.png">

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/100385397/159976278-830a301a-77c9-44c8-b387-3580d5017262.png">

