### PR TITLE
Add fields to queries

### DIFF
--- a/queries/futures/useGetFuturesMarketPositionHistory.ts
+++ b/queries/futures/useGetFuturesMarketPositionHistory.ts
@@ -42,13 +42,22 @@ const useGetFuturesMarketPositionHistory = (
 								id
 								lastTxHash
 								timestamp
+								account
+								market
+								asset
+								margin
+								size
+								feesPaid
+								netFunding
 								isOpen
 								isLiquidated
 								entryPrice
 								exitPrice
-								size
-								margin
-								asset
+								pnl
+								closeTimestamp
+								openTimestamp
+								totalVolume
+								trades
 							}
 						}
 					`,

--- a/queries/futures/useGetFuturesPositionForAccount.ts
+++ b/queries/futures/useGetFuturesPositionForAccount.ts
@@ -37,6 +37,11 @@ const useGetFuturesPositionForAccount = (options?: UseQueryOptions<any>) => {
 								isLiquidated
 								entryPrice
 								exitPrice
+								pnl
+								closeTimestamp
+								openTimestamp
+								totalVolume
+								trades
 							}
 						}
 					`,


### PR DESCRIPTION
Hotfix to correct missing funding and average pricing data on the position card.

Our utility function to clean data expects more fields that we are pulling in the query, so it's failing and not returning data to the Position Card.

Fixed:
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/10401554/163850208-e9ee3c04-4c82-4d77-8961-ecf7e0d02e71.png">

#707 