### PR TITLE
fix theme colors

### DIFF
--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -197,8 +197,8 @@ const NetworkFees = styled(FlexDivCol)`
 `;
 
 const Label = styled.div`
-	font-family: ${(props) => props.theme.fonts.bold};
-	color: ${(props) => props.theme.colors.blueberry};
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 	font-size: 12px;
 	text-transform: capitalize;
 	margin-top: 6px;
@@ -228,10 +228,10 @@ const StyledGasPriceSelect = styled(GasPriceSelect)`
 	display: flex;
 	justify-content: space-between;
 	width: auto;
-	border-bottom: 1px solid ${(props) => props.theme.colors.navy};
-	color: ${(props) => props.theme.colors.blueberry};
+	border-bottom: 1px solid ${(props) => props.theme.colors.selectedTheme.border};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 	font-size: 12px;
-	font-family: ${(props) => props.theme.fonts.bold};
+	font-family: ${(props) => props.theme.fonts.regular};
 	text-transform: capitalize;
 	margin-bottom: 8px;
 `;

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -215,7 +215,7 @@ const StyledGasPriceSelect = styled(GasPriceSelect)`
 	border-bottom: 1px solid ${(props) => props.theme.colors.selectedTheme.border};
 	color: ${(props) => props.theme.colors.common.secondaryGray};
 	font-size: 12px;
-	font-family: ${(props) => props.theme.fonts.bold};
+	font-family: ${(props) => props.theme.fonts.regular};
 	text-transform: capitalize;
 	margin-bottom: 8px;
 `;

--- a/translations/en.json
+++ b/translations/en.json
@@ -999,7 +999,7 @@
 		"switch": "switch",
 		"summary": {
 			"gas-prices": {
-				"title": "gas price (GWEI)",
+				"title": "gas price (Gwei)",
 				"average": "Average",
 				"fast": "Fast",
 				"fastest": "Fastest"


### PR DESCRIPTION
## Description
The font-family and color for labels in the `ClosePositionModal` and `TradeConfirmationModal` were not updated yet to the new v2 layout. This commit takes care of that. Also, the label for "GWEI" has been updated to "Gwei".


