### PR TITLE
fixing tooltip issue - no divs as children of p tags

### DIFF
--- a/components/Tooltip/TooltipStyles.tsx
+++ b/components/Tooltip/TooltipStyles.tsx
@@ -11,64 +11,62 @@ interface ToolTipStyleProps {
 }
 
 export const Tooltip = styled.div<ToolTipStyleProps>`
-    height: 50px;
-    width: 189px;
-    background: linear-gradient(180deg, #1E1D1D 0%, #161515 100%);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-sizing: border-box;
-    box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25), inset 0px 1px 0px rgba(255, 255, 255, 0.1), inset 0px 0px 20px rgba(255, 255, 255, 0.03);
-    border-radius: 10px;
-    padding: 1em;
-    position: absolute;
-    top: ${(props) => props.top};
-    bottom: ${(props) => props.bottom};
-    left: ${(props) => props.left};
-    right: ${(props) => props.right};
+		height: 50px;
+		width: 189px;
+		background: linear-gradient(180deg, #1E1D1D 0%, #161515 100%);
+		border: 1px solid rgba(255, 255, 255, 0.1);
+		box-sizing: border-box;
+		box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25), inset 0px 1px 0px rgba(255, 255, 255, 0.1), inset 0px 0px 20px rgba(255, 255, 255, 0.03);
+		border-radius: 10px;
+		padding: 1em;
+		position: absolute;
+		top: ${(props) => props.top};
+		bottom: ${(props) => props.bottom};
+		left: ${(props) => props.left};
+		right: ${(props) => props.right};
 
-    p {
-	margin: auto;
-	font-size: 12px;
-	text-align: left;
-        font-family: ${(props) => props.theme.fonts.mono};
-        font-style: normal;
-        font-weight: 400;
-        line-height: 12px;
-        color: ${(props) => props.theme.colors.white};
-        
-	}
+		p, span {
+			margin: auto;
+			font-size: 12px;
+			text-align: left;
+			font-family: ${(props) => props.theme.fonts.mono};
+			font-style: normal;
+			font-weight: 400;
+			line-height: 12px;
+			color: ${(props) => props.theme.colors.white};
+		}
 
-    ${(props) =>
+		${(props) =>
 			props.preset === 'top' &&
 			`
-             top: 0;
-             left: 50%;
-             transform: translate(-50%, -150%);
-             text-align: center;
-             display: inline-block;
+				top: 0;
+				left: 50%;
+				transform: translate(-50%, -150%);
+				text-align: center;
+				display: inline-block;
+			`}
 
-            `}
-    
-    ${(props) =>
+		${(props) =>
 			props.preset === 'bottom' &&
 			`
-             bottom: 0;
-             transform: translate(-25%, 125%);
-            `}
-    
-    ${(props) =>
+				bottom: 0;
+				transform: translate(-25%, 125%);
+			`}
+
+		${(props) =>
 			props.preset === 'left' &&
 			`
-             left: 0;
-             transform: translate(-105%, -80%);
-            `}
-    
-    ${(props) =>
+				left: 0;
+				transform: translate(-105%, -80%);
+			`}
+
+		${(props) =>
 			props.preset === 'right' &&
 			`
-             right: 0;
-             transform: translate(105%, -80%);
-            `}
-    `;
+				right: 0;
+				transform: translate(105%, -80%);
+			`}
+		`;
 
 export const ToolTipWrapper = styled.div`
 	position: relative;

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -178,7 +178,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 			{Object.entries(data).map(([key, { value, color }]) => (
 				<div key={key}>
 					<p className="heading">{key}</p>
-					<p className={color ? `value ${color}` : 'value'}>{value}</p>
+					<span className={color ? `value ${color}` : 'value'}>{value}</span>
 				</div>
 			))}
 		</MarketDetailsContainer>
@@ -200,7 +200,8 @@ const MarketDetailsContainer = styled.div`
 	border-radius: 10px;
 	box-sizing: border-box;
 
-	p {
+	p,
+	span {
 		margin: 0;
 		text-align: left;
 	}


### PR DESCRIPTION
validateDOMNesting(...): <div> cannot appear as a descendant of <p>.

## Description
Noticed a small issue with the tooltips on the markets page - cannot render `div` under `p` tags.

solution is to render a span instead of a `p` tag

## Related issue
N/A

## Motivation and Context
tooltips were recently changed (Friday), I believe this issue could be a symptom of the changes

## How Has This Been Tested?
in development environment - no error after changes; no styling changes on market row

## Screenshots (if appropriate):
![Screen Shot 2022-04-10 at 6 21 38 PM](https://user-images.githubusercontent.com/5998100/162766541-3b45c8b1-f13e-4617-b97a-237d3db75936.png)
