### PR TITLE
remove pageSize limit

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -72,7 +72,6 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 		<TableContainer>
 			<StyledTable
 				data={data}
-				pageSize={5}
 				showPagination={true}
 				onTableRowClick={(row) =>
 					row.original.asset !== NO_VALUE ? router.push(`/market/${row.original.asset}`) : undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Futures Positions table would only show a maximum of 5 open positions, despite the fact that the user has >5 positions open. This PR removes the 5 markets limit.

## Screenshots (if appropriate):

<img width="1095" alt="Screen Shot 2022-04-13 at 17 38 43" src="https://user-images.githubusercontent.com/548702/163266432-1eabd5c5-793c-4140-9cf5-b60eedc5c2a8.png">

