### PR TITLE
Default wallet behavior

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/WalletActions.tsx
+++ b/sections/shared/Layout/AppLayout/Header/WalletActions.tsx
@@ -100,7 +100,7 @@ export const WalletActions: FC = () => {
 
 	useEffect(() => {
 		if (signer) {
-			setWalletLabel('loading...');
+			setWalletLabel(truncatedWalletAddress!);
 			signer.getAddress().then((account: string) => {
 				const _account = account;
 				getENSName(_account, staticMainnetProvider).then((_ensName: string) => {


### PR DESCRIPTION
Fixing the default wallet behavior on connection. Right now we default to "loading..." while the ENS hook is running. This change will default to the wallet address, and only update if an ENS name exists for that address.

It should be better for addresses without an ENS name, as they never see "loading...".

It should be better for addresses with an ENS name, as they see their wallet address first before their ENS name updates which is common on other frontends.