### PR TITLE
Leaderboard Search Improvements

### DIFF
--- a/components/Table/Search.tsx
+++ b/components/Table/Search.tsx
@@ -38,7 +38,7 @@ const StyledSearchInput = styled(SearchInput)`
 	height: 100%;
 	text-indent: 16px;
 	border-radius: 8px;
-	padding: 10px 10px;
+	padding: 10px 15px;
 `;
 
 const SearchBar = styled.div`

--- a/hooks/useENS.ts
+++ b/hooks/useENS.ts
@@ -22,6 +22,8 @@ const useENS = (address?: string): { ensName: string | null; ensAvatar: string |
 
 		return () => {
 			mounted = false;
+			setENSAvatar(null);
+			setENSName(null);
 		};
 	}, [address, staticMainnetProvider]);
 

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -47,6 +47,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 			const trader = router.query.tab[0];
 			setSelectedTrader(trader);
 		} else {
+			setSearchTerm('');
 			setSelectedTrader('');
 		}
 		return null;
@@ -127,7 +128,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 	return (
 		<>
 			<SearchContainer>
-				<Search value={searchTerm} onChange={onChangeSearch} disabled={selectedTrader !== ''} />
+				<Search value={searchTerm} onChange={onChangeSearch} disabled={false} />
 			</SearchContainer>
 			<TableContainer compact={compact}>
 				{selectedTrader !== '' ? (
@@ -136,6 +137,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact }: LeaderboardProps) => {
 						traderENSName={traderENSName}
 						resetSelection={() => setSelectedTrader('')}
 						compact={compact}
+						searchTerm={searchTerm}
 					/>
 				) : (
 					<StyledTable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. After selecting an individual trader, one is able to search the individual trader's position history by Market or Status.
2. Fix the ens name bug reported in #744
Additionally, I add more space between the magnifier icon and placeholder `Search...`, which is a little bit narrow now. 

## Related issue
#731 #744

## Motivation and Context
To improve the usability of the leaderboard search function.

## How Has This Been Tested?
1. Open leaderboard
3. Select a trader
4. Search the selected trader's position history by market or status

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/164997545-4b5aba5a-7092-4317-90b7-0c9c28c323d4.png)
![image](https://user-images.githubusercontent.com/4819006/164997554-8744d013-35ef-4381-8c98-76cf20a65a81.png)
![image](https://user-images.githubusercontent.com/4819006/164997567-c9c282c7-3ced-46fb-a2d7-726ba720bf66.png)
