### PR TITLE
added FuturesPositionsTable to MarketInfo

### DIFF
--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import useSynthetixQueries from '@synthetixio/queries';
 
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
+import FuturesPositionsTable from 'sections/dashboard/FuturesPositionsTable';
+import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
 import { formatCurrency } from 'utils/formatters/number';
@@ -22,6 +24,10 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 	const { t } = useTranslation();
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery();
+
+	const futuresMarketsQuery = useGetFuturesMarkets();
+    const futuresMarkets = futuresMarketsQuery?.data ?? [];
+    const otherFuturesMarkets = futuresMarkets.filter(marketAsset => marketAsset.asset !== market) ?? []
 
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
@@ -49,6 +55,7 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 			<MarketDetails baseCurrencyKey={baseCurrencyKey} />
 			<TVChart baseCurrencyKey={baseCurrencyKey} quoteCurrencyKey={Synths.sUSD} />
 			<UserInfo marketAsset={baseCurrencyKey} />
+			<FuturesPositionsTable futuresMarkets={otherFuturesMarkets} />
 		</Container>
 	);
 };


### PR DESCRIPTION
Inside of the Markets page, I added a futures positions table for the user's positions in all markets (excluding the current market since that is already shown on the page). 

## Description
From the dashboard overview file, I copied the futuresPositionsTable from the return value and related futures market query code. I then added this to the MarketInfo file, placing the futuresPositionsTable below the UserInfo (current markets positions for the user). I then filtered out the current market from the futuresPositionsTable. This ends up displaying all of the user's futures positions inside of the Markets page.

Note that assuming the user has no other positions open, the blank "other futures positions" table will currently be displayed.

## Related issue
[<!--- If it fixes an open issue, please link to the issue here. -->](https://github.com/Kwenta/kwenta/issues/441)

## Motivation and Context
While a user is trading on the market's page, they do not want to have to switch pages or have multiple windows opens to keep track of their other positions. We want them to have everything they need while waiting to trade futures on the Markets page.

## How Has This Been Tested?
Using brave browser, metamask, on optimism mainnet, and 0.1x leverage, I tested this out using an eth perp. I ended up at the desired result. 

## Screenshots (if appropriate):
<img width="1530" alt="Screen Shot 2022-04-03 at 9 49 34 PM" src="https://user-images.githubusercontent.com/83140889/161465926-9914c48a-2374-40a5-83f6-4d4ebc6c41a5.png">

