### PR TITLE
Get correct market key from futures-market config

### DIFF
--- a/components/Input/CustomInput.tsx
+++ b/components/Input/CustomInput.tsx
@@ -17,7 +17,7 @@ const CustomInput: React.FC<CustomInputProps> = ({
 	value,
 	placeholder,
 	onChange,
-	right, 
+	right,
 	style,
 	className,
 	disabled,

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -33,6 +33,7 @@ import DepositMarginModal from './DepositMarginModal';
 import WithdrawMarginModal from './WithdrawMarginModal';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import Connector from 'containers/Connector';
+import { getMarketKey } from 'utils/futures';
 
 type TradeProps = {};
 
@@ -51,14 +52,16 @@ const Trade: React.FC<TradeProps> = () => {
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const router = useRouter();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
-	const { synthetixjs } = Connector.useContainer();
+	const { synthetixjs, network } = Connector.useContainer();
 
 	const marketAsset = (router.query.market?.[0] as CurrencyKey) ?? null;
 	const marketQuery = useGetFuturesMarkets();
 	const market = marketQuery?.data?.find(({ asset }) => asset === marketAsset) ?? null;
 
 	const futuresPositionHistoryQuery = useGetFuturesPositionHistory(marketAsset);
-	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(marketAsset);
+	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(
+		getMarketKey(marketAsset, network.id)
+	);
 	const futuresMarketsPosition = futuresMarketPositionQuery?.data ?? null;
 
 	const sUSDBalance = synthsBalancesQuery?.data?.balancesMap?.[Synths.sUSD]?.balance ?? zeroBN;

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -1,0 +1,18 @@
+import { NetworkId, NetworkIdByName } from '@synthetixio/contracts-interface';
+
+import futuresMarketsKovan from 'synthetix/publish/deployed/kovan-ovm/futures-markets.json';
+import futuresMarketsMainnet from 'synthetix/publish/deployed/mainnet-ovm/futures-markets.json';
+
+export const getMarketKey = (asset: string | null, networkId: NetworkId) => {
+	if (networkId === NetworkIdByName['mainnet-ovm']) {
+		return futuresMarketsMainnet.find((market) => market.asset === asset)?.marketKey || 'sETH';
+	} else if (networkId === NetworkIdByName['kovan-ovm']) {
+		return futuresMarketsKovan.find((market) => market.asset === asset)?.marketKey || 'sETH';
+	} else {
+		return 'sETH';
+	}
+};
+
+export const getDisplayAsset = (asset: string | null, networkId: NetworkId) => {
+	return asset ? (asset[0] === 's' ? asset.slice(1) : asset) : null;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue where the data on the futures market page was not displaying correctly, because the market key for new assets were not being parsed correctly.

## Related issue
- #595 

## Motivation and Context
This fixes issues with trading in the new markets (currently paused on mainnet-ovm)

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="374" alt="image" src="https://user-images.githubusercontent.com/15985212/161859080-5c7c0a1e-cecd-4763-a693-afaa41d4bcf0.png">

