### PR TITLE
Put OI tooltip in order

### DIFF
--- a/components/Tooltip/TooltipStyles.tsx
+++ b/components/Tooltip/TooltipStyles.tsx
@@ -32,7 +32,8 @@ export const Tooltip = styled.div<ToolTipStyleProps>`
 			font-family: ${(props) => props.theme.fonts.mono};
 			font-style: normal;
 			font-weight: 400;
-			line-height: 12px;
+			line-height: 8px;
+			white-space: pre-line;
 			color: ${(props) => props.theme.colors.white};
 		}
 

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -131,6 +131,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 								.toNumber(),
 							{ sign: '$' }
 						)}
+						
 						Short: ${formatCurrency(
 							selectedPriceCurrency.name,
 							marketSummary.marketSize


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the Tooltip styles to force line break to the OI input. Besides introducing a white-space pre, had to modify the line height to make the two lines tighter.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Kwenta/kwenta/issues/699

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
fixing intended user experience

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
modified the OI values, ran npm lint

## Screenshots (if appropriate):
![new](https://user-images.githubusercontent.com/28528607/163679360-3c966162-7714-4825-8d6a-e33ba7e1f17b.png)

