### PR TITLE
Fix closed markets

### DIFF
--- a/components/Badge/MarketBadge.tsx
+++ b/components/Badge/MarketBadge.tsx
@@ -43,15 +43,19 @@ export const MarketBadge: FC<MarketBadgeProps> = ({
 	const timerSetting = isOpen === null ? null : isOpen ? nextTransition : nextOpen;
 	const isMarketTransitioning = useIsMarketTransitioning(timerSetting ?? null);
 
+	if (typeof isFuturesMarketClosed !== 'boolean') {
+		return null;
+	}
+
+	if (isFuturesMarketClosed) {
+		return <Badge>{t(`futures.market.state.${futuresClosureReason}`)}</Badge>;
+	}
+
 	if (isMarketTransitioning && isOpen !== null) {
 		return <TransitionBadge isOpen={isOpen} />;
 	}
 
-	if (!isFuturesMarketClosed) {
-		return null;
-	}
-
-	return <Badge>{t(`futures.market.state.${futuresClosureReason}`)}</Badge>;
+	return null;
 };
 
 export default MarketBadge;

--- a/hooks/useFuturesMarketClosed.ts
+++ b/hooks/useFuturesMarketClosed.ts
@@ -1,7 +1,6 @@
 import { SynthSuspensionReason } from '@synthetixio/queries';
 import { CurrencyKey } from 'constants/currency';
 import useFuturesSuspensionQuery from 'queries/futures/useFuturesSuspensionQuery';
-import { getReasonFromCode } from 'queries/futures/utils';
 
 export type FuturesClosureReason = SynthSuspensionReason;
 export type MarketClosure = ReturnType<typeof useFuturesMarketClosed>;
@@ -12,11 +11,11 @@ const useFuturesMarketClosed = (currencyKey: CurrencyKey | null) => {
 	const isFutureMarketSuspended =
 		futuresMarketSuspendedQuery.isSuccess && futuresMarketSuspendedQuery.data
 			? futuresMarketSuspendedQuery.data.isFuturesMarketClosed
-			: false;
+			: null;
 
 	const reason =
 		futuresMarketSuspendedQuery.isSuccess && futuresMarketSuspendedQuery.data
-			? getReasonFromCode(futuresMarketSuspendedQuery.data.futuresClosureReason)
+			? futuresMarketSuspendedQuery.data.futuresClosureReason
 			: null;
 
 	return {

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -1,5 +1,5 @@
 import Wei from '@synthetixio/wei';
-import { MarketClosureReason } from 'hooks/useMarketClosed';
+import { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 
 export type PositionDetail = {
 	remainingMargin: Wei;
@@ -71,7 +71,7 @@ export type FuturesMarket = {
 	price: Wei;
 	minInitialMargin: Wei;
 	isSuspended: boolean;
-	marketClosureReason: MarketClosureReason;
+	marketClosureReason: FuturesClosureReason;
 };
 
 export type FuturesOpenInterest = {

--- a/queries/futures/useFuturesSuspensionQuery.ts
+++ b/queries/futures/useFuturesSuspensionQuery.ts
@@ -37,14 +37,16 @@ const useFuturesSuspensionQuery = (
 				} = synthetixjs!;
 
 				const marketKey = getMarketKey(currencyKey, network.id);
-				const [isSuspended, reason] = (await SystemStatus.getFuturesMarketSuspensions([
-					utils.formatBytes32String(marketKey),
-				])) as [boolean, ethers.BigNumber];
+				const marketKeyBytes32 = utils.formatBytes32String(marketKey);
+				const [isSuspended, reasonCode] = await SystemStatus.futuresMarketSuspension(
+					marketKeyBytes32
+				);
 
+				const reason = (isSuspended ? getReasonFromCode(reasonCode) : null) as FuturesClosureReason;
 				return {
-					isSuspended,
-					reasonCode: reason,
-					reason: (isSuspended ? getReasonFromCode(reason) : null) as FuturesClosureReason,
+					isFuturesMarketClosed: isSuspended,
+					reasonCode,
+					futuresClosureReason: reason,
 				};
 			} catch (e) {
 				return null;

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -10,6 +10,7 @@ import QUERY_KEYS from 'constants/queryKeys';
 import { FuturesMarket } from './types';
 import { getMarketKey } from 'utils/futures';
 import { getReasonFromCode } from './utils';
+import { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 
 const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 	const isAppReady = useRecoilValue(appReadyState);
@@ -75,7 +76,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 					price: wei(price),
 					minInitialMargin: wei(globals.minInitialMargin),
 					isSuspended: suspensions[i],
-					marketClosureReason: getReasonFromCode(reasons[i]),
+					marketClosureReason: getReasonFromCode(reasons[i]) as FuturesClosureReason,
 				})
 			);
 		},

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -230,7 +230,7 @@ export const calculateFundingRate = (
 };
 
 export const getReasonFromCode = (reasonCode?: BigNumber): MarketClosureReason | null => {
-	switch (reasonCode?.toNumber()) {
+	switch (Number(reasonCode)) {
 		case 1:
 			return 'system-upgrade';
 		case 2:

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -57,7 +57,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
 	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(
 		currencyKey as CurrencyKey
 	);
-	console.log(isFuturesMarketClosed, currencyKey);
 	const futuresPositions = futuresPositionsQuery?.data ?? null;
 
 	const { synthsMap } = Connector.useContainer();

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -57,7 +57,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(
 		currencyKey as CurrencyKey
 	);
-
+	console.log(isFuturesMarketClosed, currencyKey);
 	const futuresPositions = futuresPositionsQuery?.data ?? null;
 
 	const { synthsMap } = Connector.useContainer();

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -111,8 +111,8 @@ const MarketsDropdown: React.FC<Props> = ({ asset }) => {
 						? true
 						: false
 					: false,
-				isFuturesMarketClosed,
-				futuresClosureReason
+				market.isSuspended,
+				market.marketClosureReason
 			);
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/sections/futures/TvChartWrapper/TVChartWrapper.tsx
+++ b/sections/futures/TvChartWrapper/TVChartWrapper.tsx
@@ -10,7 +10,7 @@ type TVChartWrapperProps = {
 
 export const TVChartWrapper: FC<TVChartWrapperProps> = ({ baseCurrencyKey }) => {
 	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(baseCurrencyKey);
-
+	console.log(isFuturesMarketClosed, futuresClosureReason);
 	return isFuturesMarketClosed ? (
 		<MarketOverlay marketClosureReason={futuresClosureReason} baseCurrencyKey={baseCurrencyKey} />
 	) : (

--- a/sections/futures/TvChartWrapper/TVChartWrapper.tsx
+++ b/sections/futures/TvChartWrapper/TVChartWrapper.tsx
@@ -10,7 +10,7 @@ type TVChartWrapperProps = {
 
 export const TVChartWrapper: FC<TVChartWrapperProps> = ({ baseCurrencyKey }) => {
 	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(baseCurrencyKey);
-	console.log(isFuturesMarketClosed, futuresClosureReason);
+
 	return isFuturesMarketClosed ? (
 		<MarketOverlay marketClosureReason={futuresClosureReason} baseCurrencyKey={baseCurrencyKey} />
 	) : (


### PR DESCRIPTION
fixing paused markets, the issue was that the destructuring of the query for closed futures markets was still not returning legit values, but was returning false due to the way the response was manipulated.

## Description
there were still some issues when we tested the paused markets, KALUB from Synthetix was able to keep the market closed by giving `reasonCode = 3` (circuit-breaker) instead of `reasonCode = 2` (market-closed) - market-closed will reset after 5 minutes so reasonCode 3 allows us to test these markets.

there is a load delay on the markets page because we use this query in so many places, not sure the fix there yet but this is worth merging and creating an issue to fix it if its annoying.

## Related issue
N/A

## Motivation and Context
fix displaying paused markets

## How Has This Been Tested?
locally on WTI closed market kovan-optimism
locally on optimism mainnet

## Screenshots (if appropriate):
<img width="1243" alt="Screen Shot 2022-04-29 at 11 31 47 AM" src="https://user-images.githubusercontent.com/5998100/165995510-5b178865-98ea-41e3-b0f7-1413775d3d55.png">
<img width="953" alt="Screen Shot 2022-04-29 at 11 31 55 AM" src="https://user-images.githubusercontent.com/5998100/165995524-ed308339-500f-4e68-9c2b-dbdf3e1540e1.png">
