### PR TITLE
fixing slight issue with banner height

### DIFF
--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -118,7 +118,6 @@ const Container = styled.header`
 `;
 
 const FuturesBannerContainer = styled.div`
-	height: 65px;
 	width: 100%;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Kwenta Futures banner is expanding on the `Markets` page specifically.

## Description
removing the hardcoded height fixes the odd behavior on the Markets Page

## Related issue
N/A

## Motivation and Context
consisitency across pages

## How Has This Been Tested?
tested this locally on dev and against production (in elements tab)

## Screenshots (if appropriate):
this:
![Screen Shot 2022-04-04 at 1 34 57 PM](https://user-images.githubusercontent.com/5998100/161638276-a8315d41-cf5e-4f22-a005-21200d38a1e0.png)

to this:

<img width="1681" alt="Screen Shot 2022-04-04 at 3 52 34 PM" src="https://user-images.githubusercontent.com/5998100/161638367-367f7246-856a-4a6e-8cc0-f33cac1561fb.png">

