### PR TITLE
Display futures position indicators on chart

### DIFF
--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -110,10 +110,10 @@ const DataFeedFactory = (isL2: boolean = false): IBasicDataFeed => {
 			}
 		},
 		subscribeBars: () => {
-			console.log('=====subscribeBars runnning');
+			// do nothing
 		},
 		unsubscribeBars: (subscriberUID) => {
-			console.log('=====unsubscribeBars running');
+			// do nothing
 		},
 		searchSymbols: (
 			userInput: string,

--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -1,18 +1,26 @@
-import * as React from 'react';
+import { useRef, useContext, useEffect } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { ChartBody } from 'sections/exchange/TradeCard/Charts/common/styles';
 
 import {
 	IChartingLibraryWidget,
+	IPositionLineAdapter,
 	widget,
 } from '../../public/static/charting_library/charting_library';
 import DataFeedFactory from './DataFeed';
 import { useRecoilValue } from 'recoil';
 import { isL2State } from 'store/wallet';
+import { formatNumber } from 'utils/formatters/number';
+import { ChartPosition } from './types';
 
-type Props = {
+export type ChartProps = {
 	baseCurrencyKey: string;
 	quoteCurrencyKey: string;
+	activePosition?: ChartPosition | null;
+	potentialTrade?: ChartPosition | null;
+};
+
+type Props = ChartProps & {
 	interval: string;
 	containerId: string;
 	libraryPath: string;
@@ -32,12 +40,17 @@ export function TVChart({
 	autosize = true,
 	studiesOverrides = {},
 	overrides,
+	activePosition,
+	potentialTrade,
 }: Props) {
-	const _widget = React.useRef<IChartingLibraryWidget | null>(null);
-	const { colors } = React.useContext(ThemeContext);
+	const _widget = useRef<IChartingLibraryWidget | null>(null);
+	const _entryLine = useRef<IPositionLineAdapter | null | undefined>(null);
+	const _liquidationLine = useRef<IPositionLineAdapter | null | undefined>(null);
+
+	const { colors } = useContext(ThemeContext);
 	let isL2 = useRecoilValue(isL2State);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		const widgetOptions = {
 			symbol: baseCurrencyKey + ':' + quoteCurrencyKey,
 			datafeed: DataFeedFactory(isL2),
@@ -96,6 +109,54 @@ export function TVChart({
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [baseCurrencyKey, quoteCurrencyKey]);
+
+	useEffect(() => {
+		_widget.current?.onChartReady(() => {
+			_widget.current?.chart().dataReady(() => {
+				_entryLine.current?.remove?.();
+				_liquidationLine.current?.remove?.();
+				_entryLine.current = null;
+				_liquidationLine.current = null;
+
+				const setPositionLines = (position: ChartPosition, active: boolean) => {
+					_entryLine.current = _widget.current
+						?.chart()
+						.createPositionLine()
+						.setText('ENTRY: ' + formatNumber(position.price))
+						.setTooltip('Average entry price')
+						.setQuantity(formatNumber(position.size.abs()))
+						.setPrice(position.price.toNumber())
+						.setExtendLeft(false)
+						.setLineStyle(active ? 0 : 2)
+						.setLineLength(25);
+
+					if (position.liqPrice) {
+						_liquidationLine.current = _widget.current
+							?.chart()
+							.createPositionLine()
+							.setText('LIQUIDATION: ' + formatNumber(position.liqPrice))
+							.setTooltip('Liquidation price')
+							.setQuantity(formatNumber(position.size.abs()))
+							.setPrice(position.liqPrice.toNumber())
+							.setExtendLeft(false)
+							.setLineStyle(active ? 0 : 2)
+							.setLineColor(colors.common.primaryRed)
+							.setBodyBorderColor(colors.common.primaryRed)
+							.setQuantityBackgroundColor(colors.common.primaryRed)
+							.setQuantityBorderColor(colors.common.primaryRed)
+							.setLineLength(25);
+					}
+				};
+
+				// Always show potential over existing
+				if (potentialTrade) {
+					setPositionLines(potentialTrade, false);
+				} else if (activePosition) {
+					setPositionLines(activePosition, true);
+				}
+			});
+		});
+	}, [activePosition, potentialTrade, colors.common.primaryRed]);
 
 	return (
 		<Container>

--- a/components/TVChart/index.tsx
+++ b/components/TVChart/index.tsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { ChartProps } from './TVChart';
 
 // @ts-ignore
-const TVChartContainer = dynamic(() => import('./TVChart').then((mod) => mod.TVChart), {
+const TVChartContainer = dynamic<TVChart>(() => import('./TVChart').then((mod) => mod.TVChart), {
 	ssr: false,
 });
 
-export default (props: any) => <TVChartContainer {...props} />;
+export default (props: ChartProps) => <TVChartContainer {...props} />;

--- a/components/TVChart/types.ts
+++ b/components/TVChart/types.ts
@@ -1,0 +1,7 @@
+import Wei from '@synthetixio/wei';
+
+export type ChartPosition = {
+	size: Wei;
+	price: Wei;
+	liqPrice: Wei | undefined;
+};

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -1,4 +1,5 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
+import { PotentialTrade } from 'sections/futures/types';
 import { CurrencyKey } from './currency';
 import { Period } from './period';
 
@@ -201,6 +202,12 @@ export const QUERY_KEYS = {
 		TotalLiquidations: ['futures', 'totalLiquidations'],
 		TotalTrades: (networkId: NetworkId) => ['futures', 'totalTrades', networkId],
 		TotalVolume: ['futures', 'totalVolume'],
+		PotentialTrade: (
+			networkId: NetworkId,
+			market: string | null,
+			trade: PotentialTrade | null,
+			walletAddress: string
+		) => ['futures', 'potentialTrade', trade, networkId, market, walletAddress],
 		MarketLimit: (networkId: NetworkId, market: string | null) => [
 			'futures',
 			'marketLimit',

--- a/pages/market/[[...market]].tsx
+++ b/pages/market/[[...market]].tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -16,11 +17,14 @@ import { useTranslation } from 'react-i18next';
 
 import MarketInfo from 'sections/futures/MarketInfo';
 import Trade from 'sections/futures/Trade';
+import { PotentialTrade } from 'sections/futures/types';
 import TradingHistory from 'sections/futures/TradingHistory';
 
 const Market = () => {
 	const { t } = useTranslation();
 	const router = useRouter();
+
+	const [potentialTrade, setPotentialTrade] = useState<PotentialTrade | null>(null);
 
 	return (
 		<>
@@ -36,11 +40,11 @@ const Market = () => {
 							</StyledLeftSideContent>
 						</DesktopOnlyView>
 						<StyledMainContent>
-							<MarketInfo market={router.query.market?.[0]!} />
+							<MarketInfo market={router.query.market?.[0]!} potentialTrade={potentialTrade} />
 						</StyledMainContent>
 						<DesktopOnlyView>
 							<StyledRightSideContent>
-								<Trade />
+								<Trade onEditPositionInput={setPotentialTrade} />
 							</StyledRightSideContent>
 						</DesktopOnlyView>
 					</StyledFullHeightContainer>

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -1,3 +1,5 @@
+import { gql } from 'graphql-request';
+
 export const FUTURES_ENDPOINT_MAINNET =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
 
@@ -7,3 +9,28 @@ export const FUTURES_ENDPOINT_TESTNET =
 export const DAY_PERIOD = 24;
 
 export const SECONDS_PER_DAY = 24 * 60 * 60;
+
+export const FUTURES_POSITION_FRAGMENT = gql`
+	fragment FuturesPositionFragment on FuturesPosition {
+		id
+		openTimestamp
+		closeTimestamp
+		lastTxHash
+		timestamp
+		account
+		market
+		asset
+		margin
+		size
+		feesPaid
+		netFunding
+		isOpen
+		isLiquidated
+		entryPrice
+		exitPrice
+		avgEntryPrice
+		totalVolume
+		pnl
+		trades
+	}
+`;

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -98,6 +98,7 @@ export type RawPosition = {
 	netFunding: Wei;
 	margin: Wei;
 	entryPrice: Wei;
+	avgEntryPrice: Wei;
 	exitPrice: Wei;
 	pnl: Wei;
 	pnlWithFeesPaid: Wei;
@@ -131,6 +132,7 @@ export type PositionHistory = {
 	netFunding: Wei;
 	margin: Wei;
 	entryPrice: Wei;
+	avgEntryPrice: Wei;
 	exitPrice: Wei;
 	leverage: Wei;
 	side: PositionSide;
@@ -202,4 +204,12 @@ export type FuturesCumulativeStats = {
 export type FundingRateUpdate = {
 	funding: Wei;
 	timestamp: number;
+};
+
+export type FuturesPotentialTradeDetails = {
+	size: Wei;
+	liqPrice: Wei;
+	margin: Wei;
+	price: Wei;
+	fee: Wei;
 };

--- a/queries/futures/useGetFuturesAccountPositionHistory.ts
+++ b/queries/futures/useGetFuturesAccountPositionHistory.ts
@@ -9,6 +9,7 @@ import QUERY_KEYS from 'constants/queryKeys';
 import { PositionHistory } from './types';
 
 import { mapTradeHistory, getFuturesEndpoint } from './utils';
+import { FUTURES_POSITION_FRAGMENT } from './constants';
 
 const useGetFuturesAccountPositionHistory = (
 	account: string,
@@ -26,31 +27,14 @@ const useGetFuturesAccountPositionHistory = (
 				const response = await request(
 					futuresEndpoint,
 					gql`
+						${FUTURES_POSITION_FRAGMENT}
 						query allPositionHistory($account: String!) {
 							futuresPositions(
 								where: { account: $account }
 								orderBy: timestamp
 								orderDirection: desc
 							) {
-								id
-								account
-								market
-								lastTxHash
-								openTimestamp
-								closeTimestamp
-								totalVolume
-								trades
-								timestamp
-								isOpen
-								isLiquidated
-								entryPrice
-								exitPrice
-								size
-								margin
-								asset
-								pnl
-								feesPaid
-								netFunding
+								...FuturesPositionFragment
 							}
 						}
 					`,

--- a/queries/futures/useGetFuturesMarketPositionHistory.ts
+++ b/queries/futures/useGetFuturesMarketPositionHistory.ts
@@ -10,6 +10,7 @@ import QUERY_KEYS from 'constants/queryKeys';
 import { PositionHistory } from './types';
 import { getFuturesEndpoint, mapTradeHistory } from './utils';
 import { getDisplayAsset } from 'utils/futures';
+import { FUTURES_POSITION_FRAGMENT } from './constants';
 
 const useGetFuturesMarketPositionHistory = (
 	currencyKey: string | null,
@@ -33,31 +34,14 @@ const useGetFuturesMarketPositionHistory = (
 				const response = await request(
 					futuresEndpoint,
 					gql`
+						${FUTURES_POSITION_FRAGMENT}
 						query marketPositionHistory($market: String!, $account: String!) {
 							futuresPositions(
 								where: { market: $market, account: $account }
 								orderBy: timestamp
 								orderDirection: desc
 							) {
-								id
-								lastTxHash
-								timestamp
-								account
-								market
-								asset
-								margin
-								size
-								feesPaid
-								netFunding
-								isOpen
-								isLiquidated
-								entryPrice
-								exitPrice
-								pnl
-								closeTimestamp
-								openTimestamp
-								totalVolume
-								trades
+								...FuturesPositionFragment
 							}
 						}
 					`,

--- a/queries/futures/useGetFuturesPositionForAccount.ts
+++ b/queries/futures/useGetFuturesPositionForAccount.ts
@@ -6,6 +6,7 @@ import QUERY_KEYS from 'constants/queryKeys';
 import request, { gql } from 'graphql-request';
 import { PositionHistory } from './types';
 import { getFuturesEndpoint, mapTradeHistory } from './utils';
+import { FUTURES_POSITION_FRAGMENT } from './constants';
 
 const useGetFuturesPositionForAccount = (options?: UseQueryOptions<any>) => {
 	const walletAddress = useRecoilValue(walletAddressState);
@@ -21,27 +22,10 @@ const useGetFuturesPositionForAccount = (options?: UseQueryOptions<any>) => {
 				const response = await request(
 					futuresEndpoint,
 					gql`
+						${FUTURES_POSITION_FRAGMENT}
 						query userAllPositions($account: String!) {
 							futuresPositions(where: { account: $account }) {
-								id
-								lastTxHash
-								timestamp
-								account
-								market
-								asset
-								margin
-								size
-								feesPaid
-								netFunding
-								isOpen
-								isLiquidated
-								entryPrice
-								exitPrice
-								pnl
-								closeTimestamp
-								openTimestamp
-								totalVolume
-								trades
+								...FuturesPositionFragment
 							}
 						}
 					`,

--- a/queries/futures/useGetFuturesPotentialTradeDetails.ts
+++ b/queries/futures/useGetFuturesPotentialTradeDetails.ts
@@ -1,0 +1,53 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import { useRecoilValue } from 'recoil';
+
+import { appReadyState } from 'store/app';
+import { isL2State, networkState, walletAddressState } from 'store/wallet';
+import Connector from 'containers/Connector';
+
+import QUERY_KEYS from 'constants/queryKeys';
+import { getFuturesMarketContract } from './utils';
+import { FuturesPotentialTradeDetails } from './types';
+import { PotentialTrade } from 'sections/futures/types';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
+import { wei } from '@synthetixio/wei';
+
+const useGetFuturesPotentialTradeDetails = (
+	marketAsset: CurrencyKey | null,
+	trade: PotentialTrade | null,
+	options?: UseQueryOptions<FuturesPotentialTradeDetails | null>
+) => {
+	const isAppReady = useRecoilValue(appReadyState);
+	const isL2 = useRecoilValue(isL2State);
+	const network = useRecoilValue(networkState);
+	const walletAddress = useRecoilValue(walletAddressState);
+	const { synthetixjs } = Connector.useContainer();
+
+	return useQuery<FuturesPotentialTradeDetails | null>(
+		QUERY_KEYS.Futures.PotentialTrade(network.id, marketAsset || null, trade, walletAddress || ''),
+		async () => {
+			if (!marketAsset || !trade || !trade.size?.length) return null;
+
+			const FuturesMarketContract = getFuturesMarketContract(marketAsset, synthetixjs!.contracts);
+			const newSize = trade.side === 'long' ? +trade.size : -trade.size;
+			const { fee, liqPrice, margin, price, size } = await FuturesMarketContract.postTradeDetails(
+				wei(newSize).toBN(),
+				walletAddress
+			);
+
+			return {
+				fee: wei(fee),
+				liqPrice: wei(liqPrice),
+				margin: wei(margin),
+				price: wei(price),
+				size: wei(size),
+			};
+		},
+		{
+			enabled: isAppReady && isL2 && !!walletAddress && !!marketAsset && !!synthetixjs,
+			...options,
+		}
+	);
+};
+
+export default useGetFuturesPotentialTradeDetails;

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -300,6 +300,7 @@ export const mapTradeHistory = (
 					closeTimestamp,
 					totalVolume,
 					trades,
+					avgEntryPrice,
 				}: RawPosition) => {
 					const entryPriceWei = new Wei(entryPrice, 18, true);
 					const exitPriceWei = new Wei(exitPrice || 0, 18, true);
@@ -309,7 +310,7 @@ export const mapTradeHistory = (
 					const marginWei = new Wei(margin, 18, true);
 					const pnlWei = new Wei(pnl, 18, true);
 					const totalVolumeWei = new Wei(totalVolume, 18, true);
-
+					const avgEntryPriceWei = new Wei(avgEntryPrice, 18, true);
 					return {
 						id: Number(id.split('-')[1].toString()),
 						transactionHash: lastTxHash,
@@ -330,6 +331,7 @@ export const mapTradeHistory = (
 						pnl: pnlWei,
 						totalVolume: totalVolumeWei,
 						trades: trades,
+						avgEntryPrice: avgEntryPriceWei,
 						leverage: marginWei.eq(wei(0))
 							? wei(0)
 							: sizeWei.mul(entryPriceWei).div(marginWei).abs(),

--- a/sections/exchange/TradeCard/Charts/CombinedPriceChartCard.tsx
+++ b/sections/exchange/TradeCard/Charts/CombinedPriceChartCard.tsx
@@ -51,7 +51,9 @@ const CombinedPriceChartCard: FC<CombinedPriceChartCardProps> = ({
 				{baseCurrencyKey ? (
 					<ChartData disabledInteraction={disabledInteraction}>
 						<Container {...rest}>
-							<TVChart baseCurrencyKey={baseCurrencyKey} quoteCurrencyKey={quoteCurrencyKey} />
+							{quoteCurrencyKey && (
+								<TVChart baseCurrencyKey={baseCurrencyKey} quoteCurrencyKey={quoteCurrencyKey} />
+							)}
 						</Container>
 					</ChartData>
 				) : (

--- a/sections/exchange/TradeCard/Charts/Types/CandlesticksChart.tsx
+++ b/sections/exchange/TradeCard/Charts/Types/CandlesticksChart.tsx
@@ -29,7 +29,6 @@ const CandlesticksChart: FC<CandlesticksChartProps> = ({
 	selectedPriceCurrency,
 	tooltipPriceFormatter,
 }) => {
-	console.log('***Candlesticks');
 	const [focusCandleIndex, setFocusCandleIndex] = useState<null | number>(null);
 
 	const theme = useContext(ThemeContext);

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -11,13 +11,15 @@ import { formatCurrency } from 'utils/formatters/number';
 import UserInfo from '../UserInfo';
 import { CurrencyKey } from 'constants/currency';
 import MarketDetails from '../MarketDetails';
-import TVChartWrapper from '../TvChartWrapper';
+import PositionChart from '../PositionChart';
+import { PotentialTrade } from '../types';
 
 type MarketInfoProps = {
 	market: string;
+	potentialTrade: PotentialTrade | null;
 };
 
-const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
+const MarketInfo: FC<MarketInfoProps> = ({ market, potentialTrade }) => {
 	const { t } = useTranslation();
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery();
@@ -46,7 +48,7 @@ const MarketInfo: FC<MarketInfoProps> = ({ market }) => {
 				</title>
 			</Head>
 			<MarketDetails baseCurrencyKey={baseCurrencyKey} />
-			<TVChartWrapper baseCurrencyKey={baseCurrencyKey} />
+			<PositionChart marketAsset={baseCurrencyKey} potentialTrade={potentialTrade} />
 			<UserInfo marketAsset={baseCurrencyKey} />
 		</Container>
 	);

--- a/sections/futures/PositionChart/PositionChart.tsx
+++ b/sections/futures/PositionChart/PositionChart.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { CurrencyKey } from '@synthetixio/contracts-interface';
+
+import Connector from 'containers/Connector';
+import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
+import useGetFuturesPositionForMarket from 'queries/futures/useGetFuturesPositionForMarket';
+import useGetFuturesPotentialTradeDetails from 'queries/futures/useGetFuturesPotentialTradeDetails';
+import { getMarketKey } from 'utils/futures';
+import TvChartWrapper from '../TvChartWrapper';
+import { PotentialTrade } from '../types';
+
+type Props = {
+	marketAsset: CurrencyKey;
+	potentialTrade: PotentialTrade | null;
+};
+
+export default function PositionChart({ marketAsset, potentialTrade }: Props) {
+	const { network } = Connector.useContainer();
+
+	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(
+		getMarketKey(marketAsset, network.id)
+	);
+	const potentialTradeDetails = useGetFuturesPotentialTradeDetails(marketAsset, potentialTrade);
+
+	const futuresPositionsQuery = useGetFuturesPositionForAccount({ refetchInterval: 5000 });
+	const positionHistory = futuresPositionsQuery?.data ?? [];
+	const subgraphPosition = positionHistory.find((p) => p.isOpen && p.asset === marketAsset);
+	const futuresMarketsPosition = futuresMarketPositionQuery?.data ?? null;
+
+	const modifiedAverage = useMemo(() => {
+		if (subgraphPosition && potentialTradeDetails.data && potentialTrade) {
+			const totalSize = subgraphPosition.size.add(potentialTrade.size);
+
+			const existingValue = subgraphPosition.avgEntryPrice.mul(subgraphPosition.size);
+			const newValue = potentialTradeDetails.data.price.mul(potentialTrade.size);
+			const totalValue = existingValue.add(newValue);
+			return totalValue.div(totalSize);
+		}
+		return null;
+	}, [subgraphPosition, potentialTradeDetails.data, potentialTrade]);
+
+	const activePosition = useMemo(() => {
+		if (!futuresMarketsPosition?.position) {
+			return null;
+		}
+
+		return {
+			// As there's often a delay in subgraph sync we use the contract last
+			// price until we get average price to keep it snappy on opening a position
+			price: subgraphPosition?.avgEntryPrice || futuresMarketsPosition.position.lastPrice,
+			size: futuresMarketsPosition.position.size,
+			liqPrice: futuresMarketsPosition.position?.liquidationPrice,
+		};
+	}, [subgraphPosition, futuresMarketsPosition]);
+
+	return (
+		<TvChartWrapper
+			baseCurrencyKey={marketAsset}
+			activePosition={activePosition}
+			potentialTrade={
+				potentialTradeDetails?.data
+					? {
+							price: modifiedAverage || potentialTradeDetails.data.price,
+							liqPrice: potentialTradeDetails.data.liqPrice,
+							size: potentialTradeDetails.data.size,
+					  }
+					: null
+			}
+		/>
+	);
+}

--- a/sections/futures/PositionChart/index.tsx
+++ b/sections/futures/PositionChart/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './PositionChart';

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -40,7 +40,11 @@ import { ethers } from 'ethers';
 
 const DEFAULT_MAX_LEVERAGE = wei(10);
 
-const Trade: React.FC = () => {
+type Props = {
+	onEditPositionInput: (position: { size: string; side: PositionSide }) => void;
+};
+
+const Trade: React.FC<Props> = ({ onEditPositionInput }) => {
 	const { t } = useTranslation();
 	const walletAddress = useRecoilValue(walletAddressState);
 	const { useSynthsBalancesQuery, useEthGasPriceQuery, useSynthetixTxn } = useSynthetixQueries();
@@ -122,10 +126,10 @@ const Trade: React.FC = () => {
 
 	const onTradeAmountChange = React.useCallback(
 		(value: string, fromLeverage: boolean = false) => {
-			setTradeSize(fromLeverage ? (value === '' ? '' : wei(value).toNumber().toString()) : value);
-			setTradeSizeSUSD(
-				value === '' ? '' : marketAssetRate.mul(Number(value)).toNumber().toString()
-			);
+			const size = fromLeverage ? (value === '' ? '' : wei(value).toNumber().toString()) : value;
+			const sizeSUSD = value === '' ? '' : marketAssetRate.mul(Number(value)).toNumber().toString();
+			setTradeSize(size);
+			setTradeSizeSUSD(sizeSUSD);
 		},
 		[marketAssetRate]
 	);
@@ -266,6 +270,10 @@ const Trade: React.FC = () => {
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [orderTxn.hash]);
+
+	useEffect(() => {
+		onEditPositionInput({ size: tradeSize, side: leverageSide });
+	}, [leverageSide, tradeSize, onEditPositionInput]);
 
 	return (
 		<Panel>

--- a/sections/futures/TvChartWrapper/TVChartWrapper.tsx
+++ b/sections/futures/TvChartWrapper/TVChartWrapper.tsx
@@ -2,19 +2,31 @@ import React, { FC } from 'react';
 import { CurrencyKey, Synths } from 'constants/currency';
 import TVChart from 'components/TVChart';
 import MarketOverlay from '../MarketOverlay';
+import { ChartPosition } from 'components/TVChart/types';
 import useFuturesMarketClosed from 'hooks/useFuturesMarketClosed';
 
 type TVChartWrapperProps = {
 	baseCurrencyKey: CurrencyKey;
+	activePosition?: ChartPosition | null;
+	potentialTrade: ChartPosition | null;
 };
 
-export const TVChartWrapper: FC<TVChartWrapperProps> = ({ baseCurrencyKey }) => {
+export const TVChartWrapper: FC<TVChartWrapperProps> = ({
+	baseCurrencyKey,
+	activePosition,
+	potentialTrade,
+}) => {
 	const { isFuturesMarketClosed, futuresClosureReason } = useFuturesMarketClosed(baseCurrencyKey);
 
 	return isFuturesMarketClosed ? (
 		<MarketOverlay marketClosureReason={futuresClosureReason} baseCurrencyKey={baseCurrencyKey} />
 	) : (
-		<TVChart baseCurrencyKey={baseCurrencyKey} quoteCurrencyKey={Synths.sUSD} />
+		<TVChart
+			baseCurrencyKey={baseCurrencyKey}
+			quoteCurrencyKey={Synths.sUSD}
+			activePosition={activePosition}
+			potentialTrade={potentialTrade}
+		/>
 	);
 };
 

--- a/sections/futures/types.ts
+++ b/sections/futures/types.ts
@@ -69,3 +69,8 @@ export type Trade = {
 	status: TradeStatus;
 	txHash: string;
 };
+
+export type PotentialTrade = {
+	size: string;
+	side: PositionSide;
+};


### PR DESCRIPTION
## Description
- When no position open it will display potential position of entry and liquidation with dashed line as the user adjusts the amount
- When a user has a position open it will display the entry and liquidation points for that position
- Modifying a position when there is already a position open will update the indicators to show new liquidation and the potential average entry

## Related issue
https://github.com/Kwenta/kwenta/issues/693

