### PR TITLE
added handleRouteChange to Trade.tsx to reset input fields

### DIFF
--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -123,6 +123,18 @@ const Trade: React.FC<TradeProps> = () => {
 		setTradeSizeSUSD(value === '' ? '' : (Number(value) * marketAssetRate).toString());
 	};
 
+    useEffect(() => {
+        const handleRouteChange = () => {
+            setTradeSize('');
+            setTradeSizeSUSD('');
+        };
+        router.events.on('routeChangeStart', handleRouteChange);
+
+        return () => {
+            router.events.off('routeChangeStart', handleRouteChange);
+        };
+    }, [router.events]);
+
 	useEffect(() => {
 		// We should probably compute this using Wei(). Problem is exchangeRates return numbers.
 		if (


### PR DESCRIPTION
## Description
Inside Trade.tsx, I added a useEffect that uses useRouter to listen for 'routeChangeStart' router.events. Whenever the URL is changed, that will trigger the event. Currently whenever a use changes the market asset, BTC-PERP to ETH-PERP, that will then change the URL. Now whenever that event is triggered, the TradeSize and TradeSizeSUSD fields are reset to blank values, an empty string. 

## Related issue
https://github.com/Kwenta/kwenta/issues/489

## Motivation and Context
Whenever a user changes from one market asset to another, the input field values will likely not apply to the asset with a different price. Its best to reset the input fields when a user changes to a different market asset.

## How Has This Been Tested?
I tested the commit using npm run dev with metamask in a brave browser, both on L1 & L2. When changing between market assets, the input fields (tradeSize & tradeSizeSUSD) are now reset each time. I did not find any other code affected by adding this useEffect.

## Screenshots (if appropriate):
<img width="799" alt="Screen Shot 2022-03-29 at 12 47 22 PM" src="https://user-images.githubusercontent.com/83140889/160673542-32878e2e-953b-4ed9-9149-70c00835514d.png">