### PR TITLE
Load state ens

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/WalletActions.tsx
+++ b/sections/shared/Layout/AppLayout/Header/WalletActions.tsx
@@ -40,9 +40,8 @@ export const WalletActions: FC = () => {
 	const hardwareWallet = isHardwareWallet();
 
 	const [ensName, setEns] = useState<string>('');
+	const [walletLabel, setWalletLabel] = useState<string>('');
 	const truncatedWalletAddress = useRecoilValue(truncatedWalletAddressState);
-
-	const walletLabel = ensName ? ensName : truncatedWalletAddress;
 
 	const WALLET_OPTIONS = useMemo(() => {
 		let options = [
@@ -101,10 +100,12 @@ export const WalletActions: FC = () => {
 
 	useEffect(() => {
 		if (signer) {
+			setWalletLabel('loading...');
 			signer.getAddress().then((account: string) => {
 				const _account = account;
 				getENSName(_account, staticMainnetProvider).then((_ensName: string) => {
 					setEns(_ensName);
+					setWalletLabel(_ensName || truncatedWalletAddress!);
 				});
 			});
 		}


### PR DESCRIPTION
There are some flickers on the wallet nav item when changing wallet addresses WHEN the address has an ens name. This has to do with fetching the ens name.

## Description
adding a loading state between wallet address changes which allows time for ens to resolve

## Related issue
N/A

## Motivation and Context
fix small ui response with ens names and wallet addresses

## How Has This Been Tested?
locally in development switching between accounts.

## Screenshots (if appropriate):

screen shots are hard for this one, recorded a video instead

https://www.loom.com/share/6234e5ac2d7642b58b578deeb19392eb