### PR TITLE
Improve unsupported network state

### DIFF
--- a/constants/network.ts
+++ b/constants/network.ts
@@ -5,3 +5,10 @@ export const GWEI_DECIMALS = 9;
 export const ETH_UNIT = 1000000000000000000;
 
 export type GasLimitEstimate = BigNumber | null;
+
+export const SUPPORTED_NETWORKS = [
+	1, // Ethereum (mainnet)
+	10, // Optimism (mainnet)
+	42, // Ethereum Kovan (testnet)
+	69, // Optimism Kovan (tesnet)
+];

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,8 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { CustomThemeProvider } from 'contexts/CustomThemeContext';
 import SystemStatus from 'sections/shared/SystemStatus';
 
+import { isSupportedNetworkId } from 'utils/network';
+
 import 'styles/main.css';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -35,7 +37,7 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
 			<MediaContextProvider>
 				<SynthetixQueryContextProvider
 					value={
-						provider && network
+						provider && isSupportedNetworkId(network.id)
 							? createQueryContext({
 									provider,
 									signer: signer || undefined,

--- a/sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx
+++ b/sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx
@@ -2,55 +2,81 @@ import { FC, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
+import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
 
 import Connector from 'containers/Connector';
 
 import Button from 'components/Button';
 
-import { isWalletConnectedState } from 'store/wallet';
-import { FlexDivCentered } from 'styles/common';
+import { isWalletConnectedState, networkState } from 'store/wallet';
+import { FlexDiv, FlexDivCentered } from 'styles/common';
 
 import SettingsModal from 'sections/shared/modals/SettingsModal';
 
-import NetworksSwitcher from '../NetworksSwitcher';
 import WalletActions from '../WalletActions';
 import ConnectionDot from '../ConnectionDot';
+import NetworksSwitcher from '../NetworksSwitcher';
+import { isSupportedNetworkId } from 'utils/network';
 
 const UserMenu: FC = () => {
 	const { t } = useTranslation();
 	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const network = useRecoilValue(networkState);
 	const { connectWallet } = Connector.useContainer();
 	const [settingsModalOpened, setSettingsModalOpened] = useState<boolean>(false);
+	const { switchToL2 } = useNetworkSwitcher();
+
+	const walletIsNotConnected = (
+		<CTARow>
+			<ConnectButton
+				size="sm"
+				variant="outline"
+				onClick={connectWallet}
+				data-testid="connect-wallet"
+				mono
+			>
+				<StyledConnectionDot />
+				{t('common.wallet.connect-wallet')}
+			</ConnectButton>
+		</CTARow>
+	);
+
+	const walletIsConnectedButNotSupported = (
+		<CTARow>
+			<SwitchToL2Button variant="secondary" onClick={switchToL2}>
+				{t('homepage.l2.cta-buttons.switch-l2')}
+			</SwitchToL2Button>
+			<ConnectButton size="sm" variant="outline" data-testid="unsupported-network" mono>
+				<StyledConnectionDot />
+				{t('common.wallet.unsupported-network')}
+			</ConnectButton>
+		</CTARow>
+	);
+
+	const walletIsConnectedAndSupported = (
+		<>
+			<NetworksSwitcher />
+			<WalletActions />
+			<MenuButton
+				onClick={() => {
+					setSettingsModalOpened(!settingsModalOpened);
+				}}
+				isActive={settingsModalOpened}
+			>
+				<SettingsText>...</SettingsText>
+			</MenuButton>
+		</>
+	);
 
 	return (
 		<>
 			<Container>
 				<FlexDivCentered>
-					{isWalletConnected && <NetworksSwitcher />}
-					{isWalletConnected ? (
-						<WalletActions />
-					) : (
-						<ConnectButton
-							size="sm"
-							variant="outline"
-							onClick={connectWallet}
-							data-testid="connect-wallet"
-							mono
-						>
-							<StyledConnectionDot />
-							{t('common.wallet.connect-wallet')}
-						</ConnectButton>
-					)}
-					{isWalletConnected && (
-						<MenuButton
-							onClick={() => {
-								setSettingsModalOpened(!settingsModalOpened);
-							}}
-							isActive={settingsModalOpened}
-						>
-							<SettingsText>...</SettingsText>
-						</MenuButton>
-					)}
+					{isWalletConnected
+						? isSupportedNetworkId(network.id)
+							? walletIsConnectedAndSupported
+							: walletIsConnectedButNotSupported
+						: walletIsNotConnected}
 				</FlexDivCentered>
 			</Container>
 			{settingsModalOpened && <SettingsModal onDismiss={() => setSettingsModalOpened(false)} />}
@@ -81,6 +107,17 @@ const SettingsText = styled.p`
 
 const ConnectButton = styled(Button)`
 	font-size: 13px;
+`;
+
+const SwitchToL2Button = styled(Button)`
+	font-size: 13px;
+	color: white;
+`;
+
+const CTARow = styled(FlexDiv)`
+	> * {
+		margin-right: 16px;
+	}
 `;
 
 export default UserMenu;

--- a/translations/en.json
+++ b/translations/en.json
@@ -982,7 +982,8 @@
 			"connect-wallet": "connect wallet",
 			"switch-wallet": "Switch Wallet",
 			"switch-accounts": "Switch Accounts",
-			"disconnect-wallet": "Disconnect Wallet"
+			"disconnect-wallet": "Disconnect Wallet",
+			"unsupported-network": "Unsupported Network"
 		},
 		"tx-status": {
 			"waiting": "Waiting",

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -1,18 +1,24 @@
 import detectEthereumProvider from '@metamask/detect-provider';
-import { NetworkId, NetworkNameById } from '@synthetixio/contracts-interface';
+import { NetworkId } from '@synthetixio/contracts-interface';
 import { GasPrice } from '@synthetixio/queries';
 import Wei, { wei } from '@synthetixio/wei';
 
 import { DEFAULT_GAS_BUFFER, DEFAULT_NETWORK_ID } from 'constants/defaults';
-import { ETH_UNIT, GWEI_UNIT, GWEI_DECIMALS, GasLimitEstimate } from 'constants/network';
+import {
+	ETH_UNIT,
+	GWEI_UNIT,
+	GWEI_DECIMALS,
+	GasLimitEstimate,
+	SUPPORTED_NETWORKS,
+} from 'constants/network';
 
 type EthereumProvider = {
 	isMetaMask: boolean;
 	chainId: string;
 };
 
-export function isSupportedNetworkId(id: number | string): id is NetworkId {
-	return id in NetworkNameById;
+export function isSupportedNetworkId(id: NetworkId): boolean {
+	return SUPPORTED_NETWORKS.includes(id);
 }
 
 export async function getDefaultNetworkId(walletConnected: boolean = true): Promise<NetworkId> {
@@ -20,7 +26,7 @@ export async function getDefaultNetworkId(walletConnected: boolean = true): Prom
 		if (walletConnected && window.ethereum) {
 			const provider = (await detectEthereumProvider()) as EthereumProvider;
 			if (provider && provider.chainId) {
-				const id = Number(provider.chainId);
+				const id = Number(provider.chainId) as NetworkId;
 				return isSupportedNetworkId(id) ? id : DEFAULT_NETWORK_ID;
 			}
 		}


### PR DESCRIPTION
## Description
When a user switches to an unsupported network, Kwenta resolves in a white "Unexpected Error" page.\
Note: unsupported networks are any other networks than Ethereum, Optimism, Ethereum Kovan and Optimism Kovan.

This PR aims to solve this issue by displaying the unsupported wallet state when a user is connected to an unsupported network. This new state consists of the "Switch to L2" CTA button and an "Unsupported Network" button as shown below.

![unsupported-wallet-state](https://user-images.githubusercontent.com/28714795/163061842-f86f5351-f809-463b-bff3-b27a01b6727c.png)

I could not rely on the `isSupportedNetworkId(id)` function defined in `utils/network.ts` since it always returned that the network was supported, even for Goerly. That's why I decided to define a `SUPPORTED_NETWORKS` constant array in `constants/networks.ts`, containing all the chain ids of the supported networks. I then updated the `isSupportedNetworkId(id)` function to simply check if the id of the network is in the `SUPPORTED_NETWORKS` array or not.

Then I updated how the user menu behaves by checking if the network is supported in `sections/shared/Layout/AppLayout/Header/UserMenu/UserMenu.tsx`. If the answer is yes, the menu stays the same but if the answer is no, it displays the "Switch to L2" CTA button as well as the "Unsupported wallet" button. At the same time, I defined a new translation for "unsupported network".

I also updated `pages/_app.tsx` because there were no tests to verify if the network was supported. It was responsible for the page not loading when the user came, logged on to an unsupported network. So I added this necessary check and the website now loads no matter what chain the user is logged on to.

Finally, I updated `containers/Connector/Connector.tsx` because the network state was not always up to date. When the user was connected on an unsupported network, sometimes, the network state was not updated and still displayed the supported wallet state.

## Related issue
#557 

## Motivation and Context
This PR solves a bug that was degrading the user experience. The website now behaves properly no matter what chain the user is logged on to. It also makes it clear to the user (in terms of UI/UX) that they are or are not on the right network.

## How Has This Been Tested?
### Test 1
- Connect to the website while already being connected to a supported network with Metamak (i.e. Ethereum or Optimism) and check that the website displays the "Switch to L2" CTA button, the address (or ens name) and the dots button.
- Switch to another supported network, the color or the button updates but the rest of the user menu stays the same.
- Switch to L2, the website displays the "Optimism" button, the address (or ens name) and the dots button.
- Switch to an unsupported network (i.e. Goerli) and check that the website displays the "Switch to L2" CTA button and the "Unsupported Network" button.

### Test 2
- Connect to the website while already being connected to an unsupported network with Metamak (i.e. Goerli) and check that the website displays the "Switch to L2" CTA button and the "Unsupported Network" button.
- Switch to another unsupported network (i.e. Avalanche) and check that the website displays the "Switch to L2" CTA button and the "Unsupported Network" button.
- Switch to L2, the website displays the "Optimism" button, the address (or ens name) and the dots button.
- Switch back to another unsupported network and check again that the website displays the "Switch to L2" CTA button and the "Unsupported Network" button.
- Switch to a supported network (i.e. Ethereum) and check that the website displays the "Switch to L2" CTA button, the address (or ens name) and the dots button.

