### PR TITLE
Start using useSynthetixTxn hook for making transactions

### DIFF
--- a/components/Currency/CurrencyIcon/CurrencyIcon.tsx
+++ b/components/Currency/CurrencyIcon/CurrencyIcon.tsx
@@ -7,7 +7,6 @@ import DeprecatedXIcon from 'assets/svg/app/deprecated-x.svg';
 
 import { CRYPTO_CURRENCY_MAP, CurrencyKey } from 'constants/currency';
 
-import useSynthetixTokenList from 'queries/tokenLists/useSynthetixTokenList';
 import useZapperTokenList from 'queries/tokenLists/useZapperTokenList';
 import useOneInchTokenList from 'queries/tokenLists/useOneInchTokenList';
 
@@ -26,7 +25,7 @@ export const SNXIcon =
 	'https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/snx/SNX.svg';
 
 export const getSynthIcon = (currencyKey: CurrencyKey) =>
-	`https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/${currencyKey}.svg`;
+	`https://raw.githubusercontent.com/Synthetixio/synthetix-assets/master/synths/png/${currencyKey}.png`;
 
 const CurrencyIconContainer: FC<CurrencyIconProps> = (props) => (
 	<Container>
@@ -43,11 +42,6 @@ const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, isDeprecated, 
 	const [firstFallbackError, setFirstFallbackError] = useState<boolean>(false);
 	const [secondFallbackError, setSecondFallbackError] = useState<boolean>(false);
 	const [thirdFallbackError, setThirdFallbackError] = useState<boolean>(false);
-
-	const synthetixTokenListQuery = useSynthetixTokenList();
-	const synthetixTokenListMap = synthetixTokenListQuery.isSuccess
-		? synthetixTokenListQuery.data?.tokensMap ?? null
-		: null;
 
 	const ZapperTokenListQuery = useZapperTokenList();
 	const ZapperTokenListMap = ZapperTokenListQuery.isSuccess
@@ -78,11 +72,7 @@ const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, isDeprecated, 
 				return (
 					<TokenIcon
 						{...{ isDeprecated }}
-						src={
-							synthetixTokenListMap != null && synthetixTokenListMap[currencyKey] != null
-								? synthetixTokenListMap[currencyKey].logoURI
-								: getSynthIcon(currencyKey as CurrencyKey)
-						}
+						src={getSynthIcon(currencyKey as CurrencyKey)}
 						onError={() => setFirstFallbackError(true)}
 						{...props}
 						alt={currencyKey}

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -1,2 +1,7 @@
+import { BigNumber } from 'ethers';
+
 export const GWEI_UNIT = 1000000000;
+export const GWEI_DECIMALS = 9;
 export const ETH_UNIT = 1000000000000000000;
+
+export type GasLimitEstimate = BigNumber | null;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,7 +29,7 @@ import { createQueryContext, SynthetixQueryContextProvider } from '@synthetixio/
 import Connector from 'containers/Connector';
 
 const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
-	const { provider, network } = Connector.useContainer();
+	const { provider, signer, network } = Connector.useContainer();
 	return (
 		<>
 			<MediaContextProvider>
@@ -38,6 +38,7 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
 						provider && network
 							? createQueryContext({
 									provider: provider,
+									signer: signer || undefined,
 									networkId: network!.id,
 							  })
 							: createQueryContext({ networkId: null })

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -18,7 +18,7 @@ import {
 
 export const getFuturesMarketContract = (asset: string | null, contracts: ContractsMap) => {
 	if (!asset) throw new Error(`Asset needs to be specified`);
-	const contractName = `FuturesMarket${asset.substring(1)}`;
+	const contractName = `FuturesMarket${asset?.[0] === 's' ? asset.substring(1) : asset}`;
 	const contract = contracts[contractName];
 	if (!contract) throw new Error(`${contractName} for ${asset} does not exist`);
 	return contract;
@@ -130,14 +130,11 @@ export const mapOpenInterest = async (
 };
 
 export const calculateTradeVolume = (futuresTrades: FuturesTrade[]): Wei => {
-	return futuresTrades.reduce(
-		(acc: Wei, { size, price }: FuturesTrade) => {
-			const cleanSize = new Wei(size, 18, true).abs()
-			const cleanPrice = new Wei(price, 18, true)
-			return acc.add(cleanSize.mul(cleanPrice));
-		},
-		wei(0)
-	);
+	return futuresTrades.reduce((acc: Wei, { size, price }: FuturesTrade) => {
+		const cleanSize = new Wei(size, 18, true).abs();
+		const cleanPrice = new Wei(price, 18, true);
+		return acc.add(cleanSize.mul(cleanPrice));
+	}, wei(0));
 };
 
 export const calculateTradeVolumeForAll = (futuresTrades: FuturesTrade[]): FuturesVolumes => {
@@ -148,11 +145,10 @@ export const calculateTradeVolumeForAll = (futuresTrades: FuturesTrade[]): Futur
 		const priceAdd = new Wei(price, 18, true);
 		const volumeAdd = sizeAdd.mul(priceAdd).abs();
 
-		volumes[asset] ?
-			volumes[asset] = volumes[asset].add(volumeAdd)
-		:
-			volumes[asset] = volumeAdd
-	})
+		volumes[asset]
+			? (volumes[asset] = volumes[asset].add(volumeAdd))
+			: (volumes[asset] = volumeAdd);
+	});
 	return volumes;
 };
 
@@ -171,7 +167,10 @@ export const calculateDailyTradeStats = (futuresTrades: FuturesOneMinuteStat[]) 
 	);
 };
 
-export const mapTradeHistory = (futuresPositions: RawPosition[], openOnly: boolean): PositionHistory[] => {
+export const mapTradeHistory = (
+	futuresPositions: RawPosition[],
+	openOnly: boolean
+): PositionHistory[] => {
 	return (
 		futuresPositions
 			?.map(
@@ -188,7 +187,7 @@ export const mapTradeHistory = (futuresPositions: RawPosition[], openOnly: boole
 					feesPaid,
 					margin,
 					entryPrice,
-					exitPrice
+					exitPrice,
 				}: RawPosition) => {
 					const entryPriceWei = new Wei(entryPrice, 18, true);
 					const exitPriceWei = new Wei(exitPrice || 0, 18, true);
@@ -218,7 +217,7 @@ export const mapTradeHistory = (futuresPositions: RawPosition[], openOnly: boole
 				}
 			)
 			.filter(({ isOpen }: { isOpen: boolean }) => {
-				if(openOnly) {
+				if (openOnly) {
 					return isOpen;
 				} else {
 					return true;

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -105,7 +105,12 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 							) : (
 								<MarketContainer>
 									<IconContainer>
-										<StyledCurrencyIcon currencyKey={cellProps.row.original.asset} />
+										<StyledCurrencyIcon
+											currencyKey={
+												(cellProps.row.original.asset[0] !== 's' ? 's' : '') +
+												cellProps.row.original.asset
+											}
+										/>
 									</IconContainer>
 									<StyledText>{cellProps.row.original.market}</StyledText>
 									<StyledValue>{cellProps.row.original.description}</StyledValue>

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -50,7 +50,7 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 
 			return {
 				asset: market.asset,
-				market: market.asset.slice(1) + '-PERP',
+				market: (market.asset[0] === 's' ? market.asset.slice(1) : market.asset) + '-PERP',
 				synth: synthsMap[market.asset],
 				description: description,
 				price: market.price.toNumber(),

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -28,7 +28,6 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 	const futuresPositionQuery = useGetFuturesPositionForMarkets(
 		futuresMarkets.map(({ asset }) => asset)
 	);
-	const futuresPositions = futuresPositionQuery?.data ?? [];
 
 	const getSynthDescription = useCallback(
 		(synth: string) => {
@@ -40,28 +39,33 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 	);
 
 	let data = useMemo(() => {
-		const activePositions = futuresPositions.filter((position: FuturesPosition) => position?.position)
-		return activePositions.length > 0 ? activePositions.map((position: FuturesPosition, i: number) => {
-			const description = getSynthDescription(position.asset);
+		const futuresPositions = futuresPositionQuery?.data ?? [];
+		const activePositions = futuresPositions.filter(
+			(position: FuturesPosition) => position?.position
+		);
+		return activePositions.length > 0
+			? activePositions.map((position: FuturesPosition, i: number) => {
+					const description = getSynthDescription(position.asset);
 
-			return {
-				asset: position.asset,
-				market: position.asset.slice(1) + '-PERP',
-				description: description,
-				notionalValue: position?.position?.notionalValue.abs(),
-				position: position?.position?.side,
-				lastPrice: position?.position?.lastPrice,
-				liquidationPrice: position?.position?.liquidationPrice,
-				pnl: position?.position?.profitLoss.add(position?.position?.accruedFunding),
-				pnlPct: position?.position?.profitLoss.div(
-					position?.position?.initialMargin.mul(position?.position?.initialLeverage)
-				),
-				margin: position.accessibleMargin,
-				leverage: position?.position?.leverage,
-			};
-		})
-		: DEFAULT_DATA
-	}, [futuresPositions, futuresMarkets, getSynthDescription]);
+					return {
+						asset: position.asset,
+						market:
+							(position.asset[0] === 's' ? position.asset.slice(1) : position.asset) + '-PERP',
+						description: description,
+						notionalValue: position?.position?.notionalValue.abs(),
+						position: position?.position?.side,
+						lastPrice: position?.position?.lastPrice,
+						liquidationPrice: position?.position?.liquidationPrice,
+						pnl: position?.position?.profitLoss.add(position?.position?.accruedFunding),
+						pnlPct: position?.position?.profitLoss.div(
+							position?.position?.initialMargin.mul(position?.position?.initialLeverage)
+						),
+						margin: position.accessibleMargin,
+						leverage: position?.position?.leverage,
+					};
+			  })
+			: DEFAULT_DATA;
+	}, [futuresPositionQuery?.data, getSynthDescription]);
 
 	return (
 		<TableContainer>
@@ -69,11 +73,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 				data={data}
 				pageSize={5}
 				showPagination={true}
-				onTableRowClick={(row) => {
-					row.original.asset !== NO_VALUE ?
-						router.push(`/market/${row.original.asset}`) :
-						null;
-				}}
+				onTableRowClick={(row) =>
+					row.original.asset !== NO_VALUE ? router.push(`/market/${row.original.asset}`) : undefined
+				}
 				highlightRowsOnHover
 				columns={[
 					{
@@ -112,7 +114,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 					},
 					{
 						Header: (
-							<TableHeader>{t('dashboard.overview.futures-positions-table.notionalValue')}</TableHeader>
+							<TableHeader>
+								{t('dashboard.overview.futures-positions-table.notionalValue')}
+							</TableHeader>
 						),
 						accessor: 'notionalValue',
 						Cell: (cellProps: CellProps<any>) => {
@@ -155,12 +159,14 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 								<PnlContainer>
 									<ChangePercent value={cellProps.row.original.pnlPct} className="change-pct" />
 									<div>
-										(<Currency.Price
+										(
+										<Currency.Price
 											currencyKey={Synths.sUSD}
 											price={cellProps.row.original.pnl}
 											sign={'$'}
 											conversionRate={1}
-										/>)
+										/>
+										)
 									</div>
 								</PnlContainer>
 							);
@@ -177,20 +183,22 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 						Cell: (cellProps: CellProps<any>) => {
 							return cellProps.row.original.avgOpenClose === NO_VALUE ? (
 								<DefaultCell>{NO_VALUE}</DefaultCell>
-								) : (
-									<Currency.Price
+							) : (
+								<Currency.Price
 									currencyKey={Synths.sUSD}
 									price={cellProps.row.original.lastPrice}
 									sign={'$'}
 									conversionRate={1}
 								/>
-								);
-							},
-							width: 125,
+							);
+						},
+						width: 125,
 					},
 					{
 						Header: (
-							<TableHeader>{t('dashboard.overview.futures-positions-table.liquidationPrice')}</TableHeader>
+							<TableHeader>
+								{t('dashboard.overview.futures-positions-table.liquidationPrice')}
+							</TableHeader>
 						),
 						accessor: 'liquidationPrice',
 						Cell: (cellProps: CellProps<any>) => {

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -89,7 +89,12 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 							) : (
 								<MarketContainer>
 									<IconContainer>
-										<StyledCurrencyIcon currencyKey={cellProps.row.original.asset} />
+										<StyledCurrencyIcon
+											currencyKey={
+												(cellProps.row.original.asset[0] !== 's' ? 's' : '') +
+												cellProps.row.original.asset
+											}
+										/>
 									</IconContainer>
 									<StyledText>{cellProps.row.original.market}</StyledText>
 									<StyledValue>{cellProps.row.original.description}</StyledValue>

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -86,7 +86,7 @@ const LeverageInput: FC<LeverageInputProps> = ({
 							onClick={() => {
 								onLeverageChange(l);
 							}}
-							disabled={maxLeverage.lte(Number(l))}
+							disabled={maxLeverage.lt(Number(l))}
 						>
 							{l}x
 						</LeverageButton>

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -1,6 +1,7 @@
 import { FC, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import Wei from '@synthetixio/wei';
 
 import { FlexDivCol, FlexDivRow } from 'styles/common';
 import { PositionSide } from '../types';
@@ -8,13 +9,14 @@ import { FuturesPosition } from 'queries/futures/types';
 import LeverageSlider from '../LeverageSlider';
 import NumericInput from 'components/Input/NumericInput';
 import Button from 'components/Button';
+import { formatNumber } from 'utils/formatters/number';
 
 type LeverageInputProps = {
 	currentLeverage: string;
 	currentTradeSize: number;
-	maxLeverage: number;
+	maxLeverage: Wei;
 	side: PositionSide;
-	assetRate: number;
+	assetRate: Wei;
 	onLeverageChange: (value: string) => void;
 	setIsLeverageValueCommitted: (value: boolean) => void;
 	currentPosition: FuturesPosition | null;
@@ -46,16 +48,16 @@ const LeverageInput: FC<LeverageInputProps> = ({
 			<LeverageRow>
 				<LeverageTitle>
 					{t('futures.market.trade.input.leverage.title')}{' '}
-					<span>— Up to {maxLeverage.toFixed(1)}x</span>
+					<span>— Up to {formatNumber(maxLeverage, { maxDecimals: 1 })}x</span>
 				</LeverageTitle>
 				{modeButton}
 			</LeverageRow>
 			{mode === 'slider' ? (
 				<SliderRow>
 					<LeverageSlider
-						disabled={maxLeverage <= 0}
+						disabled={maxLeverage.lte(0)}
 						minValue={0}
-						maxValue={maxLeverage}
+						maxValue={maxLeverage.toNumber()}
 						value={currentLeverage ? Number(currentLeverage) : 0}
 						onChange={(_, newValue) => {
 							setIsLeverageValueCommitted(false);
@@ -84,7 +86,7 @@ const LeverageInput: FC<LeverageInputProps> = ({
 							onClick={() => {
 								onLeverageChange(l);
 							}}
-							disabled={Number(l) > maxLeverage}
+							disabled={maxLeverage.lte(Number(l))}
 						>
 							{l}x
 						</LeverageButton>

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
+import Wei from '@synthetixio/wei';
 
 import { Synths } from 'constants/currency';
 import CustomInput from 'components/Input/CustomInput';
 
 type OrderSizingProps = {
-	assetRate: number;
+	assetRate: Wei;
 	amount: string;
 	amountSUSD: string;
 	onAmountChange: (value: string) => void;
@@ -30,11 +31,11 @@ const OrderSizing: React.FC<OrderSizingProps> = ({
 				right={marketAsset || Synths.sUSD}
 				value={amount}
 				onChange={(_, v) => onAmountChange(v)}
-				style={{ 
-					marginBottom: '-1px', 
+				style={{
+					marginBottom: '-1px',
 					borderBottom: 'none',
-					borderBottomRightRadius: '0px', 
-					borderBottomLeftRadius: '0px' 
+					borderBottomRightRadius: '0px',
+					borderBottomLeftRadius: '0px',
 				}}
 			/>
 
@@ -42,9 +43,9 @@ const OrderSizing: React.FC<OrderSizingProps> = ({
 				right={Synths.sUSD}
 				value={amountSUSD}
 				onChange={(_, v) => onAmountSUSDChange(v)}
-				style={{ 
-					borderTopRightRadius: '0px', 
-					borderTopLeftRadius: '0px' 
+				style={{
+					borderTopRightRadius: '0px',
+					borderTopLeftRadius: '0px',
 				}}
 			/>
 		</OrderSizingContainer>

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Wei, { wei } from '@synthetixio/wei';
+import { useTranslation } from 'react-i18next';
 
 import BaseModal from 'components/BaseModal';
 import { formatCurrency } from 'utils/formatters/number';
@@ -34,6 +35,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	sUSDBalance,
 	market,
 }) => {
+	const { t } = useTranslation();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
@@ -116,9 +118,13 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	}, [sUSDBalance]);
 
 	return (
-		<StyledBaseModal title="Deposit Margin" isOpen={true} onDismiss={onDismiss}>
+		<StyledBaseModal
+			title={t('futures.market.trade.margin.modal.deposit.title')}
+			isOpen={true}
+			onDismiss={onDismiss}
+		>
 			<BalanceContainer>
-				<BalanceText $gold>Balance:</BalanceText>
+				<BalanceText $gold>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
 				<BalanceText>
 					<span>{formatCurrency(Synths.sUSD, sUSDBalance, { sign: '$' })}</span> sUSD
 				</BalanceText>
@@ -127,19 +133,21 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 				placeholder={PLACEHOLDER}
 				value={amount}
 				onChange={(_, v) => setAmount(v)}
-				right={<MaxButton onClick={handleSetMax}>Max</MaxButton>}
+				right={
+					<MaxButton onClick={handleSetMax}>{t('futures.market.trade.margin.modal.max')}</MaxButton>
+				}
 			/>
 
 			<MinimumAmountDisclaimer>
-				A $50 margin minimum is required to open a position.
+				{t('futures.market.trade.margin.modal.deposit.disclaimer')}
 			</MinimumAmountDisclaimer>
 
 			<MarginActionButton disabled={disabled} fullWidth onClick={() => depositTxn.mutate()}>
-				Deposit Margin
+				{t('futures.market.trade.margin.modal.deposit.button')}
 			</MarginActionButton>
 
 			<GasFeeContainer>
-				<BalanceText>Gas Fee:</BalanceText>
+				<BalanceText>{t('futures.market.trade.margin.modal.gas-fee')}:</BalanceText>
 				<BalanceText>
 					<span>
 						{transactionFee

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -41,7 +41,6 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
 	const [amount, setAmount] = React.useState<string>('');
 	const [disabled, setDisabled] = React.useState<boolean>(true);
-	const [error, setError] = React.useState<string | null>(null);
 
 	const ethGasPriceQuery = useEthGasPriceQuery();
 	const exchangeRatesQuery = useExchangeRatesQuery();
@@ -60,9 +59,9 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	const gasPrice = ethGasPriceQuery.data != null ? ethGasPriceQuery.data[gasSpeed] : null;
 
 	const depositTxn = useSynthetixTxn(
-		`FuturesMarket${market?.substring(1)}`,
+		`FuturesMarket${market?.[0] === 's' ? market?.substring(1) : market}`,
 		'transferMargin',
-		[wei(!!amount ? amount : 0).toBN()],
+		[wei(amount || 0).toBN()],
 		gasPrice || undefined,
 		{ enabled: !!market && !!amount && !disabled }
 	);
@@ -77,12 +76,6 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 			),
 		[gasPrice, ethPriceRate, depositTxn.gasLimit, depositTxn.optimismLayerOneFee]
 	);
-
-	React.useEffect(() => {
-		if (depositTxn.errorMessage) {
-			setError(depositTxn.errorMessage);
-		}
-	}, [depositTxn.errorMessage]);
 
 	React.useEffect(() => {
 		if (!amount) {
@@ -157,7 +150,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 				</BalanceText>
 			</GasFeeContainer>
 
-			{error && <ErrorMessage>{error}</ErrorMessage>}
+			{depositTxn.errorMessage && <ErrorMessage>{depositTxn.errorMessage}</ErrorMessage>}
 		</StyledBaseModal>
 	);
 };

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -5,7 +5,6 @@ import Wei, { wei } from '@synthetixio/wei';
 import BaseModal from 'components/BaseModal';
 import { formatCurrency } from 'utils/formatters/number';
 import { Synths } from 'constants/currency';
-import InfoBox from 'components/InfoBox';
 import Button from 'components/Button';
 import { FlexDivRowCentered } from 'styles/common';
 import useSynthetixQueries from '@synthetixio/queries';
@@ -119,7 +118,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	return (
 		<StyledBaseModal title="Deposit Margin" isOpen={true} onDismiss={onDismiss}>
 			<BalanceContainer>
-				<BalanceText>Balance:</BalanceText>
+				<BalanceText $gold>Balance:</BalanceText>
 				<BalanceText>
 					<span>{formatCurrency(Synths.sUSD, sUSDBalance, { sign: '$' })}</span> sUSD
 				</BalanceText>
@@ -130,61 +129,62 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 				onChange={(_, v) => setAmount(v)}
 				right={<MaxButton onClick={handleSetMax}>Max</MaxButton>}
 			/>
+
 			<MinimumAmountDisclaimer>
-				Note: Placing an order requires a minimum deposit of 50 sUSD.
+				A $50 margin minimum is required to open a position.
 			</MinimumAmountDisclaimer>
-			<StyledInfoBox
-				details={{
-					'Gas Fee': transactionFee
-						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
-						: NO_VALUE,
-				}}
-			/>
-			<DepositMarginButton disabled={disabled} fullWidth onClick={() => depositTxn.mutate()}>
+
+			<MarginActionButton disabled={disabled} fullWidth onClick={() => depositTxn.mutate()}>
 				Deposit Margin
-			</DepositMarginButton>
+			</MarginActionButton>
+
+			<GasFeeContainer>
+				<BalanceText>Gas Fee:</BalanceText>
+				<BalanceText>
+					<span>
+						{transactionFee
+							? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
+							: NO_VALUE}
+					</span>
+				</BalanceText>
+			</GasFeeContainer>
 
 			{error && <ErrorMessage>{error}</ErrorMessage>}
 		</StyledBaseModal>
 	);
 };
 
-const StyledBaseModal = styled(BaseModal)`
+export const StyledBaseModal = styled(BaseModal)`
 	[data-reach-dialog-content] {
 		width: 400px;
 	}
-
 	.card-body {
 		padding: 28px;
 	}
 `;
 
-const BalanceContainer = styled(FlexDivRowCentered)`
+export const BalanceContainer = styled(FlexDivRowCentered)`
 	margin-bottom: 8px;
 	padding: 0 14px;
-
 	p {
 		margin: 0;
 	}
 `;
 
-const BalanceText = styled.p`
-	color: ${(props) => props.theme.colors.common.secondaryGray};
+export const BalanceText = styled.p<{ $gold?: boolean }>`
+	color: ${(props) =>
+		props.$gold ? props.theme.colors.common.primaryGold : props.theme.colors.common.secondaryGray};
 	span {
 		color: ${(props) => props.theme.colors.common.primaryWhite};
 	}
 `;
 
-const StyledInfoBox = styled(InfoBox)`
-	margin-top: 15px;
-	margin-bottom: 15px;
-`;
-
-const DepositMarginButton = styled(Button)`
+export const MarginActionButton = styled(Button)`
+	margin-top: 16px;
 	height: 55px;
 `;
 
-const MaxButton = styled.button`
+export const MaxButton = styled.button`
 	height: 22px;
 	padding: 4px 10px;
 	background: ${(props) => props.theme.colors.selectedTheme.button.background};
@@ -200,12 +200,21 @@ const MaxButton = styled.button`
 const MinimumAmountDisclaimer = styled.div`
 	font-size: 12px;
 	margin-top: 8px;
+	color: ${(props) => props.theme.colors.common.primaryWhite};
+	text-align: center;
+`;
+
+export const ErrorMessage = styled.div`
+	margin-top: 16px;
 	color: ${(props) => props.theme.colors.common.secondaryGray};
 `;
 
-const ErrorMessage = styled.div`
-	margin-top: 16px;
-	color: ${(props) => props.theme.colors.common.secondaryGray};
+export const GasFeeContainer = styled(FlexDivRowCentered)`
+	margin-top: 13px;
+	padding: 0 14px;
+	p {
+		margin: 0;
+	}
 `;
 
 export default DepositMarginModal;

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -40,7 +40,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
 	const [amount, setAmount] = React.useState<string>('');
-	const [disabled, setDisabled] = React.useState<boolean>(true);
+	const [isDisabled, setDisabled] = React.useState<boolean>(true);
 
 	const ethGasPriceQuery = useEthGasPriceQuery();
 	const exchangeRatesQuery = useExchangeRatesQuery();
@@ -63,7 +63,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 		'transferMargin',
 		[wei(amount || 0).toBN()],
 		gasPrice || undefined,
-		{ enabled: !!market && !!amount && !disabled }
+		{ enabled: !!market && !!amount && !isDisabled }
 	);
 
 	const transactionFee = React.useMemo(
@@ -90,7 +90,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 		} else {
 			setDisabled(true);
 		}
-	}, [amount, disabled, sUSDBalance, setDisabled]);
+	}, [amount, isDisabled, sUSDBalance, setDisabled]);
 
 	React.useEffect(() => {
 		if (depositTxn.hash) {
@@ -135,7 +135,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 				{t('futures.market.trade.margin.modal.deposit.disclaimer')}
 			</MinimumAmountDisclaimer>
 
-			<MarginActionButton disabled={disabled} fullWidth onClick={() => depositTxn.mutate()}>
+			<MarginActionButton disabled={isDisabled} fullWidth onClick={() => depositTxn.mutate()}>
 				{t('futures.market.trade.margin.modal.deposit.button')}
 			</MarginActionButton>
 

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -61,7 +61,7 @@ const DepositMarginModal: React.FC<DepositMarginModalProps> = ({
 	const depositTxn = useSynthetixTxn(
 		`FuturesMarket${market?.substring(1)}`,
 		'transferMargin',
-		[wei(amount).toBN()],
+		[wei(!!amount ? amount : 0).toBN()],
 		gasPrice || undefined,
 		{ enabled: !!market && !!amount && !disabled }
 	);

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -37,11 +37,11 @@ const assetToCurrencyOption = (
 	negativeChange: boolean
 ): MarketsCurrencyOption => ({
 	value: asset as CurrencyKey,
-	label: `${asset.slice(1)}-PERP`,
+	label: `${asset[0] === 's' ? asset.slice(1) : asset}-PERP`,
 	description,
 	price,
 	change,
-	negativeChange
+	negativeChange,
 });
 
 type Props = {
@@ -65,7 +65,6 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 	const { t } = useTranslation();
 
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
-	const dailyPriceChanges = dailyPriceChangesQuery?.data ?? [];
 
 	const getSynthDescription = React.useCallback(
 		(synth: string) => {
@@ -78,10 +77,11 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 
 	const options = React.useMemo(() => {
 		const markets = futuresMarketsQuery?.data ?? [];
+		const dailyPriceChanges = dailyPriceChangesQuery?.data ?? [];
 
 		return markets.map((market) => {
 			const pastPrice = dailyPriceChanges.find((price: Price) => price.synth === market.asset);
-			
+
 			const basePriceRate = getExchangeRatesForCurrencies(
 				exchangeRates,
 				market.asset,
@@ -93,16 +93,24 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 				getSynthDescription(market.asset),
 				formatCurrency(selectedPriceCurrency.name, basePriceRate, { sign: '$' }),
 				formatPercent(
-					basePriceRate && pastPrice?.price ?
-						wei(basePriceRate).sub(pastPrice?.price).div(basePriceRate)
+					basePriceRate && pastPrice?.price
+						? wei(basePriceRate).sub(pastPrice?.price).div(basePriceRate)
 						: zeroBN
 				),
-				basePriceRate && pastPrice?.price ?
-					wei(basePriceRate).lt(pastPrice?.price) ? true : false
+				basePriceRate && pastPrice?.price
+					? wei(basePriceRate).lt(pastPrice?.price)
+						? true
+						: false
 					: false
 			);
 		});
-	}, [getSynthDescription, selectedPriceCurrency.name, exchangeRates, futuresMarketsQuery?.data, dailyPriceChangesQuery?.data]);
+	}, [
+		getSynthDescription,
+		selectedPriceCurrency.name,
+		exchangeRates,
+		futuresMarketsQuery?.data,
+		dailyPriceChangesQuery?.data,
+	]);
 
 	return (
 		<SelectContainer>
@@ -116,7 +124,13 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 						router.push(ROUTES.Markets.MarketPair(x.value));
 					}
 				}}
-				value={assetToCurrencyOption(asset, getSynthDescription(asset), DUMMY_PRICE, DUMMY_CHANGE, false)}
+				value={assetToCurrencyOption(
+					asset,
+					getSynthDescription(asset),
+					DUMMY_PRICE,
+					DUMMY_CHANGE,
+					false
+				)}
 				options={options}
 				isSearchable={false}
 				components={{

--- a/sections/futures/Trade/MarketsDropdownOption.tsx
+++ b/sections/futures/Trade/MarketsDropdownOption.tsx
@@ -7,7 +7,11 @@ import { components, OptionProps } from 'react-select';
 const MarketsDropdownOption: React.FC<OptionProps<any>> = (props) => (
 	<components.Option {...props}>
 		<OptionDetailsContainer $isSelected={props.isSelected}>
-			<CurrencyIcon currencyKey={props.data.value} width="31px" height="31px" />
+			<CurrencyIcon
+				currencyKey={(props.data.value[0] !== 's' ? 's' : '') + props.data.value}
+				width="31px"
+				height="31px"
+			/>
 			<CurrencyMeta $isSelected={props.isSelected}>
 				<div>
 					<CurrencyLabel>{props.data.label}</CurrencyLabel>

--- a/sections/futures/Trade/MarketsDropdownOption.tsx
+++ b/sections/futures/Trade/MarketsDropdownOption.tsx
@@ -16,7 +16,9 @@ const MarketsDropdownOption: React.FC<OptionProps<any>> = (props) => (
 			</CurrencyMeta>
 			<div>
 				<p className="price">{props.data.price}</p>
-				<p className={props.data.negativeChange ? `change red` : 'change green'}>{props.data.change}</p>
+				<p className={props.data.negativeChange ? `change red` : 'change green'}>
+					{props.data.change}
+				</p>
 			</div>
 		</OptionDetailsContainer>
 	</components.Option>

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useEffect } from 'react';
 import styled from 'styled-components';
-// import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import useSynthetixQueries from '@synthetixio/queries';
 import { useRecoilValue } from 'recoil';
 import Wei, { wei } from '@synthetixio/wei';
@@ -39,7 +39,7 @@ type TradeProps = {};
 const DEFAULT_MAX_LEVERAGE = wei(10);
 
 const Trade: React.FC<TradeProps> = () => {
-	// const { t } = useTranslation();
+	const { t } = useTranslation();
 	const walletAddress = useRecoilValue(walletAddressState);
 	const {
 		useExchangeRatesQuery,
@@ -249,10 +249,10 @@ const Trade: React.FC<TradeProps> = () => {
 			<MarketsDropdown asset={marketAsset || Synths.sUSD} />
 			<MarketActions>
 				<MarketActionButton onClick={() => setIsDepositMarginModalOpen(true)}>
-					Deposit
+					{t('futures.market.trade.button.deposit')}
 				</MarketActionButton>
 				<MarketActionButton onClick={() => setIsWithdrawMarginModalOpen(true)}>
-					Withdraw
+					{t('futures.market.trade.button.withdraw')}
 				</MarketActionButton>
 			</MarketActions>
 
@@ -313,7 +313,9 @@ const Trade: React.FC<TradeProps> = () => {
 					setIsTradeConfirmationModalOpen(true);
 				}}
 			>
-				{futuresMarketsPosition?.position ? 'Modify Position' : 'Open Position'}
+				{!!futuresMarketsPosition?.position
+					? t('futures.market.trade.button.modify-position')
+					: t('futures.market.trade.button.open-position')}
 			</PlaceOrderButton>
 
 			{(orderTxn.errorMessage || error) && (

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -117,17 +117,17 @@ const Trade: React.FC<TradeProps> = () => {
 		[marketAssetRate]
 	);
 
-    useEffect(() => {
-        const handleRouteChange = () => {
-            setTradeSize('');
-            setTradeSizeSUSD('');
-        };
-        router.events.on('routeChangeStart', handleRouteChange);
+	useEffect(() => {
+		const handleRouteChange = () => {
+			setTradeSize('');
+			setTradeSizeSUSD('');
+		};
+		router.events.on('routeChangeStart', handleRouteChange);
 
-        return () => {
-            router.events.off('routeChangeStart', handleRouteChange);
-        };
-    }, [router.events]);
+		return () => {
+			router.events.off('routeChangeStart', handleRouteChange);
+		};
+	}, [router.events]);
 
 	useEffect(() => {
 		if (Number(tradeSize) && !!futuresMarketsPosition?.remainingMargin) {

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -118,11 +118,7 @@ const Trade: React.FC<TradeProps> = () => {
 	);
 
 	useEffect(() => {
-		if (
-			Number(tradeSize) &&
-			marketAssetRate.toNumber() &&
-			Number(futuresMarketsPosition?.remainingMargin.toString())
-		) {
+		if (Number(tradeSize) && !!futuresMarketsPosition?.remainingMargin) {
 			setLeverage(
 				marketAssetRate
 					.mul(Number(tradeSize))

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -124,7 +124,7 @@ const Trade: React.FC<TradeProps> = () => {
 			setLeverage(
 				marketAssetRate
 					.mul(Number(tradeSize))
-					.div(Number(futuresMarketsPosition?.remainingMargin.toString()))
+					.div(futuresMarketsPosition?.remainingMargin)
 					.toString()
 			);
 		} else {
@@ -149,8 +149,9 @@ const Trade: React.FC<TradeProps> = () => {
 				setLeverage(value);
 				const newTradeSize = marketAssetRate.eq(0)
 					? 0
-					: (Number(value) * Number(futuresMarketsPosition?.remainingMargin?.toString() ?? 0)) /
-					  marketAssetRate.toNumber();
+					: wei(value)
+							.mul(futuresMarketsPosition?.remainingMargin ?? zeroBN)
+							.div(marketAssetRate);
 
 				onTradeAmountChange(newTradeSize.toString());
 			}
@@ -211,12 +212,6 @@ const Trade: React.FC<TradeProps> = () => {
 				Number(leverage) >= 0 &&
 				maxLeverageValue.gte(Number(leverage)) &&
 				!error,
-			onSuccess: (data) => {
-				console.log(data);
-			},
-			onError: (error) => {
-				setError(error as string);
-			},
 		}
 	);
 
@@ -234,14 +229,9 @@ const Trade: React.FC<TradeProps> = () => {
 				},
 			});
 		}
-	}, [
-		orderTxn.hash,
-		futuresMarketPositionQuery,
-		onLeverageChange,
-		marketQuery,
-		monitorTransaction,
-		futuresPositionHistoryQuery,
-	]);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [orderTxn.hash]);
 
 	useEffect(() => {
 		if (orderTxn.errorMessage) {

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -212,7 +212,7 @@ const Trade: React.FC<TradeProps> = () => {
 	]);
 
 	const orderTxn = useSynthetixTxn(
-		`FuturesMarket${marketAsset?.substring(1)}`,
+		`FuturesMarket${marketAsset?.[0] === 's' ? marketAsset?.substring(1) : marketAsset}`,
 		'modifyPosition',
 		[sizeDelta.toBN()],
 		gasPrice,

--- a/sections/futures/Trade/WithdrawMarginModal.tsx
+++ b/sections/futures/Trade/WithdrawMarginModal.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Wei, { wei } from '@synthetixio/wei';
+import { useTranslation } from 'react-i18next';
+import useSynthetixQueries from '@synthetixio/queries';
+
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRecoilValue } from 'recoil';
 import { gasSpeedState } from 'store/wallet';
-import useSynthetixQueries from '@synthetixio/queries';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
 import { Synths } from 'constants/currency';
@@ -38,6 +40,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	accessibleMargin,
 	market,
 }) => {
+	const { t } = useTranslation();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
@@ -130,9 +133,13 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	}, [accessibleMargin]);
 
 	return (
-		<StyledBaseModal title="Withdraw Margin" isOpen={true} onDismiss={onDismiss}>
+		<StyledBaseModal
+			title={t('futures.market.trade.margin.modal.withdraw.title')}
+			isOpen={true}
+			onDismiss={onDismiss}
+		>
 			<BalanceContainer>
-				<BalanceText $gold>Balance:</BalanceText>
+				<BalanceText $gold>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
 				<BalanceText>
 					<span>{formatCurrency(Synths.sUSD, accessibleMargin, { sign: '$' })}</span> sUSD
 				</BalanceText>
@@ -145,15 +152,17 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 					if (isMax) setMax(false);
 					setAmount(v);
 				}}
-				right={<MaxButton onClick={handleSetMax}>Max</MaxButton>}
+				right={
+					<MaxButton onClick={handleSetMax}>{t('futures.market.trade.margin.modal.max')}</MaxButton>
+				}
 			/>
 
 			<MarginActionButton disabled={disabled} fullWidth onClick={() => withdrawTxn.mutate()}>
-				Withdraw Margin
+				{t('futures.market.trade.margin.modal.withdraw.button')}
 			</MarginActionButton>
 
 			<GasFeeContainer>
-				<BalanceText>Gas Fee:</BalanceText>
+				<BalanceText>{t('futures.market.trade.margin.modal.gas-fee')}:</BalanceText>
 				<BalanceText>
 					<span>
 						{transactionFee

--- a/sections/futures/Trade/WithdrawMarginModal.tsx
+++ b/sections/futures/Trade/WithdrawMarginModal.tsx
@@ -45,7 +45,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
 	const [amount, setAmount] = React.useState<string>('');
-	const [disabled, setDisabled] = React.useState<boolean>(true);
+	const [isDisabled, setDisabled] = React.useState<boolean>(true);
 	const [isMax, setMax] = React.useState(false);
 
 	const ethGasPriceQuery = useEthGasPriceQuery();
@@ -117,7 +117,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 		} else {
 			setDisabled(true);
 		}
-	}, [amount, disabled, accessibleMargin, setDisabled]);
+	}, [amount, isDisabled, accessibleMargin, setDisabled]);
 
 	const handleSetMax = React.useCallback(() => {
 		setMax(true);
@@ -149,7 +149,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 				}
 			/>
 
-			<MarginActionButton disabled={disabled} fullWidth onClick={() => withdrawTxn.mutate()}>
+			<MarginActionButton disabled={isDisabled} fullWidth onClick={() => withdrawTxn.mutate()}>
 				{t('futures.market.trade.margin.modal.withdraw.button')}
 			</MarginActionButton>
 

--- a/sections/futures/Trade/WithdrawMarginModal.tsx
+++ b/sections/futures/Trade/WithdrawMarginModal.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
 import Wei, { wei } from '@synthetixio/wei';
-import BaseModal from 'components/BaseModal';
-import Button from 'components/Button';
-import InfoBox from 'components/InfoBox';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRecoilValue } from 'recoil';
 import { gasSpeedState } from 'store/wallet';
@@ -13,9 +9,17 @@ import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
 import { Synths } from 'constants/currency';
 import { newGetTransactionPrice } from 'utils/network';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
-import { FlexDivRowCentered } from 'styles/common';
 import { NO_VALUE } from 'constants/placeholder';
 import CustomInput from 'components/Input/CustomInput';
+import {
+	StyledBaseModal,
+	BalanceContainer,
+	BalanceText,
+	GasFeeContainer,
+	MaxButton,
+	ErrorMessage,
+	MarginActionButton,
+} from './DepositMarginModal';
 
 type WithdrawMarginModalProps = {
 	onDismiss(): void;
@@ -128,11 +132,12 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	return (
 		<StyledBaseModal title="Withdraw Margin" isOpen={true} onDismiss={onDismiss}>
 			<BalanceContainer>
-				<BalanceText>Balance:</BalanceText>
+				<BalanceText $gold>Balance:</BalanceText>
 				<BalanceText>
 					<span>{formatCurrency(Synths.sUSD, accessibleMargin, { sign: '$' })}</span> sUSD
 				</BalanceText>
 			</BalanceContainer>
+
 			<CustomInput
 				placeholder={PLACEHOLDER}
 				value={amount}
@@ -143,73 +148,24 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 				right={<MaxButton onClick={handleSetMax}>Max</MaxButton>}
 			/>
 
-			<StyledInfoBox
-				details={{
-					'Gas Fee': transactionFee
-						? formatCurrency(Synths.sUSD, transactionFee, { sign: '$' })
-						: NO_VALUE,
-				}}
-			/>
-			<DepositMarginButton disabled={disabled} fullWidth onClick={() => withdrawTxn.mutate()}>
+			<MarginActionButton disabled={disabled} fullWidth onClick={() => withdrawTxn.mutate()}>
 				Withdraw Margin
-			</DepositMarginButton>
+			</MarginActionButton>
+
+			<GasFeeContainer>
+				<BalanceText>Gas Fee:</BalanceText>
+				<BalanceText>
+					<span>
+						{transactionFee
+							? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
+							: NO_VALUE}
+					</span>
+				</BalanceText>
+			</GasFeeContainer>
 
 			{error && <ErrorMessage>{error}</ErrorMessage>}
 		</StyledBaseModal>
 	);
 };
-
-const StyledBaseModal = styled(BaseModal)`
-	[data-reach-dialog-content] {
-		width: 400px;
-	}
-
-	.card-body {
-		padding: 28px;
-	}
-`;
-
-const BalanceContainer = styled(FlexDivRowCentered)`
-	margin-bottom: 8px;
-	padding: 0 14px;
-
-	p {
-		margin: 0;
-	}
-`;
-
-const BalanceText = styled.p`
-	color: ${(props) => props.theme.colors.common.secondaryGray};
-	span {
-		color: ${(props) => props.theme.colors.common.primaryWhite};
-	}
-`;
-
-const StyledInfoBox = styled(InfoBox)`
-	margin-top: 15px;
-	margin-bottom: 15px;
-`;
-
-const DepositMarginButton = styled(Button)`
-	height: 55px;
-`;
-
-const MaxButton = styled.button`
-	height: 22px;
-	padding: 4px 10px;
-	background: ${(props) => props.theme.colors.selectedTheme.button.background};
-	border-radius: 11px;
-	font-family: ${(props) => props.theme.fonts.mono};
-	font-size: 13px;
-	line-height: 13px;
-	border: ${(props) => props.theme.colors.selectedTheme.border};
-	color: ${(props) => props.theme.colors.common.primaryWhite};
-	cursor: pointer;
-`;
-
-const ErrorMessage = styled.div`
-	font-size: 12px;
-	color: ${(props) => props.theme.colors.common.secondaryGray};
-`;
 
 export default WithdrawMarginModal;

--- a/sections/futures/Trade/WithdrawMarginModal.tsx
+++ b/sections/futures/Trade/WithdrawMarginModal.tsx
@@ -5,18 +5,15 @@ import BaseModal from 'components/BaseModal';
 import Button from 'components/Button';
 import InfoBox from 'components/InfoBox';
 import TransactionNotifier from 'containers/TransactionNotifier';
-import Connector from 'containers/Connector';
 import { useRecoilValue } from 'recoil';
 import { gasSpeedState } from 'store/wallet';
 import useSynthetixQueries from '@synthetixio/queries';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
 import { Synths } from 'constants/currency';
-import { parseGasPriceObject } from 'hooks/useGas';
-import { gasPriceInWei, getTransactionPrice } from 'utils/network';
-import { formatCurrency } from 'utils/formatters/number';
+import { newGetTransactionPrice } from 'utils/network';
+import { formatCurrency, zeroBN } from 'utils/formatters/number';
 import { FlexDivRowCentered } from 'styles/common';
-import { getFuturesMarketContract } from 'queries/futures/utils';
 import { NO_VALUE } from 'constants/placeholder';
 import CustomInput from 'components/Input/CustomInput';
 
@@ -37,14 +34,12 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	accessibleMargin,
 	market,
 }) => {
-	const { synthetixjs } = Connector.useContainer();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const gasSpeed = useRecoilValue(gasSpeedState);
-	const { useEthGasPriceQuery, useExchangeRatesQuery } = useSynthetixQueries();
+	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
 	const [amount, setAmount] = React.useState<string>('');
 	const [disabled, setDisabled] = React.useState<boolean>(true);
 	const [error, setError] = React.useState<string | null>(null);
-	const [gasLimit, setGasLimit] = React.useState<number | null>(null);
 	const [isMax, setMax] = React.useState(false);
 
 	const ethGasPriceQuery = useEthGasPriceQuery();
@@ -57,64 +52,58 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 	);
 
 	const ethPriceRate = React.useMemo(
-		() => getExchangeRatesForCurrencies(exchangeRates, Synths.sETH, selectedPriceCurrency.name),
+		() => newGetExchangeRatesForCurrencies(exchangeRates, Synths.sETH, selectedPriceCurrency.name),
 		[exchangeRates, selectedPriceCurrency.name]
 	);
 
-	const gasPrices = React.useMemo(
-		() => (ethGasPriceQuery.isSuccess ? ethGasPriceQuery?.data ?? undefined : undefined),
-		[ethGasPriceQuery.isSuccess, ethGasPriceQuery.data]
+	const gasPrice = ethGasPriceQuery.data != null ? ethGasPriceQuery.data[gasSpeed] : null;
+
+	const computedAmount = React.useMemo(
+		() =>
+			accessibleMargin.eq(!!amount ? wei(amount) : zeroBN)
+				? accessibleMargin.mul(wei(-1)).toBN()
+				: wei(-amount).toBN(),
+		[amount, accessibleMargin]
 	);
 
-	const gasPrice = ethGasPriceQuery?.data?.[gasSpeed]
-		? parseGasPriceObject(ethGasPriceQuery?.data?.[gasSpeed])
-		: null;
+	const withdrawTxn = useSynthetixTxn(
+		`FuturesMarket${market?.substring(1)}`,
+		isMax ? 'withdrawAllMargin' : 'transferMargin',
+		isMax ? [] : [computedAmount],
+		gasPrice || undefined,
+		{ enabled: !!market && !!amount }
+	);
 
 	const transactionFee = React.useMemo(
-		() => getTransactionPrice(gasPrice, gasLimit, ethPriceRate),
-		[gasPrice, gasLimit, ethPriceRate]
+		() =>
+			newGetTransactionPrice(
+				gasPrice,
+				withdrawTxn.gasLimit,
+				ethPriceRate,
+				withdrawTxn.optimismLayerOneFee
+			),
+		[gasPrice, ethPriceRate, withdrawTxn.gasLimit, withdrawTxn.optimismLayerOneFee]
 	);
 
-	const computeAmount = React.useCallback(() => {
-		return amount === accessibleMargin.toString()
-			? accessibleMargin.mul(wei(-1)).toBN()
-			: wei(-amount).toBN();
-	}, [amount, accessibleMargin]);
+	React.useEffect(() => {
+		if (withdrawTxn.hash) {
+			monitorTransaction({
+				txHash: withdrawTxn.hash,
+				onTxConfirmed: () => {
+					onTxConfirmed();
+					onDismiss();
+				},
+			});
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [withdrawTxn.hash]);
 
 	React.useEffect(() => {
-		const getGasLimit = async () => {
-			if (!market || !synthetixjs) return;
-			try {
-				setError(null);
-				if (!amount) return;
-				const FuturesMarketContract = getFuturesMarketContract(market, synthetixjs!.contracts);
-				const marginAmount = computeAmount();
-
-				let estimate;
-
-				if (isMax) {
-					estimate = await FuturesMarketContract.estimateGas.withdrawAllMargin();
-				} else {
-					estimate = await FuturesMarketContract.estimateGas.transferMargin(
-						wei(marginAmount).toBN()
-					);
-				}
-
-				setGasLimit(Number(estimate));
-			} catch (e) {
-				// @ts-ignore
-				console.log(e.message);
-				// @ts-ignore
-				if (e?.code === -32603) {
-					setError('Input amount exceeds max withdrawable amount.');
-				} else {
-					// @ts-ignore
-					setError(e?.data?.message ?? e.message);
-				}
-			}
-		};
-		getGasLimit();
-	}, [amount, market, synthetixjs, computeAmount, isMax]);
+		if (withdrawTxn.errorMessage) {
+			console.log(withdrawTxn.errorMessage);
+			setError(withdrawTxn.errorMessage);
+		}
+	}, [withdrawTxn.errorMessage]);
 
 	React.useEffect(() => {
 		if (!amount) {
@@ -130,43 +119,6 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 			setDisabled(true);
 		}
 	}, [amount, disabled, accessibleMargin, setDisabled]);
-
-	const handleWithdraw = async () => {
-		if (!amount || !gasLimit || !market || !gasPrice) return;
-		try {
-			const FuturesMarketContract = getFuturesMarketContract(market, synthetixjs!.contracts);
-
-			let tx;
-
-			if (isMax) {
-				tx = await FuturesMarketContract.withdrawAllMargin({
-					gasLimit,
-					gasPrice: gasPriceInWei(gasPrice),
-				});
-			} else {
-				const marginAmount = computeAmount();
-
-				tx = await FuturesMarketContract.transferMargin(wei(marginAmount).toBN(), {
-					gasLimit,
-					gasPrice: gasPriceInWei(gasPrice),
-				});
-			}
-
-			if (tx != null) {
-				monitorTransaction({
-					txHash: tx.hash,
-					onTxConfirmed: () => {
-						onTxConfirmed();
-						onDismiss();
-					},
-				});
-			}
-		} catch (e) {
-			console.log(e);
-			// @ts-ignore
-			setError(e?.data?.message ?? e.message);
-		}
-	};
 
 	const handleSetMax = React.useCallback(() => {
 		setMax(true);
@@ -198,7 +150,7 @@ const WithdrawMarginModal: React.FC<WithdrawMarginModalProps> = ({
 						: NO_VALUE,
 				}}
 			/>
-			<DepositMarginButton disabled={disabled} fullWidth onClick={handleWithdraw}>
+			<DepositMarginButton disabled={disabled} fullWidth onClick={() => withdrawTxn.mutate()}>
 				Withdraw Margin
 			</DepositMarginButton>
 

--- a/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
+++ b/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
@@ -5,6 +5,7 @@ import Tippy from '@tippyjs/react';
 import { customGasPriceState, gasSpeedState, isL2State } from 'store/wallet';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import { Svg } from 'react-optimized-image';
+import Wei from '@synthetixio/wei';
 
 import { NO_VALUE, ESTIMATE_VALUE } from 'constants/placeholder';
 
@@ -26,7 +27,7 @@ import { parseGasPriceObject } from 'hooks/useGas';
 
 type GasPriceSelectProps = {
 	gasPrices: GasPrices | undefined;
-	transactionFee?: number | null;
+	transactionFee?: Wei | number | null;
 	className?: string;
 };
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -642,10 +642,13 @@
 					"deposit-margin": "Deposit margin",
 					"withdraw-margin": "Withdraw margin",
 					"deposit": "Deposit",
+					"withdraw": "Withdraw",
 					"edit": "Edit",
 					"open-trade": "Submit order",
 					"warning": "WARNING: this will close your position",
-					"competition-closed": "Competition Closed"
+					"competition-closed": "Competition Closed",
+					"open-position": "Open Position",
+					"modify-position": "Modify Position"
 				},
 				"margin": {
 					"deposit-susd": "Deposit your sUSD to start trading",
@@ -655,6 +658,18 @@
 					"available-balance": "sUSD balance",
 					"balance": "Balance",
 					"modal": {
+						"balance": "Balance",
+						"gas-fee": "Gas Fee",
+						"max": "Max",
+						"deposit": {
+							"title": "Deposit Margin",
+							"button": "Deposit Margin",
+							"disclaimer": "A $50 margin minimum is required to open a position."
+						},
+						"withdraw": {
+							"title": "Withdraw Margin",
+							"button": "Withdraw Margin"
+						},
 						"title": "Edit margin",
 						"actions": {
 							"withdraw": "Withdraw",

--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -1,5 +1,6 @@
 import { CurrencyKey, Synths, CRYPTO_CURRENCY_MAP, FIAT_SYNTHS } from 'constants/currency';
 import { Rates } from '@synthetixio/queries';
+import { wei } from '@synthetixio/wei';
 
 export const isSynth = (currencyKey: CurrencyKey) => !!Synths[currencyKey];
 export const isCryptoCurrency = (currencyKey: CurrencyKey) => !!CRYPTO_CURRENCY_MAP[currencyKey];
@@ -25,6 +26,12 @@ export const getExchangeRatesForCurrencies = (
 	rates[quote] === undefined
 		? 0
 		: rates[base].toNumber() * (1 / rates[quote].toNumber());
+
+export const newGetExchangeRatesForCurrencies = (
+	rates: Rates | null,
+	base: CurrencyKey | null,
+	quote: CurrencyKey | null
+) => (rates == null || base == null || quote == null ? wei(0) : rates[base].div(rates[quote]));
 
 export const getCurrencyKeyURLPath = (currencyKey: CurrencyKey) =>
 	`https:///www.synthetix.io/assets/synths/svg/${currencyKey}.svg`;


### PR DESCRIPTION
## Description
This PR uses the `useSynthetixTxn` hook from the `@synthetixio/queries` to handle making order modification transactions on the futures page and deposit/withdraw modals. This is handy, because it removes the need to manually estimate gas for the modifyGas function, while also making sure that the transaction fee calculations are accurate, due to the addition of the `optimismLayerOneFee` required for the transaction fee estimation. It also features design-related updates to the looks of the deposit and withdraw modals.

Note: This PR does not include changes required to move the rest of the application to using this hook, since that would require a significant amount of work, not within the scope of the task which this PR addresses. However, the changes made in this PR can be adapted for use in other parts of the application that deal with transactions and/or gas estimation.

## Related issue
N/A

## Motivation and Context
This PR solves issues related to incorrect or obscure gas pricing information when making transactions on the futures page.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
