### PR TITLE
Fix disable input no wallet connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"babel-eslint": "10.1.0",
 		"babel-loader": "^8.2.3",
 		"babel-plugin-styled-components": "1.11.1",
-		"eslint": "7.12.0",
+		"eslint": "^7.12.0",
 		"eslint-config-prettier": "6.10.1",
 		"eslint-config-react-app": "6.0.0",
 		"eslint-plugin-chai-friendly": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"babel-eslint": "10.1.0",
 		"babel-loader": "^8.2.3",
 		"babel-plugin-styled-components": "1.11.1",
-		"eslint": "^7.12.0",
+		"eslint": "7.12.0",
 		"eslint-config-prettier": "6.10.1",
 		"eslint-config-react-app": "6.0.0",
 		"eslint-plugin-chai-friendly": "^0.7.2",

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -251,7 +251,10 @@ const Trade: React.FC<TradeProps> = () => {
 					{t('futures.market.trade.button.deposit')}
 				</MarketActionButton>
 				<MarketActionButton
-					disabled={!futuresMarketsPosition?.remainingMargin || futuresMarketsPosition.remainingMargin.lte(zeroBN)}
+					disabled={
+						!futuresMarketsPosition?.remainingMargin ||
+						futuresMarketsPosition.remainingMargin.lte(zeroBN)
+					}
 					onClick={() => setIsWithdrawMarginModalOpen(true)}
 				>
 					{t('futures.market.trade.button.withdraw')}
@@ -282,7 +285,10 @@ const Trade: React.FC<TradeProps> = () => {
 			<PositionButtons selected={leverageSide} onSelect={setLeverageSide} />
 
 			<OrderSizing
-				disabled={!futuresMarketsPosition?.remainingMargin || futuresMarketsPosition.remainingMargin.lte(zeroBN)}
+				disabled={
+					!futuresMarketsPosition?.remainingMargin ||
+					futuresMarketsPosition.remainingMargin.lte(zeroBN)
+				}
 				amount={tradeSize}
 				amountSUSD={tradeSizeSUSD}
 				assetRate={marketAssetRate}

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -14,7 +14,7 @@ import { PositionSide } from '../types';
 import { useRecoilState } from 'recoil';
 import { gasSpeedState } from 'store/wallet';
 import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
-import { walletAddressState } from 'store/wallet';
+import { isWalletConnectedState, walletAddressState } from 'store/wallet';
 import TransactionNotifier from 'containers/TransactionNotifier';
 
 import LeverageInput from '../LeverageInput';
@@ -43,6 +43,7 @@ const DEFAULT_MAX_LEVERAGE = wei(10);
 const Trade: React.FC<TradeProps> = () => {
 	const { t } = useTranslation();
 	const walletAddress = useRecoilValue(walletAddressState);
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
 	const { useSynthsBalancesQuery, useEthGasPriceQuery, useSynthetixTxn } = useSynthetixQueries();
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const exchangeRatesQuery = useExchangeRatesQuery();
@@ -252,8 +253,7 @@ const Trade: React.FC<TradeProps> = () => {
 				</MarketActionButton>
 				<MarketActionButton
 					disabled={
-						!futuresMarketsPosition?.remainingMargin ||
-						futuresMarketsPosition.remainingMargin.lte(zeroBN)
+						!isWalletConnected || futuresMarketsPosition?.remainingMargin?.lte(zeroBN) 
 					}
 					onClick={() => setIsWithdrawMarginModalOpen(true)}
 				>
@@ -286,8 +286,7 @@ const Trade: React.FC<TradeProps> = () => {
 
 			<OrderSizing
 				disabled={
-					!futuresMarketsPosition?.remainingMargin ||
-					futuresMarketsPosition.remainingMargin.lte(zeroBN)
+					!isWalletConnected || futuresMarketsPosition?.remainingMargin?.lte(zeroBN) 
 				}
 				amount={tradeSize}
 				amountSUSD={tradeSizeSUSD}

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -251,7 +251,7 @@ const Trade: React.FC<TradeProps> = () => {
 					{t('futures.market.trade.button.deposit')}
 				</MarketActionButton>
 				<MarketActionButton
-					disabled={futuresMarketsPosition?.remainingMargin?.lte(zeroBN)}
+					disabled={!futuresMarketsPosition?.remainingMargin || futuresMarketsPosition.remainingMargin.lte(zeroBN)}
 					onClick={() => setIsWithdrawMarginModalOpen(true)}
 				>
 					{t('futures.market.trade.button.withdraw')}
@@ -282,13 +282,13 @@ const Trade: React.FC<TradeProps> = () => {
 			<PositionButtons selected={leverageSide} onSelect={setLeverageSide} />
 
 			<OrderSizing
-				disabled={futuresMarketsPosition?.remainingMargin?.lte(zeroBN)}
+				disabled={!futuresMarketsPosition?.remainingMargin || futuresMarketsPosition.remainingMargin.lte(zeroBN)}
 				amount={tradeSize}
 				amountSUSD={tradeSizeSUSD}
 				assetRate={marketAssetRate}
 				onAmountChange={onTradeAmountChange}
 				onAmountSUSDChange={onTradeAmountSUSDChange}
-				marketAsset={marketAsset || Synths.sUSD}
+				marketAsset={marketAsset || Synths.sUSD}	
 			/>
 
 			<LeverageInput

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -288,7 +288,7 @@ const Trade: React.FC<TradeProps> = () => {
 				assetRate={marketAssetRate}
 				onAmountChange={onTradeAmountChange}
 				onAmountSUSDChange={onTradeAmountSUSDChange}
-				marketAsset={marketAsset || Synths.sUSD}	
+				marketAsset={marketAsset || Synths.sUSD}
 			/>
 
 			<LeverageInput


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disable the order amount input and withdrawal button when wallet is not connected 
## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves: #617 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):
