### PR TITLE
Average Entry Price

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -170,7 +170,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 					{
 						Header: (
 							<TableHeader>
-								{t('dashboard.overview.futures-positions-table.last-entry')}
+								{t('dashboard.overview.futures-positions-table.average-entry')}
 							</TableHeader>
 						),
 						accessor: 'lastPrice',

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -158,7 +158,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 				</DataCol>
 				<DataCol>
 					<InfoCol>
-						<StyledSubtitle>Last Entry Price</StyledSubtitle>
+						<StyledSubtitle>Avg. Entry Price</StyledSubtitle>
 						<StyledValue>
 							{positionDetails ?
 								formatCurrency(Synths.sUSD, positionHistory?.entryPrice ?? zeroBN, {

--- a/translations/en.json
+++ b/translations/en.json
@@ -374,7 +374,7 @@
 				"market": "Market",
 				"position": "Side",
 				"avg-open-close": "Avg. Open/Close",
-				"last-entry": "Last Entry Price",
+				"average-entry": "Avg. Entry Price",
 				"leverage": "Leverage",
 				"pnl": "Unrealized P&L",
 				"notionalValue": "Size",


### PR DESCRIPTION
Simple naming update to change from "last entry price" to "avg entry price"

## Description
Currently the subgraph overwrites the entry price each time the trader modifies a position. The [subgraph](https://thegraph.com/hosted-service/subgraph/kwenta/optimism-main) is syncing an update that will change this logic to "average" entry price instead.

This PR should be merged when that subgraph has completed syncing.

## Related issue
Closes Issue #509 
Closes Issue #482 

## Motivation and Context
Average price is more meaningful for long-lived positions

## How Has This Been Tested?
The subgraph update was tested using many testnet transactions modifying positions and checking against the expected behavior.
