### PR TITLE
[WIP] build: upgraded webpack from v4 to v5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"immer": "9.0.6",
 		"lodash": "4.17.20",
 		"moment-business-time": "1.1.1",
-		"next": "10.0.0",
+		"next": "^10.2.3",
 		"next-compose-plugins": "2.2.0",
 		"react": "17.0.1",
 		"react-countdown": "2.3.1",
@@ -132,11 +132,7 @@
 		"react-test-renderer": "17.0.1",
 		"typescript": "4.2.4",
 		"url-loader": "4.1.0",
-		"webp-loader": "0.6.0",
-		"webpack": "^5.70.0"
-	},
-	"resolutions": {
-		"webpack": "^5.0.0-beta.30"
+		"webp-loader": "0.6.0"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Upgraded Next js from `v10.0.0` to` v10.2.3`.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Kwenta/kwenta/issues/741

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The 1st issue that occurred is [optimized-images-loader](https://github.com/cyrilwanner/optimized-images-loader#readme) when running `npm run dev` command:
```
Error: Input buffer has corrupt header: svgload_buffer: bad dimensions
```

## Screenshots (if appropriate):
<img width="778" alt="webpack v5" src="https://user-images.githubusercontent.com/31362988/166930115-a23eb85b-2b07-4e69-bbef-b2f8f4ad4c58.png">
