### PR TITLE
Fix max leverage value display

### DIFF
--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -45,7 +45,8 @@ const LeverageInput: FC<LeverageInputProps> = ({
 		<LeverageInputWrapper>
 			<LeverageRow>
 				<LeverageTitle>
-					{t('futures.market.trade.input.leverage.title')} <span>— Up to {maxLeverage}x</span>
+					{t('futures.market.trade.input.leverage.title')}{' '}
+					<span>— Up to {maxLeverage.toFixed(1)}x</span>
 				</LeverageTitle>
 				{modeButton}
 			</LeverageRow>


### PR DESCRIPTION
## Description
This issue where leverage displays a long decimal value

## Related issue
N/A

## Motivation and Context
This PR fixes an issue reported from the v2 beta

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
