### PR TITLE
Flip Funding calculation

### DIFF
--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -189,7 +189,7 @@ export const calculateFundingRate = (
 	const fundingStart = new Wei(minFunding.funding, 18, true);
 	const fundingEnd = new Wei(maxFunding.funding, 18, true);
 
-	const fundingDiff = fundingEnd.sub(fundingStart); // funding is already in ratio units
+	const fundingDiff = fundingStart.sub(fundingEnd); // funding is already in ratio units
 	const timeDiff = maxFunding.timestamp - minFunding.timestamp;
 
 	if (timeDiff === 0) {


### PR DESCRIPTION
Flipping the funding calculation. Our average is reversed from the expected funding rate.

## Description
Really simple switch

## How Has This Been Tested?
Compared to snx funding rate [dune query](https://dune.xyz/queries/557046?days_ago_t6c1ea=7)
