### PR TITLE
Funding Fallback

### DIFF
--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -66,8 +66,13 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const pastPrice = dailyPriceChanges.find((price: Price) => price.synth === baseCurrencyKey);
 
 	const data: MarketData = React.useMemo(() => {
-		const fundingTitle = `${avgFundingRate ? '24H' : 'Inst.'} Funding Rate`;
-		const fundingValue = avgFundingRate ?? marketSummary?.currentFundingRate;
+		const fundingTitle = `${
+			fundingRateQuery.failureCount > 0 && !avgFundingRate && !!marketSummary ? 'Inst.' : '24H'
+		} Funding Rate`;
+		const fundingValue =
+			fundingRateQuery.failureCount > 0 && !avgFundingRate && !!marketSummary
+				? marketSummary?.currentFundingRate
+				: avgFundingRate;
 
 		return {
 			[baseCurrencyKey

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -184,6 +184,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 		externalPrice,
 		pastPrice?.price,
 		avgFundingRate,
+		fundingRateQuery,
 	]);
 
 	return (

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -66,6 +66,9 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const pastPrice = dailyPriceChanges.find((price: Price) => price.synth === baseCurrencyKey);
 
 	const data: MarketData = React.useMemo(() => {
+		const fundingTitle = `${avgFundingRate ? '24H' : 'Inst.'} Funding Rate`;
+		const fundingValue = avgFundingRate ?? marketSummary?.currentFundingRate;
+
 		return {
 			[baseCurrencyKey
 				? `${baseCurrencyKey[0] === 's' ? baseCurrencyKey.slice(1) : baseCurrencyKey}-PERP`
@@ -158,15 +161,9 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 					NO_VALUE
 				),
 			},
-			'24H Funding Rate': {
-				value: avgFundingRate
-					? formatPercent(avgFundingRate ?? zeroBN, { minDecimals: 6 })
-					: NO_VALUE,
-				color: avgFundingRate?.gt(zeroBN)
-					? 'green'
-					: avgFundingRate?.lt(zeroBN)
-					? 'red'
-					: undefined,
+			[fundingTitle]: {
+				value: fundingValue ? formatPercent(fundingValue ?? zeroBN, { minDecimals: 6 }) : NO_VALUE,
+				color: fundingValue?.gt(zeroBN) ? 'green' : fundingValue?.lt(zeroBN) ? 'red' : undefined,
 			},
 			'Max Leverage': {
 				value: marketSummary?.maxLeverage ? `${marketSummary?.maxLeverage.toString(0)}x` : NO_VALUE,


### PR DESCRIPTION
Add a fallback to the instantaneous funding rate when average funding is not available.

## Description
This change will ensure that we always have a value in the "Funding Rate" area of Market Details

## Related issue
None

## Motivation and Context
When we are missing recent funding events, this metric will fail to calculate and will be blank.
