### PR TITLE
Sort Futures table in Dashboard by Volume

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -37,6 +37,7 @@ type TableProps = {
 	hiddenColumns?: string[];
 	hideHeaders?: boolean;
 	highlightRowsOnHover?: boolean;
+	sortBy?: object[];
 };
 
 export const Table: FC<TableProps> = ({
@@ -54,6 +55,7 @@ export const Table: FC<TableProps> = ({
 	hiddenColumns = [],
 	hideHeaders,
 	highlightRowsOnHover,
+	sortBy = [],
 }) => {
 	const memoizedColumns = useMemo(
 		() => columns,
@@ -91,6 +93,7 @@ export const Table: FC<TableProps> = ({
 			initialState: {
 				pageSize: showPagination ? (pageSize ? pageSize : MAX_PAGE_ROWS) : data.length,
 				hiddenColumns: hiddenColumns,
+				sortBy: sortBy,
 			},
 			...options,
 		},

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -79,6 +79,12 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 					router.push(`/market/${row.original.asset}`);
 				}}
 				highlightRowsOnHover
+				sortBy={[
+					{
+						id: 'dailyVolume',
+						desc: true,
+					},
+				]}
 				columns={[
 					{
 						Header: (
@@ -215,6 +221,14 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 							);
 						},
 						width: 125,
+						sortType: useMemo(
+							() => (rowA: any, rowB: any) => {
+								const rowOne = rowA.original.volume;
+								const rowTwo = rowB.original.volume;
+								return rowOne > rowTwo ? 1 : -1;
+							},
+							[]
+						),
 					},
 				]}
 			/>


### PR DESCRIPTION

## Description

The table in FuturesMarketsTable.tsx pulls in the component from Table.tsx. The Table component did not have a prop setup to specify a default sorting preference. 

In the Table.tsx component, I added a `sortBy` prop, which can be passed on any table to specify the `columnId` to sort and a boolean for whether the sorting should be `desc`.

## Related issue
https://github.com/Kwenta/kwenta/issues/615

## Motivation and Context
When traders access the Kwenta dashboard, we want futures markets with higher volume to be listed at the top, and lower volumes to be listed at the bottom. This sorting will allow traders to quickly at a glance determine what markets have a lot of volume. 

## How Has This Been Tested?
Visual testing to confirm everything works.

## Screenshots (if appropriate):
<img width="928" alt="image" src="https://user-images.githubusercontent.com/100385397/163000392-63c46ed0-f3ee-4e87-aa99-33ed72f4b692.png">

<img width="948" alt="image" src="https://user-images.githubusercontent.com/100385397/163000520-9b29d7d3-3969-49ac-91c5-deb70f269ed6.png">

