### PR TITLE
Improve input fields

### DIFF
--- a/components/Input/CustomNumericInput.tsx
+++ b/components/Input/CustomNumericInput.tsx
@@ -1,0 +1,86 @@
+import { ChangeEvent, FC } from 'react';
+import styled from 'styled-components';
+import Input from './Input';
+
+type CustomNumericInputProps = {
+	value: string;
+	placeholder?: string;
+	suffix: string;
+	onChange: (e: ChangeEvent<HTMLInputElement>, value: string) => void;
+	className?: string;
+	defaultValue?: any;
+	maxValue?: number;
+	disabled?: boolean;
+	id?: string;
+};
+
+const CustomNumericInput: FC<CustomNumericInputProps> = ({
+	value,
+	placeholder,
+	suffix,
+	onChange,
+	className,
+	defaultValue,
+	maxValue,
+	disabled,
+	id,
+	...rest
+}) => {
+	const style = {
+		'--numchs': value.length,
+		'--suffix': `'${value.length === 0 ? '' : suffix}'`,
+	};
+
+	const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+		const { value } = e.target;
+		const max = maxValue || 0;
+		const valueIsAboveMax = max !== 0 && Number(value) > max;
+		if (!valueIsAboveMax) {
+			onChange(
+				e,
+				value
+					.replace(/[^0-9.,]/g, '')
+					.replace(/,/g, '.')
+					.substring(0, 4)
+			);
+		}
+	};
+
+	return (
+		<InputWrapper style={style as React.CSSProperties}>
+			<StyledInput
+				type="text"
+				value={value}
+				placeholder={placeholder + suffix}
+				onChange={handleOnChange}
+				className={className}
+				defaultValue={defaultValue}
+				disabled={disabled}
+				id={id}
+				{...rest}
+			/>
+		</InputWrapper>
+	);
+};
+
+export const InputWrapper = styled.div`
+	position: relative;
+	overflow: hidden;
+	::after {
+		position: absolute;
+		top: calc(25%);
+		left: calc((var(--numchs) * 1ch + 1.3ch));
+		//left: 5.3ch;
+		content: var(--suffix, 'x');
+		font-family: ${(props) => props.theme.fonts.mono};
+		font-size: 18px;
+		color: ${(props) => props.theme.colors.selectedTheme.input.placeholder};
+	}
+`;
+
+export const StyledInput = styled(Input)`
+	font-family: ${(props) => props.theme.fonts.mono};
+	text-overflow: ellipsis;
+`;
+
+export default CustomNumericInput;

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -7,7 +7,7 @@ import { FlexDivCol, FlexDivRow } from 'styles/common';
 import { PositionSide } from '../types';
 import { FuturesPosition } from 'queries/futures/types';
 import LeverageSlider from '../LeverageSlider';
-import NumericInput from 'components/Input/NumericInput';
+import CustomNumericInput from 'components/Input/CustomNumericInput';
 import Button from 'components/Button';
 import { formatNumber } from 'utils/formatters/number';
 
@@ -77,15 +77,14 @@ const LeverageInput: FC<LeverageInputProps> = ({
 				</SliderRow>
 			) : (
 				<LeverageInputContainer>
-					<NumericInput
-						value={
-							currentLeverage === ''
-								? ''
-								: (Math.round(Number(currentLeverage) * 100) / 100).toString()
-						}
-						onChange={(_, value) => {
-							onLeverageChange(value);
+					<StyledInput
+						value={currentLeverage}
+						placeholder="0"
+						suffix="x"
+						maxValue={maxLeverage.toNumber()}
+						onChange={(_, newValue) => {
 							setIsLeverageValueCommitted(true);
+							onLeverageChange(newValue.toString());
 						}}
 					/>
 					{['2', '5', '10'].map((l) => (
@@ -160,6 +159,11 @@ const LeverageDisclaimer = styled.div`
 	font-size: 12px;
 	color: ${(props) => props.theme.colors.common.secondaryGray};
 	margin: 0 8px 12px;
+`;
+
+export const StyledInput = styled(CustomNumericInput)`
+	font-family: ${(props) => props.theme.fonts.mono};
+	text-overflow: ellipsis;
 `;
 
 export default LeverageInput;

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -79,7 +79,7 @@ const LeverageInput: FC<LeverageInputProps> = ({
 				<LeverageInputContainer>
 					<StyledInput
 						value={currentLeverage}
-						placeholder="0"
+						placeholder="1"
 						suffix="x"
 						maxValue={maxLeverage.toNumber()}
 						onChange={(_, newValue) => {

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -33,7 +33,7 @@ const OrderSizing: React.FC<OrderSizingProps> = ({
 	const handleSetMax = () => {
 		const maxOrderSizeUSDValue = Number(maxLeverage.mul(totalMargin)).toFixed(0);
 		onAmountSUSDChange(maxOrderSizeUSDValue);
-		onLeverageChange(Number(maxLeverage).toString());
+		onLeverageChange(Number(maxLeverage).toString().substring(0, 4));
 	};
 
 	return (

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -4,6 +4,7 @@ import Wei from '@synthetixio/wei';
 
 import { Synths } from 'constants/currency';
 import CustomInput from 'components/Input/CustomInput';
+import { FlexDivRow } from 'styles/common';
 
 type OrderSizingProps = {
 	assetRate: Wei;
@@ -12,7 +13,10 @@ type OrderSizingProps = {
 	disabled?: boolean;
 	onAmountChange: (value: string) => void;
 	onAmountSUSDChange: (value: string) => void;
+	onLeverageChange: (value: string) => void;
 	marketAsset: string | null;
+	maxLeverage: Wei;
+	totalMargin: Wei;
 };
 
 const OrderSizing: React.FC<OrderSizingProps> = ({
@@ -22,17 +26,30 @@ const OrderSizing: React.FC<OrderSizingProps> = ({
 	disabled,
 	onAmountChange,
 	onAmountSUSDChange,
+	onLeverageChange,
+	maxLeverage,
+	totalMargin,
 }) => {
+	const handleSetMax = () => {
+		const maxOrderSizeUSDValue = Number(maxLeverage.mul(totalMargin)).toFixed(0);
+		onAmountSUSDChange(maxOrderSizeUSDValue);
+		onLeverageChange(Number(maxLeverage).toString());
+	};
+
 	return (
 		<OrderSizingContainer>
-			<OrderSizingTitle>
-				Amount&nbsp; —<span>&nbsp; Set order size</span>
-			</OrderSizingTitle>
+			<OrderSizingRow>
+				<OrderSizingTitle>
+					Amount&nbsp; —<span>&nbsp; Set order size</span>
+				</OrderSizingTitle>
+				<MaxButton onClick={handleSetMax}>Max</MaxButton>
+			</OrderSizingRow>
 
 			<CustomInput
 				disabled={disabled}
 				right={marketAsset || Synths.sUSD}
 				value={amount}
+				placeholder="0.0"
 				onChange={(_, v) => onAmountChange(v)}
 				style={{
 					marginBottom: '-1px',
@@ -46,6 +63,7 @@ const OrderSizing: React.FC<OrderSizingProps> = ({
 				disabled={disabled}
 				right={Synths.sUSD}
 				value={amountSUSD}
+				placeholder="0.0"
 				onChange={(_, v) => onAmountSUSDChange(v)}
 				style={{
 					borderTopRightRadius: '0px',
@@ -57,18 +75,34 @@ const OrderSizing: React.FC<OrderSizingProps> = ({
 };
 
 const OrderSizingContainer = styled.div`
+	margin-top: 28px;
 	margin-bottom: 16px;
 `;
 
-const OrderSizingTitle = styled.p`
+const OrderSizingTitle = styled.div`
 	color: ${(props) => props.theme.colors.common.primaryWhite};
 	font-size: 12px;
-	margin-bottom: 8px;
-	margin-left: 14px;
 
 	span {
 		color: ${(props) => props.theme.colors.common.secondaryGray};
 	}
+`;
+
+const OrderSizingRow = styled(FlexDivRow)`
+	width: 100%;
+	align-items: center;
+	margin-bottom: 8px;
+	padding: 0 14px;
+`;
+
+const MaxButton = styled.button`
+	text-decoration: underline;
+	font-size: 11px;
+	line-height: 11px;
+	color: ${(props) => props.theme.colors.common.secondaryGray};
+	background-color: transparent;
+	border: none;
+	cursor: pointer;
 `;
 
 export default OrderSizing;

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -148,18 +148,21 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 		};
 	}, [router.events]);
 
-	/*
-	// TODO: Check if commenting this part doesn't break anything.
 	useEffect(() => {
 		if (Number(tradeSize) && !!position?.remainingMargin) {
-			setLeverage(marketAssetRate.mul(Number(tradeSize)).div(position?.remainingMargin).toString());
+			setLeverage(
+				marketAssetRate
+					.mul(Number(tradeSize))
+					.div(position?.remainingMargin)
+					.toString()
+					.substring(0, 4)
+			);
 		} else {
 			if (Number(leverage) !== 0) {
 				setLeverage('');
 			}
 		}
 	}, [tradeSize, marketAssetRate, position, leverage]);
-	*/
 
 	const onTradeAmountSUSDChange = (value: string) => {
 		setTradeSizeSUSD(value === '' || Number(value) === 0 ? '' : value);

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -149,6 +149,7 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 		const handleRouteChange = () => {
 			setTradeSize('');
 			setTradeSizeSUSD('');
+			setLeverage('');
 		};
 		router.events.on('routeChangeStart', handleRouteChange);
 
@@ -171,18 +172,17 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 	const onLeverageChange = React.useCallback(
 		(value: string) => {
 			if (value === '' || Number(value) <= 0) {
-				setLeverage(Number(value) === 0 ? value : '');
 				setTradeSize('');
 				setTradeSizeSUSD('');
+				setLeverage(Number(value) === 0 ? value.substring(0, 4) : '');
 			} else {
-				setLeverage(value);
 				const newTradeSize = marketAssetRate.eq(0)
 					? 0
 					: wei(value)
 							.mul(position?.remainingMargin ?? zeroBN)
 							.div(marketAssetRate);
-
 				onTradeAmountChange(newTradeSize.toString(), true);
+				setLeverage(value.substring(0, 4));
 			}
 		},
 		[position?.remainingMargin, marketAssetRate, onTradeAmountChange]

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -130,10 +130,19 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 		(value: string, fromLeverage: boolean = false) => {
 			const size = fromLeverage ? (value === '' ? '' : wei(value).toNumber().toString()) : value;
 			const sizeSUSD = value === '' ? '' : marketAssetRate.mul(Number(value)).toNumber().toString();
+			const leverage =
+				value === ''
+					? ''
+					: marketAssetRate
+							.mul(Number(value))
+							.div(position?.remainingMargin)
+							.toString()
+							.substring(0, 4);
 			setTradeSize(size);
 			setTradeSizeSUSD(sizeSUSD);
+			setLeverage(leverage);
 		},
-		[marketAssetRate]
+		[marketAssetRate, position?.remainingMargin]
 	);
 
 	useEffect(() => {
@@ -148,29 +157,15 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 		};
 	}, [router.events]);
 
-	useEffect(() => {
-		if (Number(tradeSize) && !!position?.remainingMargin) {
-			setLeverage(
-				marketAssetRate
-					.mul(Number(tradeSize))
-					.div(position?.remainingMargin)
-					.toString()
-					.substring(0, 4)
-			);
-		} else {
-			if (Number(leverage) !== 0) {
-				setLeverage('');
-			}
-		}
-	}, [tradeSize, marketAssetRate, position, leverage]);
-
 	const onTradeAmountSUSDChange = (value: string) => {
-		setTradeSizeSUSD(value === '' || Number(value) === 0 ? '' : value);
-		setTradeSize(
-			value === '' || Number(value) === 0
-				? ''
-				: wei(value).div(marketAssetRate).toNumber().toString()
-		);
+		const valueIsNull = value === '' || Number(value) === 0;
+		const size = valueIsNull ? '' : wei(value).div(marketAssetRate).toNumber().toString();
+		const leverage = valueIsNull
+			? ''
+			: wei(value).div(position?.remainingMargin).toString().substring(0, 4);
+		setTradeSizeSUSD(value);
+		setTradeSize(size);
+		setLeverage(leverage);
 	};
 
 	const onLeverageChange = React.useCallback(

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -148,6 +148,8 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 		};
 	}, [router.events]);
 
+	/*
+	// TODO: Check if commenting this part doesn't break anything.
 	useEffect(() => {
 		if (Number(tradeSize) && !!position?.remainingMargin) {
 			setLeverage(marketAssetRate.mul(Number(tradeSize)).div(position?.remainingMargin).toString());
@@ -157,10 +159,15 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 			}
 		}
 	}, [tradeSize, marketAssetRate, position, leverage]);
+	*/
 
 	const onTradeAmountSUSDChange = (value: string) => {
-		setTradeSizeSUSD(value);
-		setTradeSize(value === '' ? '' : wei(value).div(marketAssetRate).toNumber().toString());
+		setTradeSizeSUSD(value === '' || Number(value) === 0 ? '' : value);
+		setTradeSize(
+			value === '' || Number(value) === 0
+				? ''
+				: wei(value).div(marketAssetRate).toNumber().toString()
+		);
 	};
 
 	const onLeverageChange = React.useCallback(
@@ -336,7 +343,10 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position })
 				assetRate={marketAssetRate}
 				onAmountChange={onTradeAmountChange}
 				onAmountSUSDChange={onTradeAmountSUSDChange}
+				onLeverageChange={(value) => onLeverageChange(value)}
 				marketAsset={marketAsset || Synths.sUSD}
+				maxLeverage={maxLeverageValue}
+				totalMargin={position?.remainingMargin ?? zeroBN}
 			/>
 
 			<LeverageInput


### PR DESCRIPTION
## Description
- [x] Add `1x` placeholder to leverage input.
- [x] User inputted numbers now have an `x` appended to them.
- [x] Add `0.0` placeholders in both amount input fields.
- [x] New `Add` button to open amount position input.

## Related issue
#649

## How Has This Been Tested?
- Visit the markets and check that all the placeholders are displayed.
- Click on the max button, it should match with your sUSD total balance.
