### PR TITLE
V2 Release #3: fix lint warnings

### DIFF
--- a/queries/futures/useGetFuturesTradingVolume.ts
+++ b/queries/futures/useGetFuturesTradingVolume.ts
@@ -1,7 +1,6 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useRecoilValue } from 'recoil';
 import Wei from '@synthetixio/wei';
-import request, { gql } from 'graphql-request';
 import { utils as ethersUtils } from 'ethers';
 
 import { appReadyState } from 'store/app';

--- a/queries/futures/useGetFuturesTradingVolumeForAllMarkets.ts
+++ b/queries/futures/useGetFuturesTradingVolumeForAllMarkets.ts
@@ -1,6 +1,5 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useRecoilValue } from 'recoil';
-import request, { gql } from 'graphql-request';
 
 import { appReadyState } from 'store/app';
 import { isL2State, networkState, walletAddressState } from 'store/wallet';

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -10,7 +10,6 @@ import {
 	FuturesOneMinuteStat,
 	PositionDetail,
 	PositionSide,
-	FuturesTrade,
 	FuturesVolumes,
 	RawPosition,
 	PositionHistory,
@@ -126,7 +125,6 @@ export const mapOpenInterest = async (
 					},
 				});
 			} else {
-				const longsBigger = longSize.gt(shortSize);
 				const combined = shortSize.add(longSize);
 
 				openInterest.push({

--- a/sections/dashboard/PortfolioChart/PortfolioChart.tsx
+++ b/sections/dashboard/PortfolioChart/PortfolioChart.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import styled from 'styled-components';
-import { useTranslation } from 'react-i18next';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
 import { FuturesMarket } from 'queries/futures/types';
 import { Synths } from 'constants/currency';
@@ -12,8 +11,6 @@ type PortfolioChartProps = {
 };
 
 const PortfolioChart: FC<PortfolioChartProps> = ({ futuresMarkets }: PortfolioChartProps) => {
-	const { t } = useTranslation();
-
 	const markets = futuresMarkets.map((market: FuturesMarket) => {
 		return market.asset;
 	});

--- a/sections/futures/Markets/Markets.tsx
+++ b/sections/futures/Markets/Markets.tsx
@@ -122,12 +122,6 @@ const StyledCurrency = styled.span`
 	//margin-right: 4px;
 `;
 
-const StyledPercent = styled.span`
-	color: ${(props) => props.theme.colors.white};
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 12px;
-`;
-
 const TableNoResults = styled(GridDivCenteredRow)`
 	padding: 50px 0;
 	justify-content: center;

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { castArray } from 'lodash';
-import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
 import useSynthetixQueries from '@synthetixio/queries';
 
@@ -30,7 +29,6 @@ type UserInfoProps = {
 };
 
 const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
-	const { t } = useTranslation();
 	const router = useRouter();
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery();

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -224,17 +224,6 @@ const TableHeader = styled.div`
 	color: ${(props) => props.theme.colors.common.secondaryGray};
 `;
 
-const TableTitle = styled.div`
-	width: 100%;
-	display: flex;
-	justify-content: space-between;
-`;
-
-const TitleText = styled.div`
-	font-family: ${(props) => props.theme.fonts.regular};
-	color: ${(props) => props.theme.colors.common.secondaryGray};
-`;
-
 const StyledOrderType = styled.div`
 	color: ${(props) => props.theme.colors.white};
 	display: flex;


### PR DESCRIPTION
## Description
Repository does not allow me push to it directly:

```
remote: error: GH006: Protected branch update failed for refs/heads/v2-dev.
remote: error: At least 1 approving review is required by reviewers with write access.
To https://github.com/Kwenta/kwenta.git
 ! [remote rejected]   v2-dev -> v2-dev (protected branch hook declined)
error: failed to push some refs to 'https://github.com/Kwenta/kwenta.git'
```

Hence pushing fixes via PR.

The following lint warnings have **not** been fixed yet:

```
/Users/platschi/Templates/kwenta/kwenta/components/Table/Table.tsx
  104:5  warning  React Hook useEffect has missing dependencies: 'hiddenColumns' and 'setHiddenColumns'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/platschi/Templates/kwenta/kwenta/sections/exchange/TradeCard/Cards/CombinedMarketDetailsCard.tsx
  50:5  warning  React Hook useEffect has a missing dependency: 'rates24hQuery.isSuccess'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/platschi/Templates/kwenta/kwenta/sections/futures/CountdownTimer/CountdownTimer.tsx
  46:5  warning  React Hook useEffect has a missing dependency: 'calcTime'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/platschi/Templates/kwenta/kwenta/sections/shared/Layout/AppLayout/Header/WalletActions.tsx
   66:5  warning  React Hook useMemo has missing dependencies: 'connectWallet', 'disconnectWallet', and 'switchAccounts'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
  111:5  warning  React Hook useEffect has a missing dependency: 'staticMainnetProvider'. Either include it or remove the dependency array                                    react-hooks/exhaustive-deps
```