### PR TITLE
Add: StyledConnectionDot for disconnected wallet state

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/ConnectionDot.tsx
+++ b/sections/shared/Layout/AppLayout/Header/ConnectionDot.tsx
@@ -33,7 +33,6 @@ const ConnectionDot: React.FC<ConnectionDotProps> = (props) => {
 				}
 		}
 	}
-
 	return <Dot {...props} background={background} />;
 };
 

--- a/sections/shared/Layout/AppLayout/Header/ConnectionDot.tsx
+++ b/sections/shared/Layout/AppLayout/Header/ConnectionDot.tsx
@@ -34,8 +34,6 @@ const ConnectionDot: React.FC<ConnectionDotProps> = (props) => {
 		}
 	}
 
-	if (!isWalletConnected) background = '#EF6868';
-
 	return <Dot {...props} background={background} />;
 };
 

--- a/sections/shared/Layout/AppLayout/Header/ConnectionDot.tsx
+++ b/sections/shared/Layout/AppLayout/Header/ConnectionDot.tsx
@@ -33,6 +33,9 @@ const ConnectionDot: React.FC<ConnectionDotProps> = (props) => {
 				}
 		}
 	}
+
+	if (!isWalletConnected) background = '#EF6868';
+
 	return <Dot {...props} background={background} />;
 };
 

--- a/sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx
+++ b/sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useMemo, useEffect } from 'react';
+import { FC, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
@@ -7,11 +7,8 @@ import Connector from 'containers/Connector';
 
 import Button from 'components/Button';
 
-import {
-	isWalletConnectedState,
-	truncatedWalletAddressState
-} from 'store/wallet';
-import { FlexDivCentered, } from 'styles/common';
+import { isWalletConnectedState, truncatedWalletAddressState } from 'store/wallet';
+import { FlexDivCentered } from 'styles/common';
 
 import WalletOptionsModal from 'sections/shared/modals/WalletOptionsModal';
 import SettingsModal from 'sections/shared/modals/SettingsModal';
@@ -48,9 +45,7 @@ const UserMenu: FC<UserMenuProps> = ({ isTextButton }) => {
 		<>
 			<Container>
 				<FlexDivCentered>
-					{isWalletConnected && (
-						<NetworksSwitcher />
-					)}
+					{isWalletConnected && <NetworksSwitcher />}
 					{isWalletConnected ? (
 						<WalletButton
 							className={ensName ? 'lowercase' : ''}
@@ -70,6 +65,7 @@ const UserMenu: FC<UserMenuProps> = ({ isTextButton }) => {
 							data-testid="connect-wallet"
 							mono
 						>
+							<StyledConnectionDot />
 							{t('common.wallet.connect-wallet')}
 						</ConnectButton>
 					)}

--- a/styles/theme/colors/index.ts
+++ b/styles/theme/colors/index.ts
@@ -41,7 +41,7 @@ const colors = {
 	rinkeby: '#F6C343',
 	goerli: 'rgb(48, 153, 242)',
 	connectedDefault: goldColors.color1,
-	noNetwork: 'rgb(155, 155, 155)',
+	noNetwork: '#EF6868',
 	transparentBlack: 'rgba(0, 0, 0, 0.5)',
 	common,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Copied `StyledConnectionDot` component from the truthy part of the `isWalletConnected` ternary in `UserMenu.tsx` to the falsey part of the ternary.
2. Added second conditional check for when `isWalletConnected` is `false`. This will set `background` to the desired color `#EF6868`.

## Related issue
Fixes #542 

## Motivation and Context
Addresses #542

## How Has This Been Tested?
I tested by disconnecting and reconnecting my wallet

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/99768011/161476761-82fd39b0-afa9-427f-afad-109888df301e.mov


