### PR TITLE
Hourly Candles

### DIFF
--- a/components/Input/CustomInput.tsx
+++ b/components/Input/CustomInput.tsx
@@ -17,7 +17,7 @@ const CustomInput: React.FC<CustomInputProps> = ({
 	value,
 	placeholder,
 	onChange,
-	right, 
+	right,
 	style,
 	className,
 	disabled,

--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -13,7 +13,7 @@ import {
 import { requestCandlesticks } from 'queries/rates/useCandlesticksQuery';
 import { combineDataToPair } from 'sections/exchange/TradeCard/Charts/hooks/useCombinedCandleSticksChartData';
 
-const supportedResolutions = ['H', 'D', 'W'] as ResolutionString[];
+const supportedResolutions = ['H', 'D'] as ResolutionString[];
 
 const config = {
 	supported_resolutions: supportedResolutions,
@@ -37,12 +37,13 @@ const fetchCombinedCandleSticks = async (
 	quote: string,
 	from: number,
 	to: number,
+	resolution: ResolutionString,
 	isL2: boolean
 ) => {
 	const baseCurrencyIsSUSD = base === Synths.sUSD;
 	const quoteCurrencyIsSUSD = quote === Synths.sUSD;
-	const baseData = await requestCandlesticks(base, from, to, isL2);
-	const quoteData = await requestCandlesticks(quote, from, to, isL2);
+	const baseData = await requestCandlesticks(base, from, to, resolution, isL2);
+	const quoteData = await requestCandlesticks(quote, from, to, resolution, isL2);
 	return combineDataToPair(baseData, quoteData, baseCurrencyIsSUSD, quoteCurrencyIsSUSD);
 };
 
@@ -85,7 +86,7 @@ const DataFeedFactory = (isL2: boolean = false): IBasicDataFeed => {
 			const { base, quote } = splitBaseQuote(symbolInfo.name);
 
 			try {
-				fetchCombinedCandleSticks(base, quote, from, to, isL2).then((bars) => {
+				fetchCombinedCandleSticks(base, quote, from, to, _resolution, isL2).then((bars) => {
 					const chartBars = bars.map((b) => {
 						return {
 							...b,

--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -13,7 +13,7 @@ import {
 import { requestCandlesticks } from 'queries/rates/useCandlesticksQuery';
 import { combineDataToPair } from 'sections/exchange/TradeCard/Charts/hooks/useCombinedCandleSticksChartData';
 
-const supportedResolutions = ['D', 'W'] as ResolutionString[];
+const supportedResolutions = ['H', 'D', 'W'] as ResolutionString[];
 
 const config = {
 	supported_resolutions: supportedResolutions,

--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -13,7 +13,7 @@ import { isL2State } from 'store/wallet';
 type Props = {
 	baseCurrencyKey: string;
 	quoteCurrencyKey: string;
-	interval: 'D';
+	interval: string;
 	containerId: string;
 	libraryPath: string;
 	fullscreen: boolean;
@@ -25,7 +25,7 @@ type Props = {
 export function TVChart({
 	baseCurrencyKey,
 	quoteCurrencyKey,
-	interval = 'D',
+	interval = 'H',
 	containerId = 'tv_chart_container',
 	libraryPath = '/static/charting_library/',
 	fullscreen = false,

--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -61,7 +61,6 @@ export function TVChart({
 			},
 			toolbar_bg: colors.selectedTheme.background,
 			time_frames: [
-				{ text: '3y', resolution: '1W', description: '3 Years' },
 				{ text: '1y', resolution: '1D', description: '1 Year' },
 				{ text: '6m', resolution: '1D', description: '6 Months' },
 				{ text: '3m', resolution: '1D', description: '3 Months' },

--- a/queries/rates/useCandlesticksQuery.ts
+++ b/queries/rates/useCandlesticksQuery.ts
@@ -7,45 +7,48 @@ export const requestCandlesticks = async (
 	minTimestamp: number,
 	maxTimestamp = Math.floor(Date.now() / 1000),
 	resolution: ResolutionString,
-	isL2 = false,
+	isL2 = false
 ) => {
 	const RATES_ENDPOINT = isL2
 		? 'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main'
 		: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/mainnet-main';
 
-	const period = 
-		resolution === '60' ? 3600 :
-		resolution === '1D' ? 86400 : 3600;
+	const period = resolution === '60' ? 3600 : resolution === '1D' ? 86400 : 3600;
 
 	const response = (await request(
 		RATES_ENDPOINT,
 		gql`
-					query candles($synth: String!, $minTimestamp: BigInt!, $maxTimestamp: BigInt!, $period: BigInt!) {
-						candles(
-							where: {
-								synth: $synth,
-								timestamp_gt: $minTimestamp,
-								timestamp_lt: $maxTimestamp,
-								period: $period
-							}
-							orderBy: id
-							orderDirection: desc
-						) {
-							id
-							synth
-							open
-							high
-							low
-							close
-							timestamp
-						}
+			query candles(
+				$synth: String!
+				$minTimestamp: BigInt!
+				$maxTimestamp: BigInt!
+				$period: BigInt!
+			) {
+				candles(
+					where: {
+						synth: $synth
+						timestamp_gt: $minTimestamp
+						timestamp_lt: $maxTimestamp
+						period: $period
 					}
-				`,
+					orderBy: id
+					orderDirection: desc
+				) {
+					id
+					synth
+					open
+					high
+					low
+					close
+					timestamp
+				}
+			}
+		`,
 		{
 			synth: currencyKey,
 			maxTimestamp: maxTimestamp,
 			minTimestamp: minTimestamp,
-			period: period
+			period: period,
 		}
 	)) as {
 		[key: string]: Array<Candle>;

--- a/queries/rates/useCandlesticksQuery.ts
+++ b/queries/rates/useCandlesticksQuery.ts
@@ -1,15 +1,21 @@
 import request, { gql } from 'graphql-request';
+import { ResolutionString } from 'public/static/charting_library/charting_library';
 import { Candle } from './types';
 
 export const requestCandlesticks = async (
 	currencyKey: string | null,
 	minTimestamp: number,
 	maxTimestamp = Math.floor(Date.now() / 1000),
+	resolution: ResolutionString,
 	isL2 = false,
 ) => {
 	const RATES_ENDPOINT = isL2
 		? 'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main'
 		: 'https://api.thegraph.com/subgraphs/name/synthetixio-team/mainnet-main';
+
+	const period = 
+		resolution === '60' ? 3600 :
+		resolution === '1D' ? 86400 : 3600;
 
 	const response = (await request(
 		RATES_ENDPOINT,
@@ -39,7 +45,7 @@ export const requestCandlesticks = async (
 			synth: currencyKey,
 			maxTimestamp: maxTimestamp,
 			minTimestamp: minTimestamp,
-			period: 3600
+			period: period
 		}
 	)) as {
 		[key: string]: Array<Candle>;

--- a/queries/rates/useCandlesticksQuery.ts
+++ b/queries/rates/useCandlesticksQuery.ts
@@ -6,7 +6,6 @@ export const requestCandlesticks = async (
 	minTimestamp: number,
 	maxTimestamp = Math.floor(Date.now() / 1000),
 	isL2 = false,
-	resolution = 'daily'
 ) => {
 	const RATES_ENDPOINT = isL2
 		? 'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main'
@@ -15,9 +14,14 @@ export const requestCandlesticks = async (
 	const response = (await request(
 		RATES_ENDPOINT,
 		gql`
-					query ${resolution}Candles($synth: String!, $minTimestamp: BigInt!, $maxTimestamp: BigInt!) {
-						${resolution}Candles(
-							where: { synth: $synth, timestamp_gt: $minTimestamp, timestamp_lt: $maxTimestamp }
+					query candles($synth: String!, $minTimestamp: BigInt!, $maxTimestamp: BigInt!, $period: BigInt!) {
+						candles(
+							where: {
+								synth: $synth,
+								timestamp_gt: $minTimestamp,
+								timestamp_lt: $maxTimestamp,
+								period: $period
+							}
 							orderBy: id
 							orderDirection: desc
 						) {
@@ -35,9 +39,10 @@ export const requestCandlesticks = async (
 			synth: currencyKey,
 			maxTimestamp: maxTimestamp,
 			minTimestamp: minTimestamp,
+			period: 3600
 		}
 	)) as {
 		[key: string]: Array<Candle>;
 	};
-	return response[`${resolution}Candles`].reverse();
+	return response[`candles`].reverse();
 };


### PR DESCRIPTION
Add hourly candles to TradingView chart

## Description
* Add hourly candles
* Set default to hourly
* Update subgraph entity from `dailyCandles` to `candles` and pass resolution
* Remove weekly candles

## Related issue
Fixes #552 
- #444 

## Motivation and Context
Traders have consistently requested shorter timeframes for pricing data.

## How Has This Been Tested?
Checked data against the subgraph and it looks correct. One issue I noticed is that there are some large gaps in the available data coming from the subgraph.

## Screenshots (if appropriate):
<img width="791" alt="image" src="https://user-images.githubusercontent.com/10401554/162035525-2209f2f7-7427-4f3e-9d89-f7457ff95a3d.png">

