### PR TITLE
Fix/2 decimal leftovers

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -73,7 +73,6 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 			: DEFAULT_DATA;
 	}, [futuresPositionQuery?.data, futuresMarkets, synthsMap, t, futuresPositionHistory]);
 
-	// work here (screenshot 2)
 	return (
 		<TableContainer>
 			<StyledTable

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -72,6 +72,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 			: DEFAULT_DATA;
 	}, [futuresPositionQuery?.data, futuresMarkets, synthsMap, t, futuresPositionHistory]);
 
+	// work here (screenshot 2)
 	return (
 		<TableContainer>
 			<StyledTable

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -14,7 +14,8 @@ import { formatNumber } from 'utils/formatters/number';
 import useGetFuturesPositionForMarkets from 'queries/futures/useGetFuturesPositionForMarkets';
 import { NO_VALUE } from 'constants/placeholder';
 import { DEFAULT_DATA } from './constants';
-import { getMarketKey, getSynthDescription } from 'utils/futures';
+import { DEFAULT_FIAT_EURO_DECIMALS } from 'constants/defaults';
+import { getMarketKey, getSynthDescription, isEurForex } from 'utils/futures';
 import MarketBadge from 'components/Badge/MarketBadge';
 
 type FuturesPositionTableProps = {
@@ -196,6 +197,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 						),
 						accessor: 'avgEntryPrice',
 						Cell: (cellProps: CellProps<any>) => {
+							const formatOptions = isEurForex(cellProps.row.original.asset)
+								? { minDecimals: DEFAULT_FIAT_EURO_DECIMALS }
+								: {};
 							return cellProps.row.original.avgEntryPrice === NO_VALUE ? (
 								<DefaultCell>{NO_VALUE}</DefaultCell>
 							) : (
@@ -204,6 +208,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 									price={cellProps.row.original.avgEntryPrice}
 									sign={'$'}
 									conversionRate={1}
+									formatOptions={formatOptions}
 								/>
 							);
 						},
@@ -217,6 +222,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 						),
 						accessor: 'liquidationPrice',
 						Cell: (cellProps: CellProps<any>) => {
+							const formatOptions = isEurForex(cellProps.row.original.asset)
+								? { minDecimals: DEFAULT_FIAT_EURO_DECIMALS }
+								: {};
 							return cellProps.row.original.liquidationPrice === NO_VALUE ? (
 								<DefaultCell>{NO_VALUE}</DefaultCell>
 							) : (
@@ -225,6 +233,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 									price={cellProps.row.original.liquidationPrice}
 									sign={'$'}
 									conversionRate={1}
+									formatOptions={formatOptions}
 								/>
 							);
 						},

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -71,7 +71,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
 			? DEFAULT_FIAT_EURO_DECIMALS
 			: undefined;
 
-
 	const positionHistory = futuresPositions?.find(
 		({ asset, isOpen }) => isOpen && asset === currencyKey
 	);
@@ -110,6 +109,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 			liquidationPrice: positionDetails
 				? formatCurrency(Synths.sUSD, positionDetails?.liquidationPrice ?? zeroBN, {
 						sign: '$',
+						minDecimals,
 				  })
 				: NO_VALUE,
 			pnl: pnl,
@@ -128,16 +128,16 @@ const PositionCard: React.FC<PositionCardProps> = ({
 			fees: positionDetails
 				? formatCurrency(Synths.sUSD, positionHistory?.feesPaid ?? zeroBN, {
 						sign: '$',
-						minDecimals
 				  })
 				: NO_VALUE,
 			avgEntryPrice: positionDetails
 				? formatCurrency(Synths.sUSD, positionHistory?.entryPrice ?? zeroBN, {
 						sign: '$',
+						minDecimals,
 				  })
 				: NO_VALUE,
 		};
-	}, [currencyKey, positionDetails, positionHistory, synthsMap, t]);
+	}, [currencyKey, minDecimals, positionDetails, positionHistory, synthsMap, t]);
 
 	return (
 		<>

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -74,7 +74,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 	const positionHistory = futuresPositions?.find(
 		({ asset, isOpen }) => isOpen && asset === currencyKey
 	);
-	// work here (first screenshot)
+
 	const data: PositionData = React.useMemo(() => {
 		const pnl = positionDetails?.profitLoss.add(positionDetails?.accruedFunding) ?? zeroBN;
 		const netFunding =


### PR DESCRIPTION
## Description
Changed Avg. Entry Price & Liquidation price decimals for EUR-PERP to show 4 decimals 
- on the Markets Position card (screenshot 1) 
- Futures Position table on the dashboard (screenshot 2)

## Related issue
Fix of introduced change #734 (avg. Entry Price and Liq. Price were missing)

## How Has This Been Tested?
by @platschi on optimism mainnet

## Screenshots:
![markets-position-card](https://user-images.githubusercontent.com/63062257/166469167-c775df31-8729-4cbd-ada4-c5a3cc48a6c2.png)
![future-position-dashboard](https://user-images.githubusercontent.com/63062257/166469188-fef63929-a77a-4a93-a97e-5c773dfd8943.png)


