### PR TITLE
ci: use public docker containers without auth

### DIFF
--- a/.github/workflows/audit_build_verify.yml
+++ b/.github/workflows/audit_build_verify.yml
@@ -12,10 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/synthetixio/docker-sec-tools/alpine:16.14
-      credentials:
-        username: synthetixio
-        password: ${{ secrets.GH_PACKAGES_READ_ONLY }}
+      image: synthetixio/docker-sec-tools:16.14-alpine
 
     steps:
       - name: Checkout
@@ -34,10 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/synthetixio/docker-node/alpine:16.14
-      credentials:
-        username: synthetixio
-        password: ${{ secrets.GH_PACKAGES_READ_ONLY }}
+      image: synthetixio/docker-node:16.14-alpine
 
     steps:
       - name: Checkout
@@ -93,10 +87,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/synthetixio/docker-node/alpine:16.14
-      credentials:
-        username: synthetixio
-        password: ${{ secrets.GH_PACKAGES_READ_ONLY }}
+      image: synthetixio/docker-node:16.14-alpine
 
     steps:
       - name: Checkout

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,11 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/synthetixio/docker-e2e/base:12.20
-      credentials:
-        username: synthetixio
-        password: ${{ secrets.GH_PACKAGES_READ_ONLY }}
-      options: --shm-size=7gb
+      image: synthetixio/docker-e2e:16.14-ubuntu
 
     steps:
       - name: Checkout
@@ -28,8 +24,8 @@ jobs:
           lhci autorun --config=tests/lighthouse/lhci-desktop.conf.js
           lhci autorun --config=tests/lighthouse/lhci-mobile.conf.js
         env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            BASE_URL: ${{ github.event.inputs.url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_URL: ${{ github.event.inputs.url }}
         continue-on-error: true
 
       - name: Archive lighthouse artifacts


### PR DESCRIPTION
Signed-off-by: Jakub Mucha <jakub.mucha@icloud.com>

## Description
Fixes and issue when PRs from external contributors are failing because of not being able to access repository secrets.