### PR TITLE
Add incremental data refresh

### DIFF
--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -30,7 +30,7 @@ type MarketData = Record<string, { value: string | JSX.Element; color?: string }
 const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const { network } = Connector.useContainer();
 	const { useExchangeRatesQuery } = useSynthetixQueries();
-	const exchangeRatesQuery = useExchangeRatesQuery();
+	const exchangeRatesQuery = useExchangeRatesQuery({ refetchInterval: 6000 });
 	const futuresMarketsQuery = useGetFuturesMarkets();
 	const futuresTradingVolumeQuery = useGetFuturesTradingVolume(baseCurrencyKey);
 

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -36,7 +36,10 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset }) => {
 	const { network } = Connector.useContainer();
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(
-		getMarketKey(marketAsset, network.id)
+		getMarketKey(marketAsset, network.id),
+		{
+			refetchInterval: 6000,
+		}
 	);
 	const futuresPositionHistoryQuery = useGetFuturesPositionHistory(marketAsset);
 	const futuresMarketsPosition = futuresMarketPositionQuery?.data ?? null;


### PR DESCRIPTION
Add incremental data refresh to react queries

## Description
Adding data refresh to:
* Oracle price data on market details
* External price on market details (oracle price is a dependency)
* Position card (unrealized pnl)

## Related issue
#664 

## Motivation and Context
Oracle prices do not update on the frontend when the contract receives updates, which can cause a disconnect between actual positions and what is shown on the page if a trader leaves it open for a long time (>15 minutes)

## How Has This Been Tested?
* Open this version of the app
* Open live version at `v2.beta.kwenta.io`
* Leave them open for 15+ minutes
* Check that price updates on new version
