### PR TITLE
dynamic list of shortable assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"bnc-onboard": "1.37.3",
 		"date-fns": "2.21.3",
 		"date-fns-tz": "1.1.4",
-		"ethcall": "3.2.0",
+		"ethcall": "4.4.0",
 		"ethers": "5.5.0",
 		"framer-motion": "4.1.17",
 		"graphql-request": "3.4.0",

--- a/queries/synths/useFeeReclaimPeriodsQuery.ts
+++ b/queries/synths/useFeeReclaimPeriodsQuery.ts
@@ -50,10 +50,14 @@ const useFeeReclaimPeriodsQuery = (
 			}
 
 			const waitingPeriodsRaw = (await ethcallProvider.all(
-				waitingPeriodCalls,
-				{}
+				waitingPeriodCalls
 			)) as ethers.BigNumberish[];
-			const feesRaw = await ethcallProvider.all(feeCalls, {});
+			
+			const feesRaw = (await ethcallProvider.all(feeCalls)) as [
+				ethers.BigNumber,
+				ethers.BigNumber,
+				ethers.BigNumber
+			][];
 
 			const waitingPeriods = waitingPeriodsRaw.map((period) => Number(period));
 

--- a/queries/synths/useGetShortableSynths.ts
+++ b/queries/synths/useGetShortableSynths.ts
@@ -1,0 +1,59 @@
+import { useQuery } from 'react-query';
+import { useRecoilValue } from 'recoil';
+import Connector from 'containers/Connector';
+import { ethers } from 'ethers';
+import { Provider, Contract } from 'ethcall';
+
+import { CurrencyKey, Synths } from 'constants/currency';
+import { appReadyState } from 'store/app';
+
+const ethCallProvider = new Provider();
+
+const useGetShortableSynths = (isL2: boolean) => {
+	const isAppReady = useRecoilValue(appReadyState);
+	const { synthetixjs, network, provider } = Connector.useContainer();
+
+	return useQuery(
+		['getShortableSynths', network.id],
+		async () => {
+			if (isL2) {
+				await ethCallProvider.init(provider as any);
+				const {
+					contracts: { CollateralManager },
+					sources,
+				} = synthetixjs!;
+
+				const CM = new Contract(CollateralManager.address, sources.CollateralManager.abi as any);
+
+				const getShortableCalls = [];
+				const shortableSynthsList = [];
+
+				for (const synth in Synths) {
+					shortableSynthsList.push(synth);
+					getShortableCalls.push(CM.shortableSynthsByKey(ethers.utils.formatBytes32String(synth)));
+				}
+
+				const shortableListRaw = (await ethCallProvider.all(
+					getShortableCalls
+				)) as ethers.BigNumber[];
+				const shortableList = shortableListRaw.map((retval) => Number(retval));
+
+				const SYNTHS_TO_SHORT: CurrencyKey[] = [];
+				for (let i = 0; i < shortableList.length; i++) {
+					if (shortableList[i] > 0) {
+						SYNTHS_TO_SHORT.push(shortableSynthsList[i] as CurrencyKey);
+					}
+				}
+
+				return SYNTHS_TO_SHORT as CurrencyKey[];
+			} else {
+				return [Synths.sBTC, Synths.sETH, Synths.sLINK] as CurrencyKey[];
+			}
+		},
+		{
+			enabled: isAppReady && !!synthetixjs,
+		}
+	);
+};
+
+export default useGetShortableSynths;

--- a/queries/synths/useRedeemableDeprecatedSynthsQuery.ts
+++ b/queries/synths/useRedeemableDeprecatedSynthsQuery.ts
@@ -40,8 +40,8 @@ const useRedeemableDeprecatedSynthsQuery = (
 				balanceCalls.push(Redeemer.balanceOf(addr, walletAddress));
 			}
 
-			const deprecatedSynths = (await ethCallProvider.all(symbolCalls, {})) as CurrencyKey[];
-			const balanceData = (await ethCallProvider.all(balanceCalls, {})) as ethers.BigNumber[];
+			const deprecatedSynths = (await ethCallProvider.all(symbolCalls)) as CurrencyKey[];
+			const balanceData = (await ethCallProvider.all(balanceCalls)) as ethers.BigNumber[];
 			const balances = balanceData.map((balance) => wei(balance));
 
 			let totalUSDBalance = wei(0);

--- a/queries/walletBalances/useTokensBalancesQuery.ts
+++ b/queries/walletBalances/useTokensBalancesQuery.ts
@@ -42,7 +42,7 @@ const useTokensBalancesQuery = (
 				}
 			}
 
-			const data = (await ethcallProvider.all(calls, {})) as ethers.BigNumber[];
+			const data = (await ethcallProvider.all(calls)) as ethers.BigNumber[];
 			const balancesMap = zipObject(symbols, data);
 			const positiveBalances = omitBy(balancesMap, (entry) => entry.lte(0));
 

--- a/sections/shorting/ShortingHistory/ShortingHistory.tsx
+++ b/sections/shorting/ShortingHistory/ShortingHistory.tsx
@@ -18,13 +18,19 @@ import ShortingHistoryTable from './ShortingHistoryTable';
 
 import { Title } from '../common';
 
-import { SYNTHS_TO_SHORT } from '../constants';
+import { isL2State } from 'store/wallet';
+import useGetShortableSynths from 'queries/synths/useGetShortableSynths';
 import Connector from 'containers/Connector';
 
 const ShortingHistory: FC = () => {
 	const { t } = useTranslation();
 
 	const { synthetixjs } = Connector.useContainer();
+
+	const isL2 = useRecoilValue(isL2State);
+
+	const shortListQuery = useGetShortableSynths(isL2);
+	const SYNTHS_TO_SHORT = useMemo(() => shortListQuery.data ?? [], [shortListQuery.data]);
 
 	const shortHistoryQuery = useShortHistoryQuery();
 	const historicalShortsPosition = useRecoilValue(historicalShortsPositionState);
@@ -34,7 +40,7 @@ const ShortingHistory: FC = () => {
 			{ label: t('shorting.history.assets-sort.allAssets'), key: 'ALL_SYNTHS' },
 			...SYNTHS_TO_SHORT.map((synth) => ({ label: synth, key: synth })),
 		],
-		[t]
+		[t, SYNTHS_TO_SHORT]
 	);
 
 	const datesFilterList = useMemo(

--- a/sections/shorting/ShortingRewards/ShortingRewards.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewards.tsx
@@ -7,7 +7,7 @@ import { isL2State } from 'store/wallet';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 
 import { CRYPTO_CURRENCY_MAP, Synths } from 'constants/currency';
-import { SYNTHS_TO_SHORT, SYNTHS_TO_SHORT_L1 } from '../constants';
+import useGetShortableSynths from 'queries/synths/useGetShortableSynths';
 
 import ShortingRewardRow, { GasInfo } from './ShortingRewardRow';
 
@@ -23,6 +23,9 @@ import useGas from 'hooks/useGas';
 const ShortingRewards: FC = () => {
 	const { t } = useTranslation();
 	const isL2 = useRecoilValue(isL2State);
+
+	const shortListQuery = useGetShortableSynths(isL2);
+	const SYNTHS_TO_SHORT = useMemo(() => shortListQuery.data ?? [], [shortListQuery.data]);
 
 	const [gasInfo, setGasInfo] = useState<GasInfo | null>(null);
 	const { gasPrice, gasPrices } = useGas();
@@ -60,7 +63,7 @@ const ShortingRewards: FC = () => {
 	return (
 		<div>
 			<Title>{t('shorting.rewards.title')}</Title>
-			{(isL2 ? SYNTHS_TO_SHORT : SYNTHS_TO_SHORT_L1).map((currencyKey) => (
+			{SYNTHS_TO_SHORT.map((currencyKey) => (
 				<ShortingRewardRow
 					key={currencyKey}
 					{...{

--- a/sections/shorting/ShortingStats/ShortingStats.tsx
+++ b/sections/shorting/ShortingStats/ShortingStats.tsx
@@ -17,7 +17,7 @@ import { NO_VALUE } from 'constants/placeholder';
 
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
 
-import { SYNTHS_TO_SHORT, SYNTHS_TO_SHORT_L1 } from '../constants';
+import useGetShortableSynths from 'queries/synths/useGetShortableSynths';
 import { Title } from '../common';
 import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
@@ -28,6 +28,9 @@ const ShortingStats = () => {
 	const { t } = useTranslation();
 	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
 	const isL2 = useRecoilValue(isL2State);
+
+	const shortListQuery = useGetShortableSynths(isL2);
+	const SYNTHS_TO_SHORT = useMemo(() => shortListQuery.data ?? [], [shortListQuery.data]);
 
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 
@@ -76,7 +79,7 @@ const ShortingStats = () => {
 					</TableRowHead>
 				</thead>
 				<tbody>
-					{(isL2 ? SYNTHS_TO_SHORT : SYNTHS_TO_SHORT_L1).map((currencyKey) => (
+					{SYNTHS_TO_SHORT.map((currencyKey) => (
 						<TableRow key={currencyKey}>
 							<TableCell colSpan={2}>
 								<StyledCurrencyName currencyKey={currencyKey} showIcon={true} />

--- a/sections/shorting/hooks/useShort.tsx
+++ b/sections/shorting/hooks/useShort.tsx
@@ -41,7 +41,7 @@ import { zeroBN, formatNumber } from 'utils/formatters/number';
 import { NoTextTransform } from 'styles/common';
 import { historicalShortsPositionState } from 'store/shorts';
 
-import { SYNTHS_TO_SHORT } from '../constants';
+import useGetShortableSynths from 'queries/synths/useGetShortableSynths';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import useSynthetixQueries from '@synthetixio/queries';
 import Connector from 'containers/Connector';
@@ -234,15 +234,18 @@ const useShort = ({
 			? synthsWalletBalancesQuery.data.balances.length === 0
 			: false;
 
+	const shortListQuery = useGetShortableSynths(isL2);
+	const SYNTHS_TO_SHORT = useMemo(() => shortListQuery.data ?? [], [shortListQuery.data]);
+
 	// TODO: grab these from the smart contract
 	const synthsAvailableToShort = useMemo(() => {
 		if (isAppReady) {
 			return synthetixjs!.synths.filter((synth) =>
-				SYNTHS_TO_SHORT.includes(synth.name as CurrencyKey)
+				SYNTHS_TO_SHORT?.includes(synth.name as CurrencyKey)
 			);
 		}
 		return [];
-	}, [isAppReady, synthetixjs]);
+	}, [isAppReady, synthetixjs, SYNTHS_TO_SHORT]);
 
 	const transactionFee = useMemo(
 		() => getTransactionPrice(gasPrice, gasInfo?.limit, ethPriceRate, gasInfo?.l1Fee),


### PR DESCRIPTION
## Description
Built against `dev` but would not compile unless I ran `npm i` against `v2-dev`.  

##### useGetShortableSynths.ts
Added a new query. Updated `ethcall` to 4.4.0 to enable OP support.  L2 Synths are retrieved from synthetixjs using multicall, memoed into each file that uses it.  L1 list is hard coded into the query since they are deprecated, and the L1 contract gives us no method to retrieve them dynamically. 

##### useShort.tsx
##### ShortingHistory.tsx
##### ShortingReward.tsx
##### ShortingStats.tsx
Replaced `SYNTHS_TO_SHORT` and `SYNTHS_TO_SHORT_L1` with a single query that populates `SYNTHS_TO_SHORT` based on L1 or L2 being currently active, and updated hooked memos.

##### useFeeReclaimPeriodsQuery.ts
new version of `ethcall` errors when passed {} parameter. It also returns unknown[] instead of [any,any,any], like the previous version did, so I cast the result.

##### useRedeemableDeprecatedSynthsQuery.ts
new version of `ethcall` errors when passed {} parameter

##### useTokensBalancesQuery.ts
new version of `ethcall` errors when passed {} parameter

## Related issue
https://github.com/Kwenta/kwenta/issues/359

## Motivation and Context
Allow for automated deployment of new synthetix synths to kwenta shorting market

## How Has This Been Tested?

##### useShort.tsx
##### ShortingHistory.tsx
The right-side drop-down populates with the correct L2 synths. I opened and closed positions on every L2 synth, confirming it was selectable, and showed up correctly under Your Positions.

##### ShortingReward.tsx
This is only used on L1.  Verified the synth reward list is correct for L1 after the change.

##### ShortingStats.tsx
This is used on L1 and L2.  Verified the synth list displayed is correct on both L1 and L2 after the change.

##### useFeeReclaimPeriodsQuery.ts
I don't know how to test this one other than the console.log commands I used during dev.

##### useRedeemableDeprecatedSynthsQuery.ts
DashboardCard uses this.  Synth list appears to still work after the change.

##### useTokensBalancesQuery.ts
This is used in useExchange and SelectTokenModal.  Both of these appear to still work after the change.