### PR TITLE
Let the position card change when the price moves

### DIFF
--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -37,7 +37,6 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(marketAsset);
 	const futuresPositionHistoryQuery = useGetFuturesPositionHistory(marketAsset);
 
-
 	const exchangeRates = useMemo(
 		() => (exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null),
 		[exchangeRatesQuery.isSuccess, exchangeRatesQuery.data]
@@ -50,7 +49,7 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 
 	const futuresMarketsPosition = useMemo(
 		() => (futuresMarketPositionQuery?.data ?? null),
-		[marketAssetRate]
+		[futuresMarketPositionQuery, marketAssetRate]
 	);
 
 	const positionHistory = futuresPositionHistoryQuery?.data ?? null;

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -36,7 +36,7 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(marketAsset);
 	const futuresPositionHistoryQuery = useGetFuturesPositionHistory(marketAsset);
-	const futuresMarketsPosition = futuresMarketPositionQuery?.data ?? null;
+
 
 	const exchangeRates = useMemo(
 		() => (exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null),
@@ -46,6 +46,11 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 	const marketAssetRate = useMemo(
 		() => getExchangeRatesForCurrencies(exchangeRates, marketAsset, Synths.sUSD),
 		[exchangeRates, marketAsset]
+	);
+
+	const futuresMarketsPosition = useMemo(
+		() => (futuresMarketPositionQuery?.data ?? null),
+		[marketAssetRate]
 	);
 
 	const positionHistory = futuresPositionHistoryQuery?.data ?? null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the price moves, the position card (Position Size, Unrealized P&L, Leverage, Liq) doesn't change automatically. The user has to refresh the page to update the position card.

## Related issue
#518

## Motivation and Context
The position card (Position Size, Unrealized P&L, Leverage, Liq) is supposed to change automatically when the price moves. It will increase the user experience.

## How Has This Been Tested?
1. Open a position and take a screenshot of the position card
2. Wait for the price moves (around 5-10 mins)
3. Compare the position info on dapp with the screenshot taken above

## Screenshots (if appropriate):
