### PR TITLE
Futures UI tweaks

### DIFF
--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -97,5 +97,4 @@ export function TVChart({
 const Container = styled.div`
 	border-radius: 4px;
 	background: ${(props) => props.theme.colors.selectedTheme.background};
-	padding: 4px;
 `;

--- a/constants/ui.ts
+++ b/constants/ui.ts
@@ -1,7 +1,7 @@
-export const HEADER_HEIGHT = '127px';
+export const HEADER_HEIGHT = '96px';
 export const HEADER_TOP_PADDING = '31px';
 
-export const SPACING_FROM_HEADER = '127px';
+export const SPACING_FROM_HEADER = '96px';
 
 export enum zIndex {
 	BASE = 1,

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -1,12 +1,10 @@
 import { FC } from 'react';
 import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import AppLayout from 'sections/shared/Layout/AppLayout';
-import {
-	PageContent,
-	FullHeightContainer,
-} from 'styles/common';
+import { PageContent, FullHeightContainer } from 'styles/common';
 import DashboardContainer from 'sections/dashboard/DashboardContainer';
 
 const Futures: FC = () => {
@@ -19,13 +17,17 @@ const Futures: FC = () => {
 			</Head>
 			<AppLayout>
 				<PageContent>
-					<FullHeightContainer>
+					<StyledFullHeightContainer>
 						<DashboardContainer />
-					</FullHeightContainer>
+					</StyledFullHeightContainer>
 				</PageContent>
 			</AppLayout>
 		</>
 	);
 };
+
+const StyledFullHeightContainer = styled(FullHeightContainer)`
+	padding-top: 14px;
+`;
 
 export default Futures;

--- a/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
+++ b/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
@@ -85,11 +85,7 @@ const NetworksSwitcher: FC<NetworksSwitcherProps> = () => {
 
 	return !isL2 ? (
 		<Container onClick={switchToL2}>
-			<StyledButton
-				size="sm"
-			>
-				{t('header.networks-switcher.l2')}
-			</StyledButton>
+			<StyledButton size="sm">{t('header.networks-switcher.l2')}</StyledButton>
 		</Container>
 	) : (
 		<Container>
@@ -131,7 +127,7 @@ const L2Select = styled(Select)`
 	}
 
 	.react-select__dropdown-indicator {
-		padding-right: 13px;
+		margin-right: 5px;
 	}
 
 	.react-select__value-container {


### PR DESCRIPTION
## Description
This PR fixes minor UI issues with the futures page. These include:
- Using the correct padding for the header section
- Removing the padding around the chart area
- Fixing issue with jumping dropdown arrow in `NetworkSwitcher`

## Related issue
N/A

## Motivation and Context
This fixes minor issues on the v2 beta.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
