### PR TITLE
Fix issues related to XAU and XAG rates

### DIFF
--- a/queries/rates/types.ts
+++ b/queries/rates/types.ts
@@ -1,3 +1,4 @@
+import Wei from '@synthetixio/wei';
 import { CurrencyKey } from 'constants/currency';
 
 export type SynthExchange = {
@@ -56,3 +57,5 @@ export type Price = {
 };
 
 export type Prices = Price[];
+
+export type Rates = Record<string, Wei>;

--- a/queries/rates/useExchangeRatesQuery.ts
+++ b/queries/rates/useExchangeRatesQuery.ts
@@ -1,0 +1,72 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import { BigNumberish, ethers } from 'ethers';
+import { useRecoilValue } from 'recoil';
+import { wei } from '@synthetixio/wei';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
+import {
+	CRYPTO_CURRENCY_MAP,
+	iStandardSynth,
+	synthToAsset,
+} from '@synthetixio/queries/build/node/src/currency';
+
+import Connector from 'containers/Connector';
+import { isL2State, isWalletConnectedState, networkState } from 'store/wallet';
+import { appReadyState } from 'store/app';
+import { Rates } from './types';
+
+type CurrencyRate = BigNumberish;
+type SynthRatesTuple = [string[], CurrencyRate[]];
+
+// Additional commonly used currencies to fetch, besides the one returned by the SynthUtil.synthsRates
+const additionalCurrencies = [CRYPTO_CURRENCY_MAP.SNX, 'XAU', 'XAG'].map(
+	ethers.utils.formatBytes32String
+);
+
+const useExchangeRatesQuery = (options?: UseQueryOptions<Rates>) => {
+	const isAppReady = useRecoilValue(appReadyState);
+	const network = useRecoilValue(networkState);
+	const { synthetixjs } = Connector.useContainer();
+
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const isL2 = useRecoilValue(isL2State);
+	const isReady = isAppReady && !!synthetixjs;
+
+	return useQuery<Rates>(
+		['rates', 'exchangeRates', network.id],
+		async () => {
+			console.log('here');
+			const exchangeRates: Rates = {};
+
+			const [synthsRates, ratesForCurrencies] = (await Promise.all([
+				synthetixjs!.contracts.SynthUtil.synthsRates(),
+				synthetixjs!.contracts.ExchangeRates.ratesForCurrencies(additionalCurrencies),
+			])) as [SynthRatesTuple, CurrencyRate[]];
+
+			console.log('additional', additionalCurrencies);
+			console.log('rates', ratesForCurrencies);
+
+			const synths = [...synthsRates[0], ...additionalCurrencies] as CurrencyKey[];
+			const rates = [...synthsRates[1], ...ratesForCurrencies] as CurrencyRate[];
+
+			synths.forEach((currencyKeyBytes32: CurrencyKey, idx: number) => {
+				console.log(currencyKeyBytes32);
+				const currencyKey = ethers.utils.parseBytes32String(currencyKeyBytes32) as CurrencyKey;
+				const rate = Number(ethers.utils.formatEther(rates[idx]));
+
+				exchangeRates[currencyKey] = wei(rate);
+				// only interested in the standard synths (sETH -> ETH, etc)
+				if (iStandardSynth(currencyKey)) {
+					exchangeRates[synthToAsset(currencyKey)] = wei(rate);
+				}
+			});
+
+			return exchangeRates;
+		},
+		{
+			enabled: isWalletConnected ? isL2 && isReady : isReady,
+			...options,
+		}
+	);
+};
+
+export default useExchangeRatesQuery;

--- a/queries/rates/useExchangeRatesQuery.ts
+++ b/queries/rates/useExchangeRatesQuery.ts
@@ -32,9 +32,8 @@ const useExchangeRatesQuery = (options?: UseQueryOptions<Rates>) => {
 	const isReady = isAppReady && !!synthetixjs;
 
 	return useQuery<Rates>(
-		['rates', 'exchangeRates', network.id],
+		['rates', 'exchangeRates2', network.id],
 		async () => {
-			console.log('here');
 			const exchangeRates: Rates = {};
 
 			const [synthsRates, ratesForCurrencies] = (await Promise.all([
@@ -42,14 +41,10 @@ const useExchangeRatesQuery = (options?: UseQueryOptions<Rates>) => {
 				synthetixjs!.contracts.ExchangeRates.ratesForCurrencies(additionalCurrencies),
 			])) as [SynthRatesTuple, CurrencyRate[]];
 
-			console.log('additional', additionalCurrencies);
-			console.log('rates', ratesForCurrencies);
-
 			const synths = [...synthsRates[0], ...additionalCurrencies] as CurrencyKey[];
 			const rates = [...synthsRates[1], ...ratesForCurrencies] as CurrencyRate[];
 
 			synths.forEach((currencyKeyBytes32: CurrencyKey, idx: number) => {
-				console.log(currencyKeyBytes32);
 				const currencyKey = ethers.utils.parseBytes32String(currencyKeyBytes32) as CurrencyKey;
 				const rate = Number(ethers.utils.formatEther(rates[idx]));
 

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { wei } from '@synthetixio/wei';
-import useSynthetixQueries from '@synthetixio/queries';
 import { CurrencyKey } from '@synthetixio/contracts-interface';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
@@ -20,6 +19,7 @@ import { NO_VALUE } from 'constants/placeholder';
 import { Tooltip } from 'styles/common';
 import { getMarketKey } from 'utils/futures';
 import Connector from 'containers/Connector';
+import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 
 type MarketDetailsProps = {
 	baseCurrencyKey: CurrencyKey;
@@ -29,7 +29,6 @@ type MarketData = Record<string, { value: string | JSX.Element; color?: string }
 
 const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const { network } = Connector.useContainer();
-	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const futuresMarketsQuery = useGetFuturesMarkets();
 	const futuresTradingVolumeQuery = useGetFuturesTradingVolume(baseCurrencyKey);

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -87,10 +87,6 @@ const Trade: React.FC<TradeProps> = () => {
 		[exchangeRatesQuery.isSuccess, exchangeRatesQuery.data]
 	);
 
-	useEffect(() => {
-		console.log(exchangeRates);
-	}, [exchangeRates]);
-
 	const marketAssetRate = useMemo(
 		() => newGetExchangeRatesForCurrencies(exchangeRates, marketAsset, Synths.sUSD),
 		[exchangeRates, marketAsset]

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -23,6 +23,7 @@ import { useRouter } from 'next/router';
 import useGetFuturesPositionForMarket from 'queries/futures/useGetFuturesPositionForMarket';
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesPositionHistory from 'queries/futures/useGetFuturesMarketPositionHistory';
+import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import MarketsDropdown from './MarketsDropdown';
 // import SegmentedControl from 'components/SegmentedControl';
 import PositionButtons from '../PositionButtons';
@@ -42,12 +43,7 @@ const DEFAULT_MAX_LEVERAGE = wei(10);
 const Trade: React.FC<TradeProps> = () => {
 	const { t } = useTranslation();
 	const walletAddress = useRecoilValue(walletAddressState);
-	const {
-		useExchangeRatesQuery,
-		useSynthsBalancesQuery,
-		useEthGasPriceQuery,
-		useSynthetixTxn,
-	} = useSynthetixQueries();
+	const { useSynthsBalancesQuery, useEthGasPriceQuery, useSynthetixTxn } = useSynthetixQueries();
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const router = useRouter();
@@ -90,6 +86,10 @@ const Trade: React.FC<TradeProps> = () => {
 		() => (exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null),
 		[exchangeRatesQuery.isSuccess, exchangeRatesQuery.data]
 	);
+
+	useEffect(() => {
+		console.log(exchangeRates);
+	}, [exchangeRates]);
 
 	const marketAssetRate = useMemo(
 		() => newGetExchangeRatesForCurrencies(exchangeRates, marketAsset, Synths.sUSD),


### PR DESCRIPTION
## Description
This PR copies over the `useExchangeRatesQuery` hook from the Synthetix monorepo, and adds `XAU` and `XAG` to the `additionalCurrencies` array.

## Related issue
N/A

## Motivation and Context
This is a fix for the new markets released today.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
