### PR TITLE
Bug: Position Table Link

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -70,7 +70,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 				pageSize={5}
 				showPagination={true}
 				onTableRowClick={(row) => {
-					router.push(`/market/${row.original.asset}`);
+					row.original.asset !== NO_VALUE ?
+						router.push(`/market/${row.original.asset}`) :
+						null;
 				}}
 				highlightRowsOnHover
 				columns={[


### PR DESCRIPTION
Remove the "click" behavior from the positions table when the user has no open positions.

## Description
* Remove click function when value is the default value

## Related issue
Closes #524 