### PR TITLE
fixing susd balance

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/BalanceActions.tsx
+++ b/sections/shared/Layout/AppLayout/Header/BalanceActions.tsx
@@ -147,7 +147,7 @@ const BalanceActions: FC<FuturesPositionTableProps> = ({
 
 	return (
 		<Container>
-			{sUSDBalance === zeroBN ? (
+			{sUSDBalance.eq(zeroBN) && accessiblePositions.length === 0 ? (
 				<StyledWidgetButton textTransform="none" onClick={() => setShowUniswapWidget(true)}>
 					<StyledCurrencyIcon currencyKey={Synths.sUSD} width="24px" height="24px" />
 					{t('header.balance.get-susd')}


### PR DESCRIPTION
bug with susd dropdown - when user has $0 sUSD but has positions open, it does not show the positions

## Description
listed above

## Related issue
closes #770 

## Motivation and Context
fix it

## How Has This Been Tested?
locally

## Screenshots (if appropriate):
![Screen Shot 2022-05-09 at 3 47 12 PM](https://user-images.githubusercontent.com/5998100/167504174-d9887efe-b53d-4c19-8a11-713dd365b61c.png)
