### PR TITLE
Fix unknown closure reason

### DIFF
--- a/components/Badge/MarketBadge.tsx
+++ b/components/Badge/MarketBadge.tsx
@@ -48,7 +48,8 @@ export const MarketBadge: FC<MarketBadgeProps> = ({
 	}
 
 	if (isFuturesMarketClosed) {
-		return <Badge>{t(`futures.market.state.${futuresClosureReason}`)}</Badge>;
+		const reason = futuresClosureReason || 'unknown';
+		return <Badge>{t(`futures.market.state.${reason}`)}</Badge>;
 	}
 
 	if (isMarketTransitioning && isOpen !== null) {

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -245,7 +245,6 @@ export const getReasonFromCode = (
 		case 99999:
 			return 'emergency';
 		default:
-			console.log(Number(reasonCode));
 			return 'unknown';
 	}
 };

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -240,6 +240,7 @@ export const getReasonFromCode = (
 		case 3:
 		case 55:
 		case 65:
+		case 231:
 			return 'circuit-breaker';
 		case 99999:
 			return 'emergency';

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -229,7 +229,9 @@ export const calculateFundingRate = (
 	return fundingRate;
 };
 
-export const getReasonFromCode = (reasonCode?: BigNumber): MarketClosureReason | null => {
+export const getReasonFromCode = (
+	reasonCode?: BigNumber
+): MarketClosureReason | 'unknown' | null => {
 	switch (Number(reasonCode)) {
 		case 1:
 			return 'system-upgrade';
@@ -242,7 +244,8 @@ export const getReasonFromCode = (reasonCode?: BigNumber): MarketClosureReason |
 		case 99999:
 			return 'emergency';
 		default:
-			return null;
+			console.log(Number(reasonCode));
+			return 'unknown';
 	}
 };
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -644,13 +644,14 @@
 				"avg-entry-price": "Avg. Entry Price"
 			},
 			"state": {
-				"opens-soon": "Opens soon",
-				"closes-soon": "Closes soon",
+				"opens-soon": "opens soon",
+				"closes-soon": "closes soon",
 				"frozen": "paused",
 				"market-closure": "paused",
 				"system-upgrade": "paused",
 				"circuit-breaker": "paused",
-				"emergency": "paused"
+				"emergency": "paused",
+        "unknown": "paused"
 			},
 			"chart": {
 				"overlay-messages": {
@@ -673,7 +674,11 @@
 					"emergency": {
 						"title": "Emergency shutdown activated for {{baseCurrencyKey}}",
 						"subtitle": "Reset in progress"
-					}
+					},
+          "unknown": {
+            "title": "Markets are temporarily paused",
+						"subtitle": ""
+          }
 				}
 			},
 			"trade": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -668,8 +668,8 @@
 						"subtitle": "Please check the Synthetix Discord for details."
 					},
 					"circuit-breaker": {
-						"title": "Circuit breaker triggered for {{baseCurrencyKey}}",
-						"subtitle": "Market is temporarily paused"
+						"title": "{{baseCurrencyKey}} market has been temporarily paused",
+						"subtitle": "Circuit breaker triggered"
 					},
 					"emergency": {
 						"title": "Emergency shutdown activated for {{baseCurrencyKey}}",

--- a/translations/en.json
+++ b/translations/en.json
@@ -651,7 +651,7 @@
 				"system-upgrade": "paused",
 				"circuit-breaker": "paused",
 				"emergency": "paused",
-        "unknown": "paused"
+				"unknown": "paused"
 			},
 			"chart": {
 				"overlay-messages": {
@@ -675,10 +675,10 @@
 						"title": "Emergency shutdown activated for {{baseCurrencyKey}}",
 						"subtitle": "Reset in progress"
 					},
-          "unknown": {
-            "title": "Markets are temporarily paused",
+					"unknown": {
+						"title": "Markets are temporarily paused",
 						"subtitle": ""
-          }
+					}
 				}
 			},
 			"trade": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -669,7 +669,7 @@
 					},
 					"circuit-breaker": {
 						"title": "Circuit breaker triggered for {{baseCurrencyKey}}",
-						"subtitle": "Reset in progress"
+						"subtitle": "Market is temporarily paused"
 					},
 					"emergency": {
 						"title": "Emergency shutdown activated for {{baseCurrencyKey}}",


### PR DESCRIPTION
fixing unknown state of market closure - returning `unknown` string for en.json reference vs null.

## Description
last week a market was temporarily paused for a reason unknown to us. we should have a default statement on a closed market if we do not know the reason why it was closed.

this was probably reasonCode 231 (see latency breaker actions in dune dashboard)
https://dune.com/joeyb/Synth-closures

here are the current [reason codes](https://github.com/Synthetixio/synthetix/blob/2a3640429acc07b6f485cde319fe742c921ee11e/index.js#L603-L617)

this issue is a result of [231 being 5 days ago](https://github.com/Synthetixio/synthetix/pull/1765) and the fact that we did not have a default status for unknown reason codes - resolved by adding both 231 in circuit breaker codes and adding `unknown` as the base default for reasons.

## Related issue
https://github.com/Synthetixio/synthetix/blob/e6b6aa3340ffc2536c814290e360190cc53f7a92/contracts/interfaces/ISystemStatus.sol#L13

closes #797 

## Motivation and Context
fix display of market pauses

## How Has This Been Tested?
locally

in order to reproduce on the test deploy, we need to get synthetix to update a market on kovan with reasonCode 231

## Screenshots (if appropriate):
![Screen Shot 2022-05-08 at 8 51 50 PM](https://user-images.githubusercontent.com/5998100/167332509-a887219f-3e55-44fe-8d48-3caedb3ee49f.png)
![Screen Shot 2022-05-08 at 8 51 38 PM](https://user-images.githubusercontent.com/5998100/167332519-39067140-46ec-4305-935f-bf60e5c4507b.png)


## from kovan test code 231
![Screen Shot 2022-05-09 at 9 17 14 AM](https://user-images.githubusercontent.com/5998100/167442084-f1b67174-b4c3-4a41-9f6a-a9b8f71b7717.png)
![Screen Shot 2022-05-09 at 9 17 21 AM](https://user-images.githubusercontent.com/5998100/167442090-34ea12bf-1875-42c6-90b1-d9a83d1bce3d.png)
