### PR TITLE
Fees on position card

### DIFF
--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -1,4 +1,4 @@
 export const FUTURES_ENDPOINT =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
 
 export const DAY_PERIOD = 24;

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -90,6 +90,7 @@ export type RawPosition = {
 	isOpen: boolean;
 	isLiquidated: boolean;
 	size: Wei;
+	feesPaid: Wei;
 	margin: Wei;
 	entryPrice: Wei;
 	exitPrice: Wei;
@@ -105,6 +106,7 @@ export type PositionHistory = {
 	isOpen: boolean;
 	isLiquidated: boolean;
 	size: Wei;
+	feesPaid: Wei;
 	margin: Wei;
 	entryPrice: Wei;
 	exitPrice: Wei;

--- a/queries/futures/useGetFuturesPositionForAccount.ts
+++ b/queries/futures/useGetFuturesPositionForAccount.ts
@@ -33,6 +33,7 @@ const useGetFuturesPositionForAccount = (options?: UseQueryOptions<any>) => {
 									asset
 									margin
 									size
+									feesPaid
 									isOpen
 									isLiquidated
 									entryPrice

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -185,6 +185,7 @@ export const mapTradeHistory = (futuresPositions: RawPosition[], openOnly: boole
 					isOpen,
 					isLiquidated,
 					size,
+					feesPaid,
 					margin,
 					entryPrice,
 					exitPrice
@@ -192,6 +193,7 @@ export const mapTradeHistory = (futuresPositions: RawPosition[], openOnly: boole
 					const entryPriceWei = new Wei(entryPrice, 18, true);
 					const exitPriceWei = new Wei(exitPrice || 0, 18, true);
 					const sizeWei = new Wei(size, 18, true);
+					const feesWei = new Wei(feesPaid, 18, true);
 					const marginWei = new Wei(margin, 18, true);
 					return {
 						id: Number(id.split('-')[1].toString()),
@@ -203,6 +205,7 @@ export const mapTradeHistory = (futuresPositions: RawPosition[], openOnly: boole
 						isOpen,
 						isLiquidated,
 						size: sizeWei.abs(),
+						feesPaid: feesWei,
 						margin: marginWei,
 						entryPrice: entryPriceWei,
 						exitPrice: exitPriceWei,

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -170,7 +170,14 @@ const PositionCard: React.FC<PositionCardProps> = ({
 					</InfoCol>
 					<InfoCol>
 						<StyledSubtitle>Fees</StyledSubtitle>
-						<StyledValue>{NO_VALUE}</StyledValue>
+						<StyledValue>
+							{positionDetails ?
+								formatCurrency(Synths.sUSD, positionHistory?.feesPaid ?? zeroBN, {
+									sign: '$',
+								})
+								: NO_VALUE
+							}
+						</StyledValue>
 					</InfoCol>
 				</DataCol>
 				<DataCol>


### PR DESCRIPTION
Add fees to the position card

## Description
* Point at production subgraph (`optimism-main`) instead of futures-specific subgraph (`optimism-futures`)
* Add `feesPaid` to position query
* Display fees from query on position card

## Related issue
[Issue #502](https://github.com/Kwenta/kwenta/issues/502)

## Motivation and Context
We are currently displaying a dash where fees should be

## How Has This Been Tested?
* Checked that subgraph data has not changed comparing to v2.beta version (24 hr trades and volume)
* Checked total fees for test wallet LINK position coming from subgraph against etherscan

## Screenshots (if appropriate):
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/10401554/159990559-9a1d5512-377f-407a-a80b-eecd28376d45.png">
