### PR TITLE
Show futures banner on all pages

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -24,7 +24,7 @@ const Header: FC = () => {
 	const logo = <Logo isL2={isL2} />;
 
 	return (
-		<Container isL2={isL2}>
+		<>
 			<FuturesBannerContainer>
 				<FuturesBannerLinkWrapper>
 					<>
@@ -38,24 +38,26 @@ const Header: FC = () => {
 				<Svg src={FuturesBordersSvg} />
 				<DivBorder />
 			</FuturesBannerContainer>
-			<MobileHiddenView>
-				<LogoNav>
-					{logo}
-					<Nav />
-				</LogoNav>
-				<UserMenu />
-			</MobileHiddenView>
-			<MobileOnlyView>
-				<LogoNav>{logo}</LogoNav>
-				<MobileUserMenu />
-			</MobileOnlyView>
-		</Container>
+			<Container isL2={isL2}>
+				<MobileHiddenView>
+					<LogoNav>
+						{logo}
+						<Nav />
+					</LogoNav>
+					<UserMenu />
+				</MobileHiddenView>
+				<MobileOnlyView>
+					<LogoNav>{logo}</LogoNav>
+					<MobileUserMenu />
+				</MobileOnlyView>
+			</Container>
+		</>
 	);
 };
 
 const Container = styled.header<{ isL2: boolean }>`
 	position: absolute;
-	top: 0;
+	top: ${HEADER_HEIGHT};
 	left: 0;
 	right: 0;
 	z-index: ${zIndex.HEADER};

--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -38,7 +38,7 @@ const Header: FC = () => {
 				<Svg src={FuturesBordersSvg} />
 				<DivBorder />
 			</FuturesBannerContainer>
-			<Container isL2={isL2}>
+			<Container>
 				<MobileHiddenView>
 					<LogoNav>
 						{logo}
@@ -55,7 +55,7 @@ const Header: FC = () => {
 	);
 };
 
-const Container = styled.header<{ isL2: boolean }>`
+const Container = styled.header`
 	position: absolute;
 	top: ${HEADER_HEIGHT};
 	left: 0;
@@ -67,8 +67,6 @@ const Container = styled.header<{ isL2: boolean }>`
 		box-shadow: 0 8px 8px 0 ${(props) => props.theme.colors.black};
 	`};
 	> div {
-		border-top: ${(props) =>
-			`2px solid ${props.isL2 ? props.theme.colors.goldColors.color2 : 'transparent'}`};
 		box-sizing: border-box;
 		height: ${HEADER_HEIGHT};
 		line-height: ${HEADER_HEIGHT};

--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
+import Img, { Svg } from 'react-optimized-image';
 
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
 import { HEADER_HEIGHT, zIndex } from 'constants/ui';
@@ -14,6 +15,8 @@ import UserMenu from './UserMenu';
 import MobileUserMenu from './MobileUserMenu';
 import { useRecoilValue } from 'recoil';
 import { isL2State } from 'store/wallet';
+import FuturesBordersSvg from 'assets/svg/app/futures-borders.svg';
+import LinkWhiteIcon from 'assets/svg/app/link-white.svg';
 
 const Header: FC = () => {
 	const isL2 = useRecoilValue(isL2State);
@@ -22,6 +25,19 @@ const Header: FC = () => {
 
 	return (
 		<Container isL2={isL2}>
+			<FuturesBannerContainer>
+				<FuturesBannerLinkWrapper>
+					<>
+						<FuturesLink href="https://v2.beta.kwenta.io/" target="_blank">
+							Perpetual Futures Beta available now
+						</FuturesLink>
+						<Img src={LinkWhiteIcon} />
+					</>
+				</FuturesBannerLinkWrapper>
+				<DivBorder />
+				<Svg src={FuturesBordersSvg} />
+				<DivBorder />
+			</FuturesBannerContainer>
 			<MobileHiddenView>
 				<LogoNav>
 					{logo}
@@ -59,6 +75,45 @@ const Container = styled.header<{ isL2: boolean }>`
 		justify-content: space-between;
 		align-items: center;
 	}
+`;
+
+const FuturesBannerContainer = styled.div`
+	height: 65px;
+	width: 100%;
+	display: flex;
+	align-items: center;
+	background: linear-gradient(
+		180deg,
+		${(props) => props.theme.colors.goldColors.color1} 0%,
+		${(props) => props.theme.colors.goldColors.color2} 100%
+	);
+	${media.lessThan('md')`
+		position: relative;
+		top: ${HEADER_HEIGHT};
+		margin-bottom: ${HEADER_HEIGHT};
+	`}
+`;
+
+const FuturesBannerLinkWrapper = styled.div`
+	width: 100%;
+	text-align: center;
+	position: absolute;
+	text-shadow: 0px 1px 2px ${(props) => props.theme.colors.transparentBlack};
+	color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 16px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+const DivBorder = styled.div`
+	height: 2px;
+	background: ${(props) => props.theme.colors.goldColors.color1};
+	flex-grow: 1;
+`;
+const FuturesLink = styled.a`
+	margin-right: 5px;
 `;
 
 const LogoNav = styled(GridDivCenteredCol)`

--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -62,8 +62,8 @@ const Header: FC = () => {
 			<FuturesBannerContainer>
 				<FuturesBannerLinkWrapper>
 					<>
-						<FuturesLink href="https://raise.kwenta.io" target="_blank">
-							Kwenta Community Raise now live on Aelin
+						<FuturesLink href="https://v2.beta.kwenta.io/" target="_blank">
+							Perpetual Futures Beta available now
 						</FuturesLink>
 						<Img src={LinkWhiteIcon} />
 					</>

--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -116,6 +116,7 @@ const Container = styled.header`
 		grid-template-columns: auto auto;
 	`}
 `;
+
 const FuturesBannerContainer = styled.div`
 	height: 65px;
 	width: 100%;


### PR DESCRIPTION
## Description
The "Perpetual Futures Beta available now" banner is only visible on the home page of Kwenta. It would be great to display the banner on all the pages of the website such as the dashboard, the exchange and the sorting page.

## Related issue
closes #512 

## Motivation and Context
It improves the user experience and displays information consistently across all pages of the site.

## How Has This Been Tested?
Browse all the website pages (homepage, dashboard, exchange and sorting) and check that the banner is visible. The banner should display `Perpetual Futures Beta available now` and clicking on the link should open a new page to https://v2.beta.kwenta.io/.

## Screenshots (if appropriate):
![exchange](https://user-images.githubusercontent.com/28714795/160030790-d2bb0eb4-dad9-4cea-baeb-625f0a316530.png)
