### PR TITLE
update css on pnl container to flex column allowing stacked display

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -169,7 +169,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 								<DefaultCell>{NO_VALUE}</DefaultCell>
 							) : (
 								<PnlContainer>
-									<ChangePercent value={cellProps.row.original.pnlPct} className="change-pct" />
+									<ChangePercent value={cellProps.row.original.pnlPct} />
 									<div>
 										(
 										<Currency.Price
@@ -233,12 +233,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 
 const PnlContainer = styled.div`
 	display: flex;
-	flex-direction: flex-row;
-	align-items: center;
-
-	.change-pct {
-		margin-right: 4px;
-	}
+	flex-direction: column;
 `;
 
 const StyledCurrencyIcon = styled(Currency.Icon)`


### PR DESCRIPTION
## Description
This issue was simple to fix. The existing css for the element had `flex-direction: flex-row` which renders the items in one row. I changed this to `flex-direction: column` to get the stacking display. 

Next I removed the css class associated with the change in percent, as it was used to set a margin to give space between the items when displayed in one line. 

Next I removed `align-items: center` as all items in the table render the cells with content positioned to the left.

## Related issue
https://github.com/Kwenta/kwenta/issues/676

## Motivation and Context
For higher values, numbers in the Position Table columns on the dashboard merge into each other, making the table unreadable. Additionally, parenthesis for the uPnL look weird (see screenshot).

## How Has This Been Tested?
just visual tests to confirm everything looks good, and `npm run build` to make sure no errors came up. would appreciate any guidance for running specific tests before sending a commit. just need a point in the right direction :)

## Screenshots (if appropriate):
In the below screenshot, I manually put an extremely large number in the percent gain, as I could not simulate a trade showing huge gains. The point is to show large percent gains display properly
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/100385397/163515402-db7b94cb-c919-4857-a7a1-ce43c165ada5.png">

normal display with real trade numbers
<img width="927" alt="image" src="https://user-images.githubusercontent.com/100385397/163515430-fa8c9189-4b47-4eae-a1c1-17b412a4a489.png">
