### PR TITLE
fix leaderboard navigation

### DIFF
--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -44,6 +44,8 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 		if (router.query.tab) {
 			const trader = router.query.tab[0];
 			setSelectedTrader(trader);
+		} else {
+			setSelectedTrader('');
 		}
 		return null;
 	}, [router.query]);


### PR DESCRIPTION
Clicking Leaderboard header link from TraderHistory now properly clears selectedTrader

## Description
added else statement to Leaderboard.tsx to handle blank query 

## Related issue
https://github.com/Kwenta/kwenta/issues/705

## Motivation and Context
fixing intended user experience

## How Has This Been Tested?
implemented, selected a trader from leaderboard, clicked header Leaderboard link, and confirmed the query refreshed