### PR TITLE
Add price feeds new markets

### DIFF
--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -18,6 +18,7 @@ import { Price } from 'queries/rates/types';
 import { NO_VALUE } from 'constants/placeholder';
 import { Tooltip } from 'styles/common';
 import { getMarketKey } from 'utils/futures';
+import Connector from 'containers/Connector';
 
 type MarketDetailsProps = {
 	baseCurrencyKey: CurrencyKey;
@@ -26,6 +27,7 @@ type MarketDetailsProps = {
 type MarketData = Record<string, { value: string | JSX.Element; color?: string }>;
 
 const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
+	const { network } = Connector.useContainer();
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const futuresMarketsQuery = useGetFuturesMarkets();
@@ -46,7 +48,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const futuresDailyTradeStatsQuery = useGetFuturesDailyTradeStatsForMarket(baseCurrencyKey);
 	const futuresDailyTradeStats = futuresDailyTradeStatsQuery?.data ?? null;
 
-	const marketKey = getMarketKey(baseCurrencyKey);
+	const marketKey = getMarketKey(baseCurrencyKey, network.id);
 	const priceId = synthToCoingeckoPriceId(marketKey);
 	const coinGeckoPricesQuery = useCoinGeckoPricesQuery([priceId]);
 	const coinGeckoPrices = coinGeckoPricesQuery?.data ?? null;

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -17,6 +17,7 @@ import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
 import { Price } from 'queries/rates/types';
 import { NO_VALUE } from 'constants/placeholder';
 import { Tooltip } from 'styles/common';
+import { getMarketKey } from 'utils/futures';
 
 type MarketDetailsProps = {
 	baseCurrencyKey: CurrencyKey;
@@ -45,7 +46,8 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const futuresDailyTradeStatsQuery = useGetFuturesDailyTradeStatsForMarket(baseCurrencyKey);
 	const futuresDailyTradeStats = futuresDailyTradeStatsQuery?.data ?? null;
 
-	const priceId = synthToCoingeckoPriceId(baseCurrencyKey);
+	const marketKey = getMarketKey(baseCurrencyKey);
+	const priceId = synthToCoingeckoPriceId(marketKey);
 	const coinGeckoPricesQuery = useCoinGeckoPricesQuery([priceId]);
 	const coinGeckoPrices = coinGeckoPricesQuery?.data ?? null;
 	const externalPrice = coinGeckoPrices?.[priceId]?.usd ?? 0;
@@ -65,9 +67,12 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 				value: formatCurrency(selectedPriceCurrency.name, basePriceRate, { sign: '$' }),
 			},
 			'External Price': {
-				value: formatCurrency(selectedPriceCurrency.name, externalPrice, {
-					sign: '$',
-				}),
+				value:
+					externalPrice === 0
+						? '-'
+						: formatCurrency(selectedPriceCurrency.name, externalPrice, {
+								sign: '$',
+						  }),
 			},
 			'24H Change': {
 				value:

--- a/sections/futures/MarketDetails/utils.ts
+++ b/sections/futures/MarketDetails/utils.ts
@@ -1,11 +1,27 @@
 import { Synths } from 'constants/currency';
 
-const markets = [Synths.sETH, Synths.sBTC, Synths.sLINK] as const;
+const markets = [
+	Synths.sETH,
+	Synths.sBTC,
+	Synths.sLINK,
+	Synths.sSOL,
+	Synths.sAVAX,
+	Synths.sMATIC,
+	Synths.sAAVE,
+	Synths.sUNI,
+	Synths.sEUR,
+] as const;
 
 const map: Record<typeof markets[number], string> = {
 	[Synths.sETH]: 'ethereum',
 	[Synths.sBTC]: 'bitcoin',
 	[Synths.sLINK]: 'chainlink',
+	[Synths.sSOL]: 'solana',
+	[Synths.sAVAX]: 'avalanche-2',
+	[Synths.sMATIC]: 'matic-network',
+	[Synths.sAAVE]: 'aave',
+	[Synths.sUNI]: 'uniswap',
+	[Synths.sEUR]: 'euro',
 };
 
 export const synthToCoingeckoPriceId = (synth: any) => {

--- a/sections/futures/MarketDetails/utils.ts
+++ b/sections/futures/MarketDetails/utils.ts
@@ -10,6 +10,9 @@ const markets = [
 	Synths.sAAVE,
 	Synths.sUNI,
 	Synths.sEUR,
+	'sXAU',
+	'sXAG',
+	'sWTI',
 ] as const;
 
 const map: Record<typeof markets[number], string> = {
@@ -22,6 +25,9 @@ const map: Record<typeof markets[number], string> = {
 	[Synths.sAAVE]: 'aave',
 	[Synths.sUNI]: 'uniswap',
 	[Synths.sEUR]: 'euro',
+	sXAU: '',
+	sXAG: '',
+	sWTI: '',
 };
 
 export const synthToCoingeckoPriceId = (synth: any) => {

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -3,7 +3,7 @@ import { NetworkId, NetworkIdByName } from '@synthetixio/contracts-interface';
 import futuresMarketsKovan from 'synthetix/publish/deployed/kovan-ovm/futures-markets.json';
 import futuresMarketsMainnet from 'synthetix/publish/deployed/mainnet-ovm/futures-markets.json';
 
-export const getMarketKey = (asset: string | null, networkId: NetworkId) => {
+export const getMarketKey = (asset: string | null, networkId: NetworkId = 10) => {
 	if (networkId === NetworkIdByName['mainnet-ovm']) {
 		return futuresMarketsMainnet.find((market) => market.asset === asset)?.marketKey || 'sETH';
 	} else if (networkId === NetworkIdByName['kovan-ovm']) {

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -3,7 +3,7 @@ import { NetworkId, NetworkIdByName } from '@synthetixio/contracts-interface';
 import futuresMarketsKovan from 'synthetix/publish/deployed/kovan-ovm/futures-markets.json';
 import futuresMarketsMainnet from 'synthetix/publish/deployed/mainnet-ovm/futures-markets.json';
 
-export const getMarketKey = (asset: string | null, networkId: NetworkId = 10) => {
+export const getMarketKey = (asset: string | null, networkId: NetworkId) => {
 	if (networkId === NetworkIdByName['mainnet-ovm']) {
 		return futuresMarketsMainnet.find((market) => market.asset === asset)?.marketKey || 'sETH';
 	} else if (networkId === NetworkIdByName['kovan-ovm']) {


### PR DESCRIPTION
adding external price feeds for SOL, AVAX, MATIC, AAVE, UNI

## Description
- [X] added new synths to the `MarketDetails/utils.ts`
- [X] adjusting MarketDetails to handle routing conditions for any synths that are referenced via the synthetix `Synths` const

## Related issue
https://github.com/Kwenta/kwenta/issues/590

## Motivation and Context
need to add all price feeds for the new synth markets

## How Has This Been Tested?
tested on Chrome, optimistic kovan, routing specifically to each market via the url and the displayed synths in the market table

## Screenshots (if appropriate):
![Screen Shot 2022-04-04 at 11 00 45 AM](https://user-images.githubusercontent.com/5998100/161600283-217bc340-1b4e-435b-9b5a-5a0a79ff9a93.png)
![Screen Shot 2022-04-04 at 11 01 52 AM](https://user-images.githubusercontent.com/5998100/161600285-80ebb316-fbf9-4dd2-a513-5d664f88ffbb.png)
![Screen Shot 2022-04-04 at 11 02 18 AM](https://user-images.githubusercontent.com/5998100/161600287-13fda34d-89fa-4294-b888-34a4249c18a2.png)
![Screen Shot 2022-04-04 at 11 26 09 AM](https://user-images.githubusercontent.com/5998100/161600289-3875f8c8-6337-42bc-818c-32782e54a6c8.png)
![Screen Shot 2022-04-04 at 11 26 38 AM](https://user-images.githubusercontent.com/5998100/161600290-a53aa38a-f648-44fe-b0b9-82457e50b69e.png)
