### PR TITLE
Fix paused markets

### DIFF
--- a/components/Badge/MarketBadge.tsx
+++ b/components/Badge/MarketBadge.tsx
@@ -1,6 +1,6 @@
 import { CurrencyKey } from 'constants/currency';
+import { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 import useIsMarketTransitioning from 'hooks/useIsMarketTransitioning';
-import { FuturesSuspensionReason } from 'queries/futures/useFuturesSuspensionQuery';
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -12,7 +12,7 @@ import Badge from './Badge';
 type MarketBadgeProps = {
 	currencyKey: CurrencyKey | null;
 	isFuturesMarketClosed: boolean;
-	futuresClosureReason: FuturesSuspensionReason;
+	futuresClosureReason: FuturesClosureReason;
 };
 
 type TransitionBadgeProps = {

--- a/components/Badge/MarketBadge.tsx
+++ b/components/Badge/MarketBadge.tsx
@@ -1,6 +1,6 @@
 import { CurrencyKey } from 'constants/currency';
 import useIsMarketTransitioning from 'hooks/useIsMarketTransitioning';
-import useMarketClosed from 'hooks/useMarketClosed';
+import { useFuturesMarketClosed } from 'hooks/useMarketClosed';
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -31,8 +31,7 @@ export const MarketBadge: FC<MarketBadgeProps> = ({ currencyKey }) => {
 	const { t } = useTranslation();
 	const isOpen = marketIsOpen((currencyKey as CurrencyKey) ?? null);
 
-	const { isMarketClosed, marketClosureReason } = useMarketClosed(currencyKey);
-
+	const { isMarketClosed, marketClosureReason } = useFuturesMarketClosed(currencyKey);
 	const nextOpen = marketNextOpen((currencyKey as CurrencyKey) ?? '');
 	const nextTransition = marketNextTransition((currencyKey as CurrencyKey) ?? '');
 

--- a/components/Badge/MarketBadge.tsx
+++ b/components/Badge/MarketBadge.tsx
@@ -1,6 +1,6 @@
 import { CurrencyKey } from 'constants/currency';
 import useIsMarketTransitioning from 'hooks/useIsMarketTransitioning';
-import { useFuturesMarketClosed } from 'hooks/useMarketClosed';
+import { FuturesSuspensionReason } from 'queries/futures/useFuturesSuspensionQuery';
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -11,6 +11,8 @@ import Badge from './Badge';
 
 type MarketBadgeProps = {
 	currencyKey: CurrencyKey | null;
+	isFuturesMarketClosed: boolean;
+	futuresClosureReason: FuturesSuspensionReason;
 };
 
 type TransitionBadgeProps = {
@@ -27,11 +29,14 @@ export const TransitionBadge: FC<TransitionBadgeProps> = ({ isOpen }) => {
 	);
 };
 
-export const MarketBadge: FC<MarketBadgeProps> = ({ currencyKey }) => {
+export const MarketBadge: FC<MarketBadgeProps> = ({
+	currencyKey,
+	isFuturesMarketClosed,
+	futuresClosureReason,
+}) => {
 	const { t } = useTranslation();
 	const isOpen = marketIsOpen((currencyKey as CurrencyKey) ?? null);
 
-	const { isMarketClosed, marketClosureReason } = useFuturesMarketClosed(currencyKey);
 	const nextOpen = marketNextOpen((currencyKey as CurrencyKey) ?? '');
 	const nextTransition = marketNextTransition((currencyKey as CurrencyKey) ?? '');
 
@@ -42,11 +47,11 @@ export const MarketBadge: FC<MarketBadgeProps> = ({ currencyKey }) => {
 		return <TransitionBadge isOpen={isOpen} />;
 	}
 
-	if (!isMarketClosed) {
+	if (!isFuturesMarketClosed) {
 		return null;
 	}
 
-	return <Badge>{t(`futures.market.state.${marketClosureReason}`)}</Badge>;
+	return <Badge>{t(`futures.market.state.${futuresClosureReason}`)}</Badge>;
 };
 
 export default MarketBadge;

--- a/constants/currency.ts
+++ b/constants/currency.ts
@@ -43,8 +43,8 @@ export const CRYPTO_CURRENCY = [
 ];
 
 export const CRYPTO_CURRENCY_MAP = keyBy(CRYPTO_CURRENCY);
-
-export const FIAT_SYNTHS: Set<CurrencyKey | 'EUR'> = new Set([
+export type FUTURES_FIAT = 'EUR' | 'JPY' | 'USD' | 'AUD' | 'GBP' | 'CHF';
+export const FIAT_SYNTHS: Set<CurrencyKey | FUTURES_FIAT> = new Set([
 	Synths.sEUR,
 	Synths.sJPY,
 	Synths.sUSD,
@@ -52,6 +52,11 @@ export const FIAT_SYNTHS: Set<CurrencyKey | 'EUR'> = new Set([
 	Synths.sGBP,
 	Synths.sCHF,
 	'EUR',
+	'JPY',
+	'USD',
+	'AUD',
+	'GBP',
+	'CHF',
 ]);
 
 export const LSE_SYNTHS = new Set<CurrencyKey>([]);

--- a/constants/currency.ts
+++ b/constants/currency.ts
@@ -44,13 +44,14 @@ export const CRYPTO_CURRENCY = [
 
 export const CRYPTO_CURRENCY_MAP = keyBy(CRYPTO_CURRENCY);
 
-export const FIAT_SYNTHS: Set<CurrencyKey> = new Set([
+export const FIAT_SYNTHS: Set<CurrencyKey | 'EUR'> = new Set([
 	Synths.sEUR,
 	Synths.sJPY,
 	Synths.sUSD,
 	Synths.sAUD,
 	Synths.sGBP,
 	Synths.sCHF,
+	'EUR',
 ]);
 
 export const LSE_SYNTHS = new Set<CurrencyKey>([]);

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -135,6 +135,12 @@ export const QUERY_KEYS = {
 			networkId,
 			currencyKey,
 		],
+		MarketClosure: (networkId: NetworkId, currencyKey: string | null) => [
+			'futures',
+			'closures',
+			networkId,
+			currencyKey,
+		],
 		OpenInterest: (currencyKeys: string[]) => ['futures', 'openInterest', currencyKeys],
 		TradingVolume: (networkId: NetworkId, currencyKey: string | null) => [
 			'futures',

--- a/hooks/useFuturesMarketClosed.ts
+++ b/hooks/useFuturesMarketClosed.ts
@@ -1,0 +1,31 @@
+import { CurrencyKey } from 'constants/currency';
+
+import useFuturesSuspensionQuery, {
+	FuturesSuspensionReason,
+} from 'queries/futures/useFuturesSuspensionQuery';
+import { getReasonFromCode } from 'queries/futures/utils';
+
+export type MarketClosureReason = FuturesSuspensionReason;
+export type MarketClosure = ReturnType<typeof useFuturesMarketClosed>;
+
+const useFuturesMarketClosed = (currencyKey: CurrencyKey | null) => {
+	const futuresMarketSuspendedQuery = useFuturesSuspensionQuery(currencyKey);
+
+	const isFutureMarketSuspended =
+		futuresMarketSuspendedQuery.isSuccess && futuresMarketSuspendedQuery.data
+			? futuresMarketSuspendedQuery.data.isFuturesMarketClosed
+			: false;
+
+	const reason =
+		futuresMarketSuspendedQuery.isSuccess && futuresMarketSuspendedQuery.data
+			? getReasonFromCode(futuresMarketSuspendedQuery.data.futuresClosureReason)
+			: null;
+
+	return {
+		isFuturesMarketClosed: isFutureMarketSuspended,
+		isFutureMarketSuspended,
+		futuresClosureReason: reason as FuturesSuspensionReason,
+	};
+};
+
+export default useFuturesMarketClosed;

--- a/hooks/useFuturesMarketClosed.ts
+++ b/hooks/useFuturesMarketClosed.ts
@@ -1,11 +1,9 @@
+import { SynthSuspensionReason } from '@synthetixio/queries';
 import { CurrencyKey } from 'constants/currency';
-
-import useFuturesSuspensionQuery, {
-	FuturesSuspensionReason,
-} from 'queries/futures/useFuturesSuspensionQuery';
+import useFuturesSuspensionQuery from 'queries/futures/useFuturesSuspensionQuery';
 import { getReasonFromCode } from 'queries/futures/utils';
 
-export type MarketClosureReason = FuturesSuspensionReason;
+export type FuturesClosureReason = SynthSuspensionReason;
 export type MarketClosure = ReturnType<typeof useFuturesMarketClosed>;
 
 const useFuturesMarketClosed = (currencyKey: CurrencyKey | null) => {
@@ -24,7 +22,7 @@ const useFuturesMarketClosed = (currencyKey: CurrencyKey | null) => {
 	return {
 		isFuturesMarketClosed: isFutureMarketSuspended,
 		isFutureMarketSuspended,
-		futuresClosureReason: reason as FuturesSuspensionReason,
+		futuresClosureReason: reason as FuturesClosureReason,
 	};
 };
 

--- a/hooks/useMarketClosed.ts
+++ b/hooks/useMarketClosed.ts
@@ -2,6 +2,14 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { CurrencyKey } from 'constants/currency';
 
 import { SynthSuspensionReason } from '@synthetixio/queries';
+import { useEffect, useState } from 'react';
+import { utils } from 'ethers';
+import SystemStatus from 'sections/shared/SystemStatus';
+import { getMarketKey } from 'utils/futures';
+import { useRecoilValue } from 'recoil';
+import { isL2State, isWalletConnectedState, networkState } from 'store/wallet';
+import Connector from 'containers/Connector';
+import { getReasonFromCode } from 'queries/futures/utils';
 
 export type MarketClosureReason = 'frozen' | SynthSuspensionReason;
 export type MarketClosure = ReturnType<typeof useMarketClosed>;
@@ -20,6 +28,41 @@ const useMarketClosed = (currencyKey: CurrencyKey | null) => {
 		isMarketClosed: isCurrencySuspended,
 		isCurrencySuspended,
 		marketClosureReason: currencySuspendedQuery.data?.reason as MarketClosureReason,
+	};
+};
+
+export const useFuturesMarketClosed = (currencyKey: CurrencyKey | null) => {
+	const [isMarketClosed, setIsMarketClosed] = useState(false);
+	const [marketClosureReason, setMarketClosureReason] = useState<MarketClosureReason>();
+	const { synthetixjs } = Connector.useContainer();
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const isL2 = useRecoilValue(isL2State);
+	const network = useRecoilValue(networkState);
+
+	useEffect(() => {
+		if (!synthetixjs && isWalletConnected && !isL2) {
+			return null;
+		}
+
+		async function getMarketSuspended() {
+			const {
+				contracts: { SystemStatus },
+			} = synthetixjs!;
+			const marketKey = getMarketKey(currencyKey, network.id);
+			const market = utils.formatBytes32String(marketKey);
+
+			const { suspensions, reasons } = await SystemStatus.getFuturesMarketSuspensions([market]);
+			const reason = getReasonFromCode(reasons[0]);
+			setIsMarketClosed(suspensions[0]);
+			setMarketClosureReason(reason || undefined);
+		}
+
+		getMarketSuspended();
+	}, [synthetixjs]);
+
+	return {
+		isMarketClosed,
+		marketClosureReason,
 	};
 };
 

--- a/hooks/useMarketClosed.ts
+++ b/hooks/useMarketClosed.ts
@@ -2,14 +2,6 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { CurrencyKey } from 'constants/currency';
 
 import { SynthSuspensionReason } from '@synthetixio/queries';
-import { useEffect, useState } from 'react';
-import { utils } from 'ethers';
-import SystemStatus from 'sections/shared/SystemStatus';
-import { getMarketKey } from 'utils/futures';
-import { useRecoilValue } from 'recoil';
-import { isL2State, isWalletConnectedState, networkState } from 'store/wallet';
-import Connector from 'containers/Connector';
-import { getReasonFromCode } from 'queries/futures/utils';
 
 export type MarketClosureReason = 'frozen' | SynthSuspensionReason;
 export type MarketClosure = ReturnType<typeof useMarketClosed>;
@@ -28,41 +20,6 @@ const useMarketClosed = (currencyKey: CurrencyKey | null) => {
 		isMarketClosed: isCurrencySuspended,
 		isCurrencySuspended,
 		marketClosureReason: currencySuspendedQuery.data?.reason as MarketClosureReason,
-	};
-};
-
-export const useFuturesMarketClosed = (currencyKey: CurrencyKey | null) => {
-	const [isMarketClosed, setIsMarketClosed] = useState(false);
-	const [marketClosureReason, setMarketClosureReason] = useState<MarketClosureReason>();
-	const { synthetixjs } = Connector.useContainer();
-	const isWalletConnected = useRecoilValue(isWalletConnectedState);
-	const isL2 = useRecoilValue(isL2State);
-	const network = useRecoilValue(networkState);
-
-	useEffect(() => {
-		if (!synthetixjs && isWalletConnected && !isL2) {
-			return null;
-		}
-
-		async function getMarketSuspended() {
-			const {
-				contracts: { SystemStatus },
-			} = synthetixjs!;
-			const marketKey = getMarketKey(currencyKey, network.id);
-			const market = utils.formatBytes32String(marketKey);
-
-			const { suspensions, reasons } = await SystemStatus.getFuturesMarketSuspensions([market]);
-			const reason = getReasonFromCode(reasons[0]);
-			setIsMarketClosed(suspensions[0]);
-			setMarketClosureReason(reason || undefined);
-		}
-
-		getMarketSuspended();
-	}, [synthetixjs]);
-
-	return {
-		isMarketClosed,
-		marketClosureReason,
 	};
 };
 

--- a/queries/futures/useFuturesSuspensionQuery.ts
+++ b/queries/futures/useFuturesSuspensionQuery.ts
@@ -6,16 +6,14 @@ import { getReasonFromCode } from 'queries/futures/utils';
 import { CurrencyKey } from '@synthetixio/contracts-interface';
 import QUERY_KEYS from 'constants/queryKeys';
 import { useQuery, UseQueryOptions } from 'react-query';
-import { SynthSuspensionReason } from '@synthetixio/queries';
 import { appReadyState } from 'store/app';
 import { ethers } from 'ethers';
-
-export type FuturesSuspensionReason = SynthSuspensionReason;
+import { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 
 interface FuturesMarketClosure {
 	isSuspended: boolean;
 	reasonCode: ethers.BigNumber;
-	reason: FuturesSuspensionReason;
+	reason: FuturesClosureReason;
 }
 
 const useFuturesSuspensionQuery = (
@@ -50,7 +48,7 @@ const useFuturesSuspensionQuery = (
 				return {
 					isSuspended,
 					reasonCode: reason,
-					reason: (isSuspended ? getReasonFromCode(reason) : null) as FuturesSuspensionReason,
+					reason: (isSuspended ? getReasonFromCode(reason) : null) as FuturesClosureReason,
 				};
 			} catch (e) {
 				return null;

--- a/queries/futures/useFuturesSuspensionQuery.ts
+++ b/queries/futures/useFuturesSuspensionQuery.ts
@@ -1,0 +1,66 @@
+import { getMarketKey } from 'utils/futures';
+import { useRecoilValue } from 'recoil';
+import { isL2State, isWalletConnectedState, networkState } from 'store/wallet';
+import Connector from 'containers/Connector';
+import { getReasonFromCode } from 'queries/futures/utils';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
+import QUERY_KEYS from 'constants/queryKeys';
+import { useQuery, UseQueryOptions } from 'react-query';
+import { SynthSuspensionReason } from '@synthetixio/queries';
+import { appReadyState } from 'store/app';
+import { ethers } from 'ethers';
+
+export type FuturesSuspensionReason = SynthSuspensionReason;
+
+interface FuturesMarketClosure {
+	isSuspended: boolean;
+	reasonCode: ethers.BigNumber;
+	reason: FuturesSuspensionReason;
+}
+
+const useFuturesSuspensionQuery = (
+	currencyKey: CurrencyKey | null,
+	options?: UseQueryOptions<FuturesMarketClosure>
+) => {
+	const isAppReady = useRecoilValue(appReadyState);
+	const { synthetixjs } = Connector.useContainer();
+	const isWalletConnected = useRecoilValue(isWalletConnectedState);
+	const isL2 = useRecoilValue(isL2State);
+	const network = useRecoilValue(networkState);
+	const isReady = isAppReady && !!synthetixjs;
+
+	return useQuery<any>(
+		QUERY_KEYS.Futures.MarketClosure(network.id, currencyKey),
+		async () => {
+			if (isWalletConnected && !isL2) {
+				return null;
+			}
+
+			try {
+				const {
+					contracts: { SystemStatus },
+					utils,
+				} = synthetixjs!;
+
+				const marketKey = getMarketKey(currencyKey, network.id);
+				const [isSuspended, reason] = (await SystemStatus.getFuturesMarketSuspensions([
+					utils.formatBytes32String(marketKey),
+				])) as [boolean, ethers.BigNumber];
+
+				return {
+					isSuspended,
+					reasonCode: reason,
+					reason: (isSuspended ? getReasonFromCode(reason) : null) as FuturesSuspensionReason,
+				};
+			} catch (e) {
+				return null;
+			}
+		},
+		{
+			enabled: isWalletConnected ? isL2 && isReady : isReady,
+			...options,
+		}
+	);
+};
+
+export default useFuturesSuspensionQuery;

--- a/queries/futures/useFuturesSuspensionQuery.ts
+++ b/queries/futures/useFuturesSuspensionQuery.ts
@@ -30,10 +30,6 @@ const useFuturesSuspensionQuery = (
 	return useQuery<any>(
 		QUERY_KEYS.Futures.MarketClosure(network.id, currencyKey),
 		async () => {
-			if (isWalletConnected && !isL2) {
-				return null;
-			}
-
 			try {
 				const {
 					contracts: { SystemStatus },

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -86,6 +86,8 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 					.mul(market.price)
 					.toNumber(),
 				marketSkew: market.marketSkew,
+				isSuspended: market.isSuspended,
+				marketClosureReason: market.marketClosureReason,
 			};
 		});
 	}, [
@@ -134,7 +136,11 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 									</IconContainer>
 									<StyledText>
 										{cellProps.row.original.market}
-										<MarketBadge currencyKey={cellProps.row.original.asset} />
+										<MarketBadge
+											currencyKey={cellProps.row.original.asset}
+											isFuturesMarketClosed={cellProps.row.original.isSuspended}
+											futuresClosureReason={cellProps.row.original.marketClosureReason}
+										/>
 									</StyledText>
 									<StyledValue>{cellProps.row.original.description}</StyledValue>
 								</MarketContainer>

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -41,8 +41,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 		);
 		return activePositions.length > 0
 			? activePositions.map((position: FuturesPosition, i: number) => {
-					const isSuspended =
-						futuresMarkets.find((market) => market.asset === position.asset)?.isSuspended ?? false;
+					const market = futuresMarkets.find((market) => market.asset === position.asset);
 					const description = getSynthDescription(position.asset, synthsMap, t);
 					const positionHistory = futuresPositionHistory?.find(
 						(positionHistory: PositionHistory) => {
@@ -66,7 +65,8 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 						),
 						margin: position.accessibleMargin,
 						leverage: position?.position?.leverage,
-						isSuspended,
+						isSuspended: market?.isSuspended,
+						marketClosureReason: market?.marketClosureReason,
 					};
 			  })
 			: DEFAULT_DATA;
@@ -102,7 +102,11 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 									</IconContainer>
 									<StyledText>
 										{cellProps.row.original.market}
-										<MarketBadge currencyKey={cellProps.row.original.asset} />
+										<MarketBadge
+											currencyKey={cellProps.row.original.asset}
+											isFuturesMarketClosed={cellProps.row.original.isSuspended}
+											futuresClosureReason={cellProps.row.original.marketClosureReason}
+										/>
 									</StyledText>
 									<StyledValue>{cellProps.row.original.description}</StyledValue>
 								</MarketContainer>

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -130,7 +130,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 
 	return (
 		<>
-			<Container id={isFuturesMarketClosed ? 'closed' : ''}>
+			<Container id={isFuturesMarketClosed ? 'closed' : undefined}>
 				<DataCol>
 					<InfoCol>
 						<CurrencyInfo>

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -15,9 +15,9 @@ import { NO_VALUE } from 'constants/placeholder';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
 import { getSynthDescription } from 'utils/futures';
 import Wei from '@synthetixio/wei';
-import useMarketClosed from 'hooks/useMarketClosed';
 import { CurrencyKey } from 'constants/currency';
 import MarketBadge from 'components/Badge/MarketBadge';
+import useFuturesMarketClosed from 'hooks/useFuturesMarketClosed';
 
 type PositionCardProps = {
 	currencyKey: string;
@@ -54,7 +54,9 @@ const PositionCard: React.FC<PositionCardProps> = ({
 	const positionDetails = position?.position ?? null;
 	const [closePositionModalIsVisible, setClosePositionModalIsVisible] = useState<boolean>(false);
 	const futuresPositionsQuery = useGetFuturesPositionForAccount();
-	const { isMarketClosed } = useMarketClosed(currencyKey as CurrencyKey);
+	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(
+		currencyKey as CurrencyKey
+	);
 
 	const futuresPositions = futuresPositionsQuery?.data ?? null;
 
@@ -128,7 +130,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 
 	return (
 		<>
-			<Container id={isMarketClosed ? 'closed' : ''}>
+			<Container id={isFuturesMarketClosed ? 'closed' : ''}>
 				<DataCol>
 					<InfoCol>
 						<CurrencyInfo>
@@ -136,7 +138,11 @@ const PositionCard: React.FC<PositionCardProps> = ({
 							<div>
 								<CurrencySubtitle>
 									{data.marketShortName}
-									<MarketBadge currencyKey={currencyKey as CurrencyKey} />
+									<MarketBadge
+										currencyKey={currencyKey as CurrencyKey}
+										isFuturesMarketClosed={isFuturesMarketClosed}
+										futuresClosureReason={futuresClosureReason}
+									/>
 								</CurrencySubtitle>
 								<StyledValue>{data.marketLongName}</StyledValue>
 							</div>
@@ -205,7 +211,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 								size="sm"
 								variant="danger"
 								onClick={() => setClosePositionModalIsVisible(true)}
-								disabled={!positionDetails || isMarketClosed}
+								disabled={!positionDetails || isFuturesMarketClosed}
 								noOutline={true}
 							>
 								{t('futures.market.user.position.close-position')}

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -21,8 +21,7 @@ import { getExchangeRatesForCurrencies } from 'utils/currencies';
 import { Price } from 'queries/rates/types';
 import { getSynthDescription, isEurForex } from 'utils/futures';
 import { DEFAULT_FIAT_EURO_DECIMALS } from 'constants/defaults';
-import useFuturesMarketClosed from 'hooks/useFuturesMarketClosed';
-import { FuturesSuspensionReason } from 'queries/futures/useFuturesSuspensionQuery';
+import useFuturesMarketClosed, { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 
 function setLastVisited(baseCurrencyPair: string): void {
 	localStorage.setItem('lastVisited', ROUTES.Markets.MarketPair(baseCurrencyPair));
@@ -36,7 +35,7 @@ export type MarketsCurrencyOption = {
 	change: string;
 	negativeChange: boolean;
 	isFuturesMarketClosed: boolean;
-	futuresClosureReason: FuturesSuspensionReason;
+	futuresClosureReason: FuturesClosureReason;
 };
 
 const assetToCurrencyOption = (
@@ -46,7 +45,7 @@ const assetToCurrencyOption = (
 	change: string,
 	negativeChange: boolean,
 	isFuturesMarketClosed: boolean,
-	futuresClosureReason: FuturesSuspensionReason
+	futuresClosureReason: FuturesClosureReason
 ): MarketsCurrencyOption => ({
 	value: asset as CurrencyKey,
 	label: `${asset[0] === 's' ? asset.slice(1) : asset}-PERP`,

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -20,8 +20,9 @@ import { formatCurrency, formatPercent, zeroBN } from 'utils/formatters/number';
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
 import { Price } from 'queries/rates/types';
 import { getSynthDescription, isEurForex } from 'utils/futures';
-import useMarketClosed from 'hooks/useMarketClosed';
 import { DEFAULT_FIAT_EURO_DECIMALS } from 'constants/defaults';
+import useFuturesMarketClosed from 'hooks/useFuturesMarketClosed';
+import { FuturesSuspensionReason } from 'queries/futures/useFuturesSuspensionQuery';
 
 function setLastVisited(baseCurrencyPair: string): void {
 	localStorage.setItem('lastVisited', ROUTES.Markets.MarketPair(baseCurrencyPair));
@@ -34,7 +35,8 @@ export type MarketsCurrencyOption = {
 	price: string;
 	change: string;
 	negativeChange: boolean;
-	isMarketClosed: boolean;
+	isFuturesMarketClosed: boolean;
+	futuresClosureReason: FuturesSuspensionReason;
 };
 
 const assetToCurrencyOption = (
@@ -43,7 +45,8 @@ const assetToCurrencyOption = (
 	price: string,
 	change: string,
 	negativeChange: boolean,
-	isMarketClosed: boolean
+	isFuturesMarketClosed: boolean,
+	futuresClosureReason: FuturesSuspensionReason
 ): MarketsCurrencyOption => ({
 	value: asset as CurrencyKey,
 	label: `${asset[0] === 's' ? asset.slice(1) : asset}-PERP`,
@@ -51,7 +54,8 @@ const assetToCurrencyOption = (
 	price,
 	change,
 	negativeChange,
-	isMarketClosed,
+	isFuturesMarketClosed,
+	futuresClosureReason,
 });
 
 type Props = {
@@ -69,7 +73,9 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 		futuresMarketsQuery?.data?.map(({ asset }) => asset) ?? []
 	);
 
-	const { isMarketClosed } = useMarketClosed(asset as CurrencyKey);
+	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(
+		asset as CurrencyKey
+	);
 
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const router = useRouter();
@@ -106,7 +112,8 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 						? true
 						: false
 					: false,
-				isMarketClosed
+				isFuturesMarketClosed,
+				futuresClosureReason
 			);
 		});
 	}, [
@@ -116,7 +123,7 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 		selectedPriceCurrency.name,
 		synthsMap,
 		t,
-		isMarketClosed,
+		isFuturesMarketClosed,
 	]);
 
 	return (
@@ -138,7 +145,8 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 					DUMMY_PRICE,
 					DUMMY_CHANGE,
 					false,
-					isMarketClosed
+					isFuturesMarketClosed,
+					futuresClosureReason
 				)}
 				options={options}
 				isSearchable={false}

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -116,6 +116,7 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 				futuresClosureReason
 			);
 		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		dailyPriceChangesQuery?.data,
 		futuresMarketsQuery?.data,

--- a/sections/futures/Trade/MarketsDropdownOption.tsx
+++ b/sections/futures/Trade/MarketsDropdownOption.tsx
@@ -4,8 +4,9 @@ import { CurrencyLabel, SingleValueContainer } from './MarketsDropdownSingleValu
 import { FlexDivCentered } from 'styles/common';
 import { components, OptionProps } from 'react-select';
 import MarketBadge from 'components/Badge/MarketBadge';
+import { MarketsCurrencyOption } from './MarketsDropdown';
 
-const MarketsDropdownOption: React.FC<OptionProps<any>> = (props) => (
+const MarketsDropdownOption: React.FC<OptionProps<MarketsCurrencyOption>> = (props) => (
 	<components.Option {...props}>
 		<OptionDetailsContainer $isSelected={props.isSelected}>
 			<CurrencyIcon
@@ -17,7 +18,11 @@ const MarketsDropdownOption: React.FC<OptionProps<any>> = (props) => (
 				<div>
 					<CurrencyLabel>
 						{props.data.label}
-						<MarketBadge currencyKey={props.data.value} />
+						<MarketBadge
+							currencyKey={props.data.value}
+							isFuturesMarketClosed={props.data.isFuturesMarketClosed}
+							futuresClosureReason={props.data.futuresClosureReason}
+						/>
 					</CurrencyLabel>
 					<p className="name">{props.data.description}</p>
 				</div>

--- a/sections/futures/Trade/MarketsDropdownSingleValue.tsx
+++ b/sections/futures/Trade/MarketsDropdownSingleValue.tsx
@@ -4,8 +4,9 @@ import { components, SingleValueProps } from 'react-select';
 import { FlexDivCentered } from 'styles/common';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import MarketBadge from 'components/Badge/MarketBadge';
+import { MarketsCurrencyOption } from './MarketsDropdown';
 
-const MarketsDropdownSingleValue: React.FC<SingleValueProps<any>> = (props) => (
+const MarketsDropdownSingleValue: React.FC<SingleValueProps<MarketsCurrencyOption>> = (props) => (
 	<components.SingleValue {...props}>
 		<SingleValueContainer>
 			<CurrencyIcon
@@ -16,7 +17,11 @@ const MarketsDropdownSingleValue: React.FC<SingleValueProps<any>> = (props) => (
 			<div className="currency-meta">
 				<CurrencyLabel>
 					{props.data.label}
-					<MarketBadge currencyKey={props.data.value} />
+					<MarketBadge
+						currencyKey={props.data.value}
+						isFuturesMarketClosed={props.data.isFuturesMarketClosed}
+						futuresClosureReason={props.data.futuresClosureReason}
+					/>
 				</CurrencyLabel>
 				<p className="name">{props.data.description}</p>
 			</div>

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -35,7 +35,7 @@ import WithdrawMarginModal from './WithdrawMarginModal';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import Connector from 'containers/Connector';
 import { getMarketKey } from 'utils/futures';
-import useMarketClosed from 'hooks/useMarketClosed';
+import useFuturesMarketClosed from 'hooks/useFuturesMarketClosed';
 
 const DEFAULT_MAX_LEVERAGE = wei(10);
 
@@ -50,7 +50,7 @@ const Trade: React.FC = () => {
 	const { synthetixjs, network } = Connector.useContainer();
 
 	const marketAsset = (router.query.market?.[0] as CurrencyKey) ?? null;
-	const { isMarketClosed } = useMarketClosed(marketAsset);
+	const { isFuturesMarketClosed } = useFuturesMarketClosed(marketAsset);
 	const marketQuery = useGetFuturesMarkets();
 	const market = marketQuery?.data?.find(({ asset }) => asset === marketAsset) ?? null;
 
@@ -256,13 +256,13 @@ const Trade: React.FC = () => {
 			<MarketsDropdown asset={marketAsset || Synths.sUSD} />
 			<MarketActions>
 				<MarketActionButton
-					disabled={isMarketClosed}
+					disabled={isFuturesMarketClosed}
 					onClick={() => setIsDepositMarginModalOpen(true)}
 				>
 					{t('futures.market.trade.button.deposit')}
 				</MarketActionButton>
 				<MarketActionButton
-					disabled={futuresMarketsPosition?.remainingMargin?.lte(zeroBN) || isMarketClosed}
+					disabled={futuresMarketsPosition?.remainingMargin?.lte(zeroBN) || isFuturesMarketClosed}
 					onClick={() => setIsWithdrawMarginModalOpen(true)}
 				>
 					{t('futures.market.trade.button.withdraw')}
@@ -286,7 +286,7 @@ const Trade: React.FC = () => {
 				}
 				liquidationPrice={futuresMarketsPosition?.position?.liquidationPrice ?? zeroBN}
 				leverage={futuresMarketsPosition?.position?.leverage ?? zeroBN}
-				isMarketClosed={isMarketClosed}
+				isMarketClosed={isFuturesMarketClosed}
 			/>
 
 			{/* <StyledSegmentedControl values={['Market', 'Limit']} selectedIndex={0} onChange={() => {}} /> */}
@@ -294,7 +294,7 @@ const Trade: React.FC = () => {
 			<PositionButtons
 				selected={leverageSide}
 				onSelect={setLeverageSide}
-				isMarketClosed={isMarketClosed}
+				isMarketClosed={isFuturesMarketClosed}
 			/>
 
 			<OrderSizing
@@ -316,7 +316,7 @@ const Trade: React.FC = () => {
 				currentPosition={futuresMarketsPosition}
 				assetRate={marketAssetRate}
 				currentTradeSize={tradeSize ? Number(tradeSize) : 0}
-				isMarketClosed={isMarketClosed}
+				isMarketClosed={isFuturesMarketClosed}
 			/>
 
 			<PlaceOrderButton
@@ -329,7 +329,7 @@ const Trade: React.FC = () => {
 					sizeDelta.eq(zeroBN) ||
 					!!error ||
 					placeOrderTranslationKey === 'futures.market.trade.button.deposit-margin-minimum' ||
-					isMarketClosed
+					isFuturesMarketClosed
 				}
 				onClick={() => {
 					setIsTradeConfirmationModalOpen(true);

--- a/sections/futures/TvChartWrapper/TVChartWrapper.tsx
+++ b/sections/futures/TvChartWrapper/TVChartWrapper.tsx
@@ -1,18 +1,18 @@
 import React, { FC } from 'react';
-import useMarketClosed from 'hooks/useMarketClosed';
 import { CurrencyKey, Synths } from 'constants/currency';
 import TVChart from 'components/TVChart';
 import MarketOverlay from '../MarketOverlay';
+import useFuturesMarketClosed from 'hooks/useFuturesMarketClosed';
 
 type TVChartWrapperProps = {
 	baseCurrencyKey: CurrencyKey;
 };
 
 export const TVChartWrapper: FC<TVChartWrapperProps> = ({ baseCurrencyKey }) => {
-	const { isMarketClosed, marketClosureReason } = useMarketClosed(baseCurrencyKey);
+	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(baseCurrencyKey);
 
-	return isMarketClosed ? (
-		<MarketOverlay marketClosureReason={marketClosureReason} baseCurrencyKey={baseCurrencyKey} />
+	return isFuturesMarketClosed ? (
+		<MarketOverlay marketClosureReason={futuresClosureReason} baseCurrencyKey={baseCurrencyKey} />
 	) : (
 		<TVChart baseCurrencyKey={baseCurrencyKey} quoteCurrencyKey={Synths.sUSD} />
 	);


### PR DESCRIPTION
issue with paused markets - the wrong query is being used from the synthetix contracts

## Description
implemented a new query that specifically fetches the market and closure reason then built that into a hook similar to the `useMarketIsClosed` hook.

The images below only show that the new hook works
## Related issue
https://github.com/Kwenta/kwenta/issues/712

## Motivation and Context
present the paused badges when markets are closed (XAU, XAG, EUR).

## How Has This Been Tested?
- [X] - local development forcing hook and query to closed
 

## Screenshots (if appropriate):

![Screen Shot 2022-04-25 at 1 21 18 PM](https://user-images.githubusercontent.com/5998100/165159224-4a54cdaf-f441-4e98-94d8-f2f0a9e0a18a.png)
![Screen Shot 2022-04-25 at 1 21 29 PM](https://user-images.githubusercontent.com/5998100/165159227-97748728-293a-4eaa-8287-542a83fa42af.png)