### PR TITLE
Hotfix: Switch ClosePositionModal to useSynthetixTxn hook

### DIFF
--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -15,13 +15,12 @@ import GasPriceSelect from 'sections/shared/components/GasPriceSelect';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import Connector from 'containers/Connector';
 import Button from 'components/Button';
-import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import { getTransactionPrice, gasPriceInWei } from 'utils/network';
+import { newGetTransactionPrice } from 'utils/network';
 import { gasSpeedState } from 'store/wallet';
 import { FuturesFilledPosition } from 'queries/futures/types';
 import { walletAddressState } from 'store/wallet';
-import { parseGasPriceObject } from 'hooks/useGas';
 
 type ClosePositionModalProps = {
 	onDismiss: () => void;
@@ -39,13 +38,12 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 	const { t } = useTranslation();
 	const walletAddress = useRecoilValue(walletAddressState);
 	const { synthetixjs } = Connector.useContainer();
-	const { useEthGasPriceQuery, useExchangeRatesQuery } = useSynthetixQueries();
+	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
 	const ethGasPriceQuery = useEthGasPriceQuery();
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const gasSpeed = useRecoilValue(gasSpeedState);
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const [error, setError] = useState<string | null>(null);
-	const [gasLimit, setGasLimit] = useState<number | null>(null);
 	const [orderFee, setOrderFee] = useState<Wei>(wei(0));
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 
@@ -60,35 +58,42 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 	);
 
 	const ethPriceRate = useMemo(
-		() => getExchangeRatesForCurrencies(exchangeRates, Synths.sETH, selectedPriceCurrency.name),
+		() => newGetExchangeRatesForCurrencies(exchangeRates, Synths.sETH, selectedPriceCurrency.name),
 		[exchangeRates, selectedPriceCurrency.name]
 	);
 
-	const gasPrice = ethGasPriceQuery?.data?.[gasSpeed]
-		? parseGasPriceObject(ethGasPriceQuery?.data?.[gasSpeed])
-		: null;
+	const gasPrice = ethGasPriceQuery.data != null ? ethGasPriceQuery.data[gasSpeed] : null;
 
-	const transactionFee = useMemo(() => getTransactionPrice(gasPrice, gasLimit, ethPriceRate), [
-		gasPrice,
-		gasLimit,
-		ethPriceRate,
-	]);
+	const closeTxn = useSynthetixTxn(
+		`FuturesMarket${currencyKey[0] === 's' ? currencyKey : `s${currencyKey}`}`,
+		'closePosition',
+		[],
+		gasPrice ?? undefined,
+		{ enabled: !!currencyKey }
+	);
+
+	const transactionFee = useMemo(
+		() =>
+			newGetTransactionPrice(
+				gasPrice,
+				closeTxn.gasLimit,
+				ethPriceRate,
+				closeTxn.optimismLayerOneFee
+			),
+		[gasPrice, ethPriceRate, closeTxn.gasLimit, closeTxn.optimismLayerOneFee]
+	);
 
 	const positionSize = position?.size ?? wei(0);
 
 	useEffect(() => {
-		const getGasLimit = async () => {
+		const getOrderFee = async () => {
 			try {
-				if (!synthetixjs || !currencyKey || !walletAddress || !positionSize) return;
+				if (!synthetixjs || !currencyKey || !positionSize) return;
 				setError(null);
 				const FuturesMarketContract = getFuturesMarketContract(currencyKey, synthetixjs!.contracts);
-				const size = wei(-positionSize);
-				const [estimate, orderFee] = await Promise.all([
-					FuturesMarketContract.estimateGas.closePosition(),
-					FuturesMarketContract.orderFee(size.toBN()),
-				]);
+				const size = positionSize.neg();
+				const orderFee = await FuturesMarketContract.orderFee(size.toBN());
 				setOrderFee(wei(orderFee.fee));
-				setGasLimit(Number(estimate));
 			} catch (e) {
 				// @ts-ignore
 				console.log(e.message);
@@ -96,7 +101,7 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 				setError(e?.data?.message ?? e.message);
 			}
 		};
-		getGasLimit();
+		getOrderFee();
 	}, [synthetixjs, currencyKey, walletAddress, positionSize]);
 
 	const dataRows = useMemo(() => {
@@ -125,28 +130,19 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 		];
 	}, [position, currencyKey, t, orderFee]);
 
-	const handleClosePosition = async () => {
-		if (!gasLimit || !gasPrice) return;
-		try {
-			const FuturesMarketContract = getFuturesMarketContract(currencyKey, synthetixjs!.contracts);
-			const tx = await FuturesMarketContract.closePosition({
-				gasLimit,
-				gasPrice: gasPriceInWei(gasPrice),
+	useEffect(() => {
+		if (closeTxn.hash) {
+			monitorTransaction({
+				txHash: closeTxn.hash,
+				onTxConfirmed: () => {
+					onDismiss();
+					onPositionClose();
+				},
 			});
-			if (tx) {
-				monitorTransaction({
-					txHash: tx.hash,
-					onTxConfirmed: () => {
-						onDismiss();
-						onPositionClose();
-					},
-				});
-			}
-		} catch (e) {
-			console.log(e);
-			setError(e?.data?.message ?? e.message);
 		}
-	};
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [closeTxn.hash]);
 
 	return (
 		<StyledBaseModal
@@ -170,10 +166,10 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 					variant="primary"
 					isRounded
 					size="lg"
-					onClick={handleClosePosition}
-					disabled={!gasLimit || !!error}
+					onClick={() => closeTxn.mutate()}
+					disabled={!!error || !!closeTxn.errorMessage}
 				>
-					{error || t('futures.market.user.position.modal-close.title')}
+					{error || closeTxn.errorMessage || t('futures.market.user.position.modal-close.title')}
 				</StyledButton>
 			</>
 		</StyledBaseModal>

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -20,7 +20,6 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { newGetTransactionPrice } from 'utils/network';
 import { gasSpeedState } from 'store/wallet';
 import { FuturesFilledPosition } from 'queries/futures/types';
-import { walletAddressState } from 'store/wallet';
 
 type ClosePositionModalProps = {
 	onDismiss: () => void;
@@ -36,7 +35,6 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 	onPositionClose,
 }) => {
 	const { t } = useTranslation();
-	const walletAddress = useRecoilValue(walletAddressState);
 	const { synthetixjs } = Connector.useContainer();
 	const { useEthGasPriceQuery, useExchangeRatesQuery, useSynthetixTxn } = useSynthetixQueries();
 	const ethGasPriceQuery = useEthGasPriceQuery();
@@ -102,7 +100,7 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 			}
 		};
 		getOrderFee();
-	}, [synthetixjs, currencyKey, walletAddress, positionSize]);
+	}, [synthetixjs, currencyKey, positionSize]);
 
 	const dataRows = useMemo(() => {
 		if (!position || !currencyKey) return [];


### PR DESCRIPTION
## Description
This PR makes the `ClosePositionModal` use the `useSynthetixTxn` hook for creating transactions, to solve out-of-gas errors.

## Related issue
N/A

## Motivation and Context
This PR fixes a bug in the v2 beta.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
