### PR TITLE
Leaderboard

### DIFF
--- a/assets/svg/app/caret-left-end.svg
+++ b/assets/svg/app/caret-left-end.svg
@@ -1,6 +1,6 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.25 13.5L8.75 8L14.25 2.5L12.75 1L5.75 8L12.75 15L14.25 13.5Z" fill="url(#caret-left-end_paint0_linear)"/>
-<rect x="3" y="15.25" width="2" height="14" transform="rotate(-180 3 15.25)" fill="url(#caret-left-end_paint1_linear)"/>
+<path d="M14.25 13.5L8.75 8L14.25 2.5L12.75 1L5.75 8L12.75 15L14.25 13.5Z" />
+<rect x="3" y="15.25" width="2" height="14" transform="rotate(-180 3 15.25)" />
 <defs>
 <linearGradient id="caret-left-end_paint0_linear" x1="14.25" y1="8" x2="5.75" y2="8" gradientUnits="userSpaceOnUse">
 <stop stop-color="#BE9461"/>

--- a/assets/svg/app/caret-left.svg
+++ b/assets/svg/app/caret-left.svg
@@ -1,5 +1,5 @@
 <svg width="10" height="15" viewBox="0 0 10 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9.25 1.75L3.75 7.25L9.25 12.75L7.75 14.25L0.75 7.25L7.75 0.25L9.25 1.75Z" fill="url(#caret-left_paint0_linear)"/>
+<path d="M9.25 1.75L3.75 7.25L9.25 12.75L7.75 14.25L0.75 7.25L7.75 0.25L9.25 1.75Z" />
 <defs>
 <linearGradient id="caret-left_paint0_linear" x1="9.25" y1="7.25" x2="0.75" y2="7.25" gradientUnits="userSpaceOnUse">
 <stop stop-color="#BE9461"/>

--- a/assets/svg/app/caret-right-end.svg
+++ b/assets/svg/app/caret-right-end.svg
@@ -1,6 +1,6 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 2.75L6.5 8.25L1 13.75L2.5 15.25L9.5 8.25L2.5 1.25L1 2.75Z" fill="url(#caret-right-end_paint0_linear)"/>
-<rect x="12.25" y="1" width="2" height="14" fill="url(#caret-right-end_paint1_linear)"/>
+<path d="M1 2.75L6.5 8.25L1 13.75L2.5 15.25L9.5 8.25L2.5 1.25L1 2.75Z" />
+<rect x="12.25" y="1" width="2" height="14" />
 <defs>
 <linearGradient id="caret-right-end_paint0_linear" x1="1" y1="8.25" x2="9.5" y2="8.25" gradientUnits="userSpaceOnUse">
 <stop stop-color="#BE9461"/>

--- a/assets/svg/app/caret-right.svg
+++ b/assets/svg/app/caret-right.svg
@@ -1,5 +1,5 @@
 <svg width="10" height="15" viewBox="0 0 10 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0.75 1.75L6.25 7.25L0.750001 12.75L2.25 14.25L9.25 7.25L2.25 0.25L0.75 1.75Z" fill="url(#caret-right_paint0_linear)"/>
+<path d="M0.75 1.75L6.25 7.25L0.750001 12.75L2.25 14.25L9.25 7.25L2.25 0.25L0.75 1.75Z" />
 <defs>
 <linearGradient id="caret-right_paint0_linear" x1="0.75" y1="7.25" x2="9.25" y2="7.25" gradientUnits="userSpaceOnUse">
 <stop stop-color="#BE9461"/>

--- a/components/Table/Pagination.tsx
+++ b/components/Table/Pagination.tsx
@@ -72,7 +72,6 @@ const PageInfo = styled.span`
 
 const PaginationContainer = styled(GridDivCenteredCol)`
 	grid-template-columns: auto 1fr auto;
-	background-color: ${(props) => props.theme.colors.elderberry};
 	padding: 15px 12px;
 	border-bottom-left-radius: 4px;
 	border-bottom-right-radius: 4px;
@@ -89,7 +88,7 @@ const ArrowButton = styled.button`
 	svg {
 		width: 14px;
 		height: 14px;
-		color: ${(props) => props.theme.colors.goldColors.color1};
+		fill: ${(props) => props.theme.colors.common.primaryWhite};
 	}
 `;
 

--- a/components/Table/Pagination.tsx
+++ b/components/Table/Pagination.tsx
@@ -67,7 +67,7 @@ const Pagination: FC<PaginationProps> = ({
 };
 
 const PageInfo = styled.span`
-	color: ${(props) => props.theme.colors.silver};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 `;
 
 const PaginationContainer = styled(GridDivCenteredCol)`

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -179,7 +179,11 @@ export const QUERY_KEYS = {
 		],
 		Participants: () => ['futures', 'participants'],
 		Participant: (walletAddress: string) => ['futures', 'participant', walletAddress],
-		Stats: ['futures', 'stats'],
+		Stats: (networkId: NetworkId) => [
+			'futures',
+			'stats',
+			networkId
+		],
 		AverageLeverage: ['futures', 'averageLeverage'],
 		CumulativeVolume: ['futures', 'cumulativeVolume'],
 		TotalLiquidations: ['futures', 'totalLiquidations'],

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -179,11 +179,7 @@ export const QUERY_KEYS = {
 		],
 		Participants: () => ['futures', 'participants'],
 		Participant: (walletAddress: string) => ['futures', 'participant', walletAddress],
-		Stats: (networkId: NetworkId) => [
-			'futures',
-			'stats',
-			networkId
-		],
+		Stats: (networkId: NetworkId) => ['futures', 'stats', networkId],
 		AverageLeverage: ['futures', 'averageLeverage'],
 		CumulativeVolume: ['futures', 'cumulativeVolume'],
 		TotalLiquidations: ['futures', 'totalLiquidations'],

--- a/queries/futures/useGetStats.ts
+++ b/queries/futures/useGetStats.ts
@@ -42,7 +42,7 @@ const useGetStats = (options?: UseQueryOptions<any>) => {
 	};
 
 	return useQuery({
-		queryKey: QUERY_KEYS.Futures.Stats,
+		queryKey: QUERY_KEYS.Futures.Stats(network.id),
 		queryFn: () => query([], 0),
 		enabled: isAppReady && isL2,
 		...options,

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -60,10 +60,6 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 				liquidations: (pnlMap[stat.account]?.liquidations ?? wei(0)).toNumber(),
 				'24h': 80000,
 				pnl: (pnlMap[stat.account]?.pnl ?? wei(0)).toNumber(),
-				pnlPct:
-					pnlMap[stat.account]?.totalVolume > 0
-						? pnlMap[stat.account]?.pnl.div(pnlMap[stat.account]?.totalVolume).toNumber()
-						: 0,
 			}))
 			.filter((i: { trader: string }) =>
 				searchTerm?.length ? i.trader.toLowerCase().includes(searchTerm) : true
@@ -139,14 +135,14 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 						Header: <TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>,
 						accessor: 'totalTrades',
 						sortType: 'basic',
-						width: 175,
+						width: 100,
 						sortable: true,
 					},
 					{
 						Header: <TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>,
 						accessor: 'liquidations',
 						sortType: 'basic',
-						width: 175,
+						width: 100,
 						sortable: true,
 					},
 					{
@@ -175,16 +171,6 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 								sign={'$'}
 								conversionRate={1}
 							/>
-						),
-						width: compact ? 'auto' : 100,
-						sortable: true,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.percent-pnl')}</TableHeader>,
-						accessor: 'pnlPct',
-						sortType: 'basic',
-						Cell: (cellProps: CellProps<any>) => (
-							<ChangePercent value={cellProps.row.original.pnlPct} />
 						),
 						width: compact ? 'auto' : 100,
 						sortable: true,

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -149,9 +149,9 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 								Cell: (cellProps: CellProps<any>) => (
 									<StyledOrderType>
 										{compact && cellProps.row.original.rank + '. '}
-										<StyledTrader onClick={() => { onClickTrader(cellProps.row.original.trader) }}>
+										<StyledOrderType>
 											{cellProps.row.original.traderShort}
-										</StyledTrader>
+										</StyledOrderType>
 										{getMedal(cellProps.row.index + 1)}
 									</StyledOrderType>
 								),

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -95,21 +95,21 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 	};
 
 	const onClickTrader = (trader: string) => {
-		setSelectedTrader(trader)
-	}
+		setSelectedTrader(trader);
+	};
 
 	if (statsQuery.isLoading) {
 		return <Loader />;
 	}
 
-	if(selectedTrader !== '') {
+	if (selectedTrader !== '') {
 		return (
 			<TraderHistory
 				trader={selectedTrader}
 				resetSelection={() => setSelectedTrader('')}
 				compact={compact}
 			/>
-		)
+		);
 	}
 
 	return (
@@ -125,10 +125,11 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 				}
 				columns={[
 					{
-						Header:
+						Header: (
 							<TableTitle>
 								<TitleText>{t('leaderboard.leaderboard.table.title')}</TitleText>
-							</TableTitle>,
+							</TableTitle>
+						),
 						accessor: 'title',
 						columns: [
 							{
@@ -149,30 +150,34 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 								Cell: (cellProps: CellProps<any>) => (
 									<StyledOrderType>
 										{compact && cellProps.row.original.rank + '. '}
-										<StyledOrderType>
-											{cellProps.row.original.traderShort}
-										</StyledOrderType>
+										<StyledOrderType>{cellProps.row.original.traderShort}</StyledOrderType>
 										{getMedal(cellProps.row.index + 1)}
 									</StyledOrderType>
 								),
 								width: 175,
 							},
 							{
-								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>,
+								Header: (
+									<TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>
+								),
 								accessor: 'totalTrades',
 								sortType: 'basic',
 								width: 100,
 								sortable: true,
 							},
 							{
-								Header: <TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>,
+								Header: (
+									<TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>
+								),
 								accessor: 'liquidations',
 								sortType: 'basic',
 								width: 100,
 								sortable: true,
 							},
 							{
-								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-volume')}</TableHeader>,
+								Header: (
+									<TableHeader>{t('leaderboard.leaderboard.table.total-volume')}</TableHeader>
+								),
 								accessor: 'totalVolume',
 								sortType: 'basic',
 								Cell: (cellProps: CellProps<any>) => (
@@ -200,9 +205,9 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 								),
 								width: compact ? 'auto' : 100,
 								sortable: true,
-							},	
-						]
-					}
+							},
+						],
+					},
 				]}
 			/>
 		</TableContainer>

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -108,73 +108,82 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, searchTerm }: LeaderboardP
 				}
 				columns={[
 					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.rank')}</TableHeader>,
-						accessor: 'rank',
-						Cell: (cellProps: CellProps<any>) => (
-							<StyledOrderType>{cellProps.row.original.rank}</StyledOrderType>
-						),
-						width: compact ? 40 : 100,
-					},
-					{
-						Header: !compact ? (
-							<TableHeader>{t('leaderboard.leaderboard.table.trader')}</TableHeader>
-						) : (
-							<></>
-						),
-						accessor: 'trader',
-						Cell: (cellProps: CellProps<any>) => (
-							<StyledOrderType>
-								{compact && cellProps.row.original.rank + '. '}
-								{cellProps.row.original.trader}
-								{getMedal(cellProps.row.index + 1)}
-							</StyledOrderType>
-						),
-						width: 175,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>,
-						accessor: 'totalTrades',
-						sortType: 'basic',
-						width: 100,
-						sortable: true,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>,
-						accessor: 'liquidations',
-						sortType: 'basic',
-						width: 100,
-						sortable: true,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.total-volume')}</TableHeader>,
-						accessor: 'totalVolume',
-						sortType: 'basic',
-						Cell: (cellProps: CellProps<any>) => (
-							<Currency.Price
-								currencyKey={Synths.sUSD}
-								price={cellProps.row.original.totalVolume}
-								sign={'$'}
-								conversionRate={1}
-							/>
-						),
-						width: compact ? 'auto' : 125,
-						sortable: true,
-					},
-					{
-						Header: <TableHeader>{t('leaderboard.leaderboard.table.total-pnl')}</TableHeader>,
-						accessor: 'pnl',
-						sortType: 'basic',
-						Cell: (cellProps: CellProps<any>) => (
-							<ColorCodedPrice
-								currencyKey={Synths.sUSD}
-								price={cellProps.row.original.pnl}
-								sign={'$'}
-								conversionRate={1}
-							/>
-						),
-						width: compact ? 'auto' : 100,
-						sortable: true,
-					},
+						Header:
+							<TableTitle>
+								<TitleText>{t('leaderboard.leaderboard.table.title')}</TitleText>
+							</TableTitle>,
+						accessor: 'title',
+						columns: [
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.rank')}</TableHeader>,
+								accessor: 'rank',
+								Cell: (cellProps: CellProps<any>) => (
+									<StyledOrderType>{cellProps.row.original.rank}</StyledOrderType>
+								),
+								width: compact ? 40 : 100,
+							},
+							{
+								Header: !compact ? (
+									<TableHeader>{t('leaderboard.leaderboard.table.trader')}</TableHeader>
+								) : (
+									<></>
+								),
+								accessor: 'trader',
+								Cell: (cellProps: CellProps<any>) => (
+									<StyledOrderType>
+										{compact && cellProps.row.original.rank + '. '}
+										{cellProps.row.original.trader}
+										{getMedal(cellProps.row.index + 1)}
+									</StyledOrderType>
+								),
+								width: 175,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-trades')}</TableHeader>,
+								accessor: 'totalTrades',
+								sortType: 'basic',
+								width: 100,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.liquidations')}</TableHeader>,
+								accessor: 'liquidations',
+								sortType: 'basic',
+								width: 100,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-volume')}</TableHeader>,
+								accessor: 'totalVolume',
+								sortType: 'basic',
+								Cell: (cellProps: CellProps<any>) => (
+									<Currency.Price
+										currencyKey={Synths.sUSD}
+										price={cellProps.row.original.totalVolume}
+										sign={'$'}
+										conversionRate={1}
+									/>
+								),
+								width: compact ? 'auto' : 125,
+								sortable: true,
+							},
+							{
+								Header: <TableHeader>{t('leaderboard.leaderboard.table.total-pnl')}</TableHeader>,
+								accessor: 'pnl',
+								sortType: 'basic',
+								Cell: (cellProps: CellProps<any>) => (
+									<ColorCodedPrice
+										currencyKey={Synths.sUSD}
+										price={cellProps.row.original.pnl}
+										sign={'$'}
+										conversionRate={1}
+									/>
+								),
+								width: compact ? 'auto' : 100,
+								sortable: true,
+							},	
+						]
+					}
 				]}
 			/>
 		</TableContainer>
@@ -203,6 +212,17 @@ const TableContainer = styled.div<{ compact: boolean | undefined }>`
 
 const StyledTable = styled(Table)<{ compact: boolean | undefined }>`
 	margin-top: ${({ compact }) => (compact ? '0' : '15px')};
+`;
+
+const TableTitle = styled.div`
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+`;
+
+const TitleText = styled.div`
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 `;
 
 const TableHeader = styled.div`

--- a/sections/leaderboard/LeaderboardContainer/LeaderboardContainer.tsx
+++ b/sections/leaderboard/LeaderboardContainer/LeaderboardContainer.tsx
@@ -63,7 +63,13 @@ const LeaderboardContainer: FC = () => {
 		<>
 			<TabButtonsContainer>
 				{TABS.map(({ name, label, active, disabled, onClick }) => (
-					<TabButton key={name} title={label} active={active} disabled={disabled} onClick={onClick} />
+					<TabButton
+						key={name}
+						title={label}
+						active={active}
+						disabled={disabled}
+						onClick={onClick}
+					/>
 				))}
 				<Search onChange={onChangeSearch} disabled={!(activeTab === Tab.Leaderboard)} />
 			</TabButtonsContainer>

--- a/sections/leaderboard/LeaderboardContainer/LeaderboardContainer.tsx
+++ b/sections/leaderboard/LeaderboardContainer/LeaderboardContainer.tsx
@@ -41,12 +41,14 @@ const LeaderboardContainer: FC = () => {
 				name: Tab.Leaderboard,
 				label: t('leaderboard.tabs.nav.leaderboard'),
 				active: activeTab === Tab.Leaderboard,
+				disabled: false,
 				onClick: () => router.push(ROUTES.Leaderboard.Leaderboard),
 			},
 			{
 				name: Tab.Statistics,
 				label: t('leaderboard.tabs.nav.statistics'),
 				active: activeTab === Tab.Statistics,
+				disabled: true,
 				onClick: () => router.push(ROUTES.Leaderboard.Statistics),
 			},
 		],
@@ -60,8 +62,8 @@ const LeaderboardContainer: FC = () => {
 	return (
 		<>
 			<TabButtonsContainer>
-				{TABS.map(({ name, label, active, onClick }) => (
-					<TabButton key={name} title={label} active={active} onClick={onClick} />
+				{TABS.map(({ name, label, active, disabled, onClick }) => (
+					<TabButton key={name} title={label} active={active} disabled={disabled} onClick={onClick} />
 				))}
 				<Search onChange={onChangeSearch} disabled={!(activeTab === Tab.Leaderboard)} />
 			</TabButtonsContainer>

--- a/sections/leaderboard/TraderHistory/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory/TraderHistory.tsx
@@ -21,7 +21,11 @@ type TraderHistoryProps = {
 	compact?: boolean;
 };
 
-const TraderHistory: FC<TraderHistoryProps> = ({ trader, resetSelection, compact }: TraderHistoryProps) => {
+const TraderHistory: FC<TraderHistoryProps> = ({
+	trader,
+	resetSelection,
+	compact,
+}: TraderHistoryProps) => {
 	const { t } = useTranslation();
 
 	return (
@@ -34,32 +38,35 @@ const TraderHistory: FC<TraderHistoryProps> = ({ trader, resetSelection, compact
 				hideHeaders={compact}
 				columns={[
 					{
-						Header:
+						Header: (
 							<TableTitle>
-								<TitleText onClick={() => { resetSelection() }}>
+								<TitleText
+									onClick={() => {
+										resetSelection();
+									}}
+								>
 									{t('leaderboard.leaderboard.table.title')}
 								</TitleText>
 								<TitleSeparator>&gt;</TitleSeparator>
 								<TraderText>{trader}</TraderText>
-							</TableTitle>,
+							</TableTitle>
+						),
 						accessor: 'title',
 						columns: [
 							{
 								Header: <TableHeader>Test</TableHeader>,
 								accessor: 'rank',
-								Cell: (cellProps: CellProps<any>) => (
-									<p>Test</p>
-								),
+								Cell: (cellProps: CellProps<any>) => <p>Test</p>,
 								width: compact ? 40 : 100,
 							},
-						]
-					}
+						],
+					},
 				]}
 			/>
 		</TableContainer>
 	);
 
-	return <></>
+	return <></>;
 };
 
 const TableContainer = styled.div<{ compact: boolean | undefined }>`
@@ -67,7 +74,7 @@ const TableContainer = styled.div<{ compact: boolean | undefined }>`
 	margin-bottom: ${({ compact }) => (compact ? '0' : '40px')};
 `;
 
-const StyledTable = styled(Table) <{ compact: boolean | undefined }>`
+const StyledTable = styled(Table)<{ compact: boolean | undefined }>`
 	margin-top: ${({ compact }) => (compact ? '0' : '15px')};
 `;
 

--- a/sections/leaderboard/TraderHistory/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory/TraderHistory.tsx
@@ -1,0 +1,107 @@
+import Table from 'components/Table';
+import { FC, SyntheticEvent, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CellProps } from 'react-table';
+import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import Wei, { wei } from '@synthetixio/wei';
+
+import Currency from 'components/Currency';
+import ChangePercent from 'components/ChangePercent';
+import { Synths } from 'constants/currency';
+import useGetStats from 'queries/futures/useGetStats';
+import { walletAddressState } from 'store/wallet';
+import { truncateAddress } from 'utils/formatters/string';
+import { FuturesStat } from 'queries/futures/types';
+import Loader from 'components/Loader';
+
+type TraderHistoryProps = {
+	trader: string;
+	resetSelection: Function;
+	compact?: boolean;
+};
+
+const TraderHistory: FC<TraderHistoryProps> = ({ trader, resetSelection, compact }: TraderHistoryProps) => {
+	const { t } = useTranslation();
+
+	return (
+		<TableContainer compact={compact}>
+			<StyledTable
+				compact={compact}
+				showPagination={true}
+				isLoading={false}
+				data={[]}
+				hideHeaders={compact}
+				columns={[
+					{
+						Header:
+							<TableTitle>
+								<TitleText onClick={() => { resetSelection() }}>
+									{t('leaderboard.leaderboard.table.title')}
+								</TitleText>
+								<TitleSeparator>&gt;</TitleSeparator>
+								<TraderText>{trader}</TraderText>
+							</TableTitle>,
+						accessor: 'title',
+						columns: [
+							{
+								Header: <TableHeader>Test</TableHeader>,
+								accessor: 'rank',
+								Cell: (cellProps: CellProps<any>) => (
+									<p>Test</p>
+								),
+								width: compact ? 40 : 100,
+							},
+						]
+					}
+				]}
+			/>
+		</TableContainer>
+	);
+
+	return <></>
+};
+
+const TableContainer = styled.div<{ compact: boolean | undefined }>`
+	margin-top: 6px;
+	margin-bottom: ${({ compact }) => (compact ? '0' : '40px')};
+`;
+
+const StyledTable = styled(Table) <{ compact: boolean | undefined }>`
+	margin-top: ${({ compact }) => (compact ? '0' : '15px')};
+`;
+
+const TableTitle = styled.div`
+	width: 100%;
+	display: flex;
+	justify-content: flex-start;
+`;
+
+const TitleText = styled.a`
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
+
+	&:hover {
+		text-decoration: underline;
+		cursor: pointer;
+	}
+`;
+
+const TitleSeparator = styled.div`
+	margin-left: 10px;
+	margin-right: 10px;
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
+`;
+
+const TraderText = styled.div`
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.common.primaryWhite};
+`;
+
+const TableHeader = styled.div`
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
+`;
+
+export default TraderHistory;

--- a/sections/leaderboard/TraderHistory/index.tsx
+++ b/sections/leaderboard/TraderHistory/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './TraderHistory';

--- a/sections/shared/Layout/AppLayout/Header/constants.ts
+++ b/sections/shared/Layout/AppLayout/Header/constants.ts
@@ -16,10 +16,10 @@ export const MENU_LINKS: MenuLinks = [
 		i18nLabel: 'header.nav.markets',
 		link: ROUTES.Markets.Home,
 	},
-	// {
-	// 	i18nLabel: 'header.nav.leaderboard',
-	// 	link: ROUTES.Leaderboard.Home,
-	// },
+	{
+		i18nLabel: 'header.nav.leaderboard',
+		link: ROUTES.Leaderboard.Home,
+	},
 	// {
 	// 	i18nLabel: 'header.nav.earn',
 	// 	link: ROUTES.Earn.Home,


### PR DESCRIPTION
Add simple leaderboard

## Description
Add leaderboard page and route.

This doesn't match the designs _exactly_ as well need to determine the best way to represent PnL % before the competition, taking leverage into account.

## Related issue
#376 
closes #565 

## How Has This Been Tested?
Subgraph PnL was tested, data on this page matches data coming directly from the subgraph.

## Screenshots (if appropriate):
<img width="959" alt="image" src="https://user-images.githubusercontent.com/10401554/163020609-23117c39-376c-4a23-bdd6-2a9fae522356.png">

<img width="965" alt="image" src="https://user-images.githubusercontent.com/10401554/163020761-46c6219a-0cbf-4595-a6ee-64e942750bcd.png">
