### PR TITLE
Remove MaxLeverage from MarketDetails

### DIFF
--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -164,9 +164,6 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 				value: fundingValue ? formatPercent(fundingValue ?? zeroBN, { minDecimals: 6 }) : NO_VALUE,
 				color: fundingValue?.gt(zeroBN) ? 'green' : fundingValue?.lt(zeroBN) ? 'red' : undefined,
 			},
-			'Max Leverage': {
-				value: marketSummary?.maxLeverage ? `${marketSummary?.maxLeverage.toString(0)}x` : NO_VALUE,
-			},
 		};
 	}, [
 		baseCurrencyKey,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the Max Leverage information in the `MarketDetails` to be in line with latest design changes. We already show the max available leverage for a given position in the bottom right.

## Screenshots

![Screen Shot 2022-04-21 at 20 26 47](https://user-images.githubusercontent.com/548702/164567057-34edfc7f-f083-46c1-9af4-e2d82ae1f465.png)


