### PR TITLE
Show SOL correctly in closing position modal

### DIFF
--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -9,7 +9,7 @@ export const isFiatCurrency = (currencyKey: CurrencyKey) => FIAT_SYNTHS.has(curr
 // TODO: replace this with a more robust logic (like checking the asset field)
 export const toInverseSynth = (currencyKey: CurrencyKey) => currencyKey.replace(/^s/i, 'i');
 export const toStandardSynth = (currencyKey: CurrencyKey) => currencyKey.replace(/^i/i, 's');
-export const synthToAsset = (currencyKey: CurrencyKey) => currencyKey.replace(/^(i|s)/i, '');
+export const synthToAsset = (currencyKey: CurrencyKey) => currencyKey.replace(/^(i|s)/, '');
 export const assetToSynth = (currencyKey: CurrencyKey) => `s${currencyKey}`;
 export const iStandardSynth = (currencyKey: CurrencyKey) => currencyKey.startsWith('s');
 export const synthToContractName = (currencyKey: CurrencyKey) => `Synth${currencyKey}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the name of SOL in the closing position modal. 

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
#730 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current `synthToAsset` is case-insensitive. It always removes the first letter `s` or `S`. However, we only want to remove the lowercase.

## How Has This Been Tested?
1. Open position sLINK and close it. The name is displayed correctly.
2. Open position sSOL and close it. The name is displayed correctly.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/164539786-e3f939c2-c6d3-43e1-a815-163c1d0e6de9.png)
