### PR TITLE
fixing alignment of react-select dropdowns;

### DIFF
--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -60,6 +60,7 @@ function Select<T>(props: Props<T>) {
 				boxShadow: colors.selectedTheme.button.shadow,
 				padding: 0,
 				width: state.selectProps.menuWidth,
+				right: 0,
 			}),
 			menuList: (provided) => ({
 				...provided,
@@ -80,6 +81,9 @@ function Select<T>(props: Props<T>) {
 				backgroundColor: 'transparent',
 				padding: state.selectProps.optionPadding ?? '6px 8px',
 				borderBottom: colors.selectedTheme.border,
+				'&:hover': {
+					background: colors.selectedTheme.button.hover,
+				},
 				':last-child': {
 					borderBottom: 'none',
 				},


### PR DESCRIPTION
fixing react-select css:

- [X] adjusting alignment defaults to be `right` alrigned so they do not bleed off page.
- [X] adding a `hover` effect to the options so the user sees which options is being selected.

## Description

details for this change can be found on discord ticket 559
https://discord.com/channels/852273007370960937/958830876815401020/959163629805113394

## Related issue

N/A - discovered during investigation for https://github.com/Kwenta/kwenta/issues/559

## Motivation and Context

- better UI experience for user with hover effect
- prevent menus from overflowing beyond browser window.

## How Has This Been Tested?
- [X] visually test aligment defaults
- [X] change screen sizes to make sure alignment works
- [X] visually test hover effects

## Screenshots (if appropriate):
![Screen Shot 2022-03-31 at 3 29 31 PM](https://user-images.githubusercontent.com/5998100/161311346-3727c4d7-9571-44b1-b656-192cd7783276.png)
![Screen Shot 2022-04-01 at 10 21 47 AM](https://user-images.githubusercontent.com/5998100/161311351-136d0421-06dd-4564-8629-9737d7aba89f.png)
