### PR TITLE
Fix UI issues on close modal position 

### DIFF
--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -15,13 +15,14 @@ import GasPriceSelect from 'sections/shared/components/GasPriceSelect';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import Connector from 'containers/Connector';
 import Button from 'components/Button';
-import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { getExchangeRatesForCurrencies, synthToAsset } from 'utils/currencies';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { getTransactionPrice, gasPriceInWei } from 'utils/network';
 import { gasSpeedState } from 'store/wallet';
 import { FuturesFilledPosition } from 'queries/futures/types';
 import { walletAddressState } from 'store/wallet';
 import { parseGasPriceObject } from 'hooks/useGas';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
 
 type ClosePositionModalProps = {
 	onDismiss: () => void;
@@ -109,7 +110,7 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 			{
 				label: t('futures.market.user.position.modal-close.size'),
 				value: formatCurrency(currencyKey || '', position?.size ?? zeroBN, {
-					sign: currencyKey[0] === 's' ? currencyKey.slice(1) : currencyKey,
+					sign: synthToAsset(currencyKey as CurrencyKey),
 				}),
 			},
 			{

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -108,7 +108,9 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 			},
 			{
 				label: t('futures.market.user.position.modal-close.size'),
-				value: formatCurrency(currencyKey, position?.size ?? zeroBN, { currencyKey }),
+				value: formatCurrency(currencyKey || '', position?.size ?? zeroBN, {
+					sign: currencyKey[0] === 's' ? currencyKey.slice(1) : currencyKey,
+				}),
 			},
 			{
 				label: t('futures.market.user.position.modal-close.leverage'),

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -221,11 +221,11 @@ const ValueColumn = styled(FlexDivCol)`
 `;
 
 const StyledButton = styled(Button)`
-	width: 100%;
 	margin-top: 24px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
+	height: 55px; 
 `;
 
 const StyledGasPriceSelect = styled(GasPriceSelect)`


### PR DESCRIPTION
## Description

- Updated height on close button to match other gold buttons. 
- Removed "s" from synth symbol and moved after number on size row. 

## Related issue
closes #495

## Motivation and Context
Fixes small UI issues with close position modal

## How Has This Been Tested?
Tested visually after created position for BTC and ETH. 

## Screenshots (if appropriate):
![closepositionmodal](https://user-images.githubusercontent.com/101892440/161966134-3bbf9cab-c8e0-4f76-a0ae-7ef3fb3da6c2.png)
![close_btc](https://user-images.githubusercontent.com/101892440/161966974-6568b04b-5cc9-4bea-929d-809c1cd878c8.png)

