### PR TITLE
Add Kwenta tracking code to Close Position

### DIFF
--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -21,6 +21,7 @@ import { newGetTransactionPrice } from 'utils/network';
 import { gasSpeedState } from 'store/wallet';
 import { FuturesFilledPosition } from 'queries/futures/types';
 import { CurrencyKey } from '@synthetixio/contracts-interface';
+import { KWENTA_TRACKING_CODE } from 'queries/futures/constants';
 
 type ClosePositionModalProps = {
 	onDismiss: () => void;
@@ -65,8 +66,8 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 
 	const closeTxn = useSynthetixTxn(
 		`FuturesMarket${currencyKey[0] === 's' ? currencyKey.substring(1) : currencyKey}`,
-		'closePosition',
-		[],
+		'closePositionWithTracking',
+		[KWENTA_TRACKING_CODE],
 		gasPrice ?? undefined,
 		{ enabled: !!currencyKey }
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a tracking code to `closePosition`
Note: The change was made on `ClosePositionModal` so it won't affect the `PositionCard` in #805. 

## Related issue
closes #808 

## Motivation and Context

## How Has This Been Tested?
1.Close a Position
2.Check the trx on explorer and verify the tracking code as "KWENTA"

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/167498552-86d7c5c6-1468-4510-830a-d46dae45c920.png)
