### PR TITLE
Use Infura endpoint as default when wallets are not connected

### DIFF
--- a/components/Input/CustomInput.tsx
+++ b/components/Input/CustomInput.tsx
@@ -17,7 +17,7 @@ const CustomInput: React.FC<CustomInputProps> = ({
 	value,
 	placeholder,
 	onChange,
-	right, 
+	right,
 	style,
 	className,
 	disabled,

--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -16,7 +16,7 @@ export const DEFAULT_PRICE_CURRENCY: Synth = localStore.get(priceCurrencyStateKe
 };
 
 // network defaults
-export const DEFAULT_NETWORK_ID = NetworkIdByName.mainnet;
+export const DEFAULT_NETWORK_ID = NetworkIdByName['mainnet-ovm'];
 
 export const DEFAULT_GAS_BUFFER = 5000;
 export const DEFAULT_GAS_LIMIT = 500000;

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -8,7 +8,12 @@ import { loadProvider } from '@synthetixio/providers';
 
 import { getDefaultNetworkId, getIsOVM } from 'utils/network';
 import { useSetRecoilState, useRecoilState } from 'recoil';
-import { NetworkId, SynthetixJS, synthetix } from '@synthetixio/contracts-interface';
+import {
+	NetworkId,
+	SynthetixJS,
+	synthetix,
+	NetworkIdByName,
+} from '@synthetixio/contracts-interface';
 import { ethers } from 'ethers';
 
 import { ordersState } from 'store/orders';
@@ -67,7 +72,7 @@ const useConnector = () => {
 			const networkId = await getDefaultNetworkId();
 
 			const provider = loadProvider({
-				networkId,
+				networkId: walletAddress ? networkId : NetworkIdByName['mainnet-ovm'],
 				infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
 				provider: walletAddress ? window.ethereum : undefined,
 			});

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -66,16 +66,11 @@ const useConnector = () => {
 			// TODO: need to verify we support the network
 			const networkId = await getDefaultNetworkId();
 
-			let provider;
-
-			if (walletAddress && window.ethereum) {
-				provider = loadProvider({ networkId, provider: window.ethereum });
-			} else {
-				provider = loadProvider({
-					networkId,
-					infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
-				});
-			}
+			const provider = loadProvider({
+				networkId,
+				infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
+				provider: walletAddress ? window.ethereum : undefined,
+			});
 
 			const useOvm = getIsOVM(Number(networkId));
 

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -66,11 +66,17 @@ const useConnector = () => {
 			// TODO: need to verify we support the network
 			const networkId = await getDefaultNetworkId();
 
-			const provider = loadProvider({
-				networkId,
-				infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
-				provider: window.ethereum,
-			});
+			let provider;
+
+			if (walletAddress && window.ethereum) {
+				provider = loadProvider({ networkId, provider: window.ethereum });
+			} else {
+				provider = loadProvider({
+					networkId,
+					infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
+				});
+			}
+
 			const useOvm = getIsOVM(Number(networkId));
 
 			const snxjs = synthetix({ provider, networkId, useOvm });

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -8,12 +8,7 @@ import { loadProvider } from '@synthetixio/providers';
 
 import { getDefaultNetworkId, getIsOVM } from 'utils/network';
 import { useSetRecoilState, useRecoilState } from 'recoil';
-import {
-	NetworkId,
-	SynthetixJS,
-	synthetix,
-	NetworkIdByName,
-} from '@synthetixio/contracts-interface';
+import { NetworkId, SynthetixJS, synthetix } from '@synthetixio/contracts-interface';
 import { ethers } from 'ethers';
 
 import { ordersState } from 'store/orders';
@@ -72,7 +67,7 @@ const useConnector = () => {
 			const networkId = await getDefaultNetworkId();
 
 			const provider = loadProvider({
-				networkId: walletAddress ? networkId : NetworkIdByName['mainnet-ovm'],
+				networkId,
 				infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
 				provider: walletAddress ? window.ethereum : undefined,
 			});

--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -7,14 +7,14 @@ import {
 import { loadProvider } from '@synthetixio/providers';
 
 import { getDefaultNetworkId, getIsOVM } from 'utils/network';
-import { useSetRecoilState, useRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilState, useRecoilValue } from 'recoil';
 import { NetworkId, SynthetixJS, synthetix } from '@synthetixio/contracts-interface';
 import { ethers } from 'ethers';
 
 import { ordersState } from 'store/orders';
 import { hasOrdersNotificationState } from 'store/ui';
 import { appReadyState } from 'store/app';
-import { walletAddressState, networkState } from 'store/wallet';
+import { walletAddressState, networkState, isWalletConnectedState } from 'store/wallet';
 
 import { Wallet as OnboardWallet } from 'bnc-onboard/dist/src/interfaces';
 
@@ -34,6 +34,7 @@ const useConnector = () => {
 	const [synthetixjs, setSynthetixjs] = useState<SynthetixJS | null>(null);
 	const [onboard, setOnboard] = useState<ReturnType<typeof initOnboard> | null>(null);
 	const [isAppReady, setAppReady] = useRecoilState(appReadyState);
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const [walletAddress, setWalletAddress] = useRecoilState(walletAddressState);
 	const setOrders = useSetRecoilState(ordersState);
 	const setHasOrdersNotification = useSetRecoilState(hasOrdersNotificationState);
@@ -64,12 +65,12 @@ const useConnector = () => {
 	useEffect(() => {
 		const init = async () => {
 			// TODO: need to verify we support the network
-			const networkId = await getDefaultNetworkId();
+			const networkId = await getDefaultNetworkId(isWalletConnected);
 
 			const provider = loadProvider({
 				networkId,
 				infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
-				provider: walletAddress ? window.ethereum : undefined,
+				provider: isWalletConnected ? window.ethereum : undefined,
 			});
 
 			const useOvm = getIsOVM(Number(networkId));

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -67,7 +67,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 				);
 		},
 		{
-			enabled: isAppReady && isL2 && !!synthetixjs,
+			enabled: isAppReady && !!synthetixjs,
 			...options,
 		}
 	);

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { wei } from '@synthetixio/wei';
 
 import { appReadyState } from 'store/app';
-import { isL2State, networkState, walletAddressState } from 'store/wallet';
+import { isL2State, networkState } from 'store/wallet';
 
 import Connector from 'containers/Connector';
 import QUERY_KEYS from 'constants/queryKeys';

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { wei } from '@synthetixio/wei';
 
 import { appReadyState } from 'store/app';
-import { isL2State, networkState } from 'store/wallet';
+import { isL2State, isWalletConnectedState, networkState } from 'store/wallet';
 
 import Connector from 'containers/Connector';
 import QUERY_KEYS from 'constants/queryKeys';
@@ -11,13 +11,20 @@ import { FuturesMarket } from './types';
 
 const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 	const isAppReady = useRecoilValue(appReadyState);
-	const isL2 = useRecoilValue(isL2State);
 	const network = useRecoilValue(networkState);
 	const { synthetixjs } = Connector.useContainer();
+
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const isL2 = useRecoilValue(isL2State);
+	const isReady = isAppReady && !!synthetixjs;
 
 	return useQuery<FuturesMarket[]>(
 		QUERY_KEYS.Futures.Markets(network.id),
 		async () => {
+			if (isWalletConnected && !isL2) {
+				return null;
+			}
+
 			const {
 				contracts: { FuturesMarketData, SystemStatus },
 				utils,
@@ -67,7 +74,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 				);
 		},
 		{
-			enabled: isAppReady && !!synthetixjs,
+			enabled: isWalletConnected ? isL2 && isReady : isReady,
 			...options,
 		}
 	);

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -13,7 +13,6 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 	const isAppReady = useRecoilValue(appReadyState);
 	const isL2 = useRecoilValue(isL2State);
 	const network = useRecoilValue(networkState);
-	const walletAddress = useRecoilValue(walletAddressState);
 	const { synthetixjs } = Connector.useContainer();
 
 	return useQuery<FuturesMarket[]>(
@@ -68,7 +67,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 				);
 		},
 		{
-			enabled: isAppReady && isL2 && !!walletAddress && !!synthetixjs,
+			enabled: isAppReady && isL2 && !!synthetixjs,
 			...options,
 		}
 	);

--- a/store/wallet/index.ts
+++ b/store/wallet/index.ts
@@ -19,7 +19,7 @@ export type Network = {
 
 export const networkState = atom<Network>({
 	key: getWalletKey('network'),
-	default: { id: NetworkIdByName.mainnet, name: NetworkNameById[1] },
+	default: { id: NetworkIdByName['mainnet-ovm'], name: NetworkNameById[10] },
 });
 
 export const isMainnetState = selector<boolean>({

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -15,9 +15,9 @@ export function isSupportedNetworkId(id: number | string): id is NetworkId {
 	return id in NetworkNameById;
 }
 
-export async function getDefaultNetworkId(): Promise<NetworkId> {
+export async function getDefaultNetworkId(walletConnected: boolean = true): Promise<NetworkId> {
 	try {
-		if (window.ethereum) {
+		if (walletConnected && window.ethereum) {
 			const provider = (await detectEthereumProvider()) as EthereumProvider;
 			if (provider && provider.chainId) {
 				const id = Number(provider.chainId);


### PR DESCRIPTION
## Description
This PR uses Infura as a default/fallback when wallets are not connected, so we can display information on futures markets on the dashboard.

## Related issue
closes #470 

## Motivation and Context
This fixes an important UX issue on the v2 beta.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15985212/161836618-2088efbd-4c59-49fd-a2fb-3cd859f0251d.png">
