### PR TITLE
ci: fix skipped lint and unit tests pipelines on v2 & v2-dev branches

### DIFF
--- a/.github/workflows/audit_build_verify.yml
+++ b/.github/workflows/audit_build_verify.yml
@@ -3,12 +3,12 @@ name: Kwenta CI
 on:
   push:
   pull_request:
-    branches: [master, dev]
+    branches: [master, dev, v2, v2-dev]
 
 jobs:
   audit:
-    # run only on master/dev branch and pull requests
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'
+    # run only on master/dev/v2/v2-dev branch and pull requests
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/v2' || github.ref == 'refs/heads/v2-dev' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     container:
@@ -58,17 +58,18 @@ jobs:
         run: npm ci --no-audit --legacy-peer-deps
 
       - name: Lint
-        # run only on master/dev branch and pull requests
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'
+        # run only on master/dev/v2/v2-dev branch and pull requests
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/v2' || github.ref == 'refs/heads/v2-dev' || github.event_name == 'pull_request'
         run: npm run lint:sarif
+
       - name: Unit tests
-        # run only on master/dev branch and pull requests
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'
+        # run only on master/dev/v2/v2-dev branch and pull requests
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/v2' || github.ref == 'refs/heads/v2-dev' || github.event_name == 'pull_request'
         run: npm run test:unit
 
       - name: Upload lint results
-        # run if lint failed and only on master/dev branch and pull requests
-        if: always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request')
+        # run if lint failed and only on master/dev/v2/v2-dev branch and pull requests
+        if: always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/v2' || github.ref == 'refs/heads/v2-dev' || github.event_name == 'pull_request')
         uses: github/codeql-action/upload-sarif@33f3438c1d59883f5e769fdf2b6adb6794d91d0f # pin@codeql-bundle-20210517
         with:
           sarif_file: lint-results.sarif
@@ -90,7 +91,7 @@ jobs:
         run: tar -zcvf build.tar.gz .next
 
       - name: Archive build
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/v2' || github.ref == 'refs/heads/v2-dev' || github.event_name == 'pull_request'
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # pin@v2
         with:
           name: build


### PR DESCRIPTION
Signed-off-by: Jakub Mucha <jakub.mucha@icloud.com>

## Description
Currently linting and unit tests are not being run on `v2` and `v2-dev` branches, so we have no linting and tests at all. This PR fixes it.