### PR TITLE
Chore: Update node to v16 and npm to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
 		"testEnvironment": "jest-environment-jsdom"
 	},
 	"engines": {
-		"node": ">=14",
-		"npm": ">=7"
+		"node": ">=16",
+		"npm": ">=8"
 	}
 }

--- a/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
+++ b/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 import { isL2State, networkState } from 'store/wallet';


### PR DESCRIPTION
Vercel now deploys with node v16. When switching, we received the following warning:

> Warning: Due to "engines": { "node": ">=14" } in your package.json file, the Node.js Version defined in your Project Settings ("16.x") will not apply. Learn More: http://vercel.link/node-version

Therefore, we should update our "engines" to node v16 (and npm v8 respectively) which are the latest LTS versions of each.

This update is only for `v2-dev`, as it potentially have issues with the outdated v1 (main/dev) branches. This update should not affect them.