### PR TITLE
Layout changes

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Svg } from 'react-optimized-image';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
-
 import media from 'styles/media';
 import { FlexDivRowCentered } from 'styles/common';
 
@@ -19,16 +17,14 @@ const NotFoundPage = () => {
 			<Head>
 				<title>{t('not-found.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<Container>
-					<Svg src={CaretLeftXLIcon} />
-					<Content>
-						<Title>{t('not-found.title')}</Title>
-						<Subtitle>{t('not-found.subtitle')}</Subtitle>
-					</Content>
-					<Svg src={CaretRightXLICon} />
-				</Container>
-			</AppLayout>
+			<Container>
+				<Svg src={CaretLeftXLIcon} />
+				<Content>
+					<Title>{t('not-found.title')}</Title>
+					<Subtitle>{t('not-found.subtitle')}</Subtitle>
+				</Content>
+				<Svg src={CaretRightXLICon} />
+			</Container>
 		</>
 	);
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,6 +15,7 @@ import { CustomThemeProvider } from 'contexts/CustomThemeContext';
 import SystemStatus from 'sections/shared/SystemStatus';
 
 import { isSupportedNetworkId } from 'utils/network';
+import AppLayout from 'sections/shared/Layout/AppLayout';
 
 import 'styles/main.css';
 import 'slick-carousel/slick/slick.css';
@@ -48,7 +49,9 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }) => {
 				>
 					<Layout>
 						<SystemStatus>
-							<Component {...pageProps} />
+							<AppLayout>
+								<Component {...pageProps} />
+							</AppLayout>
 						</SystemStatus>
 					</Layout>
 					<ReactQueryDevtools />

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -3,7 +3,6 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
 import { PageContent, FullHeightContainer } from 'styles/common';
 import DashboardContainer from 'sections/dashboard/DashboardContainer';
 
@@ -15,13 +14,11 @@ const Futures: FC = () => {
 			<Head>
 				<title>{t('futures.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<PageContent>
-					<StyledFullHeightContainer>
-						<DashboardContainer />
-					</StyledFullHeightContainer>
-				</PageContent>
-			</AppLayout>
+			<PageContent>
+				<StyledFullHeightContainer>
+					<DashboardContainer />
+				</StyledFullHeightContainer>
+			</PageContent>
 		</>
 	);
 };

--- a/pages/earn.tsx
+++ b/pages/earn.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import Head from 'next/head';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
-
 import { PageContent, FullHeightContainer } from 'styles/common';
 
 import Text from 'components/Text';
@@ -18,24 +16,22 @@ const Earn: React.FC = () => {
 			<Head>
 				<title>Earn | Kwenta</title>
 			</Head>
-			<AppLayout>
-				<PageContent>
-					<FullHeightContainer>
-						<MainContainer>
-							<EmptyColumn />
-							<GridsContainer>
-								<PageHeading variant="h4">Liquidity Mining Program</PageHeading>
-								<StyledBody size="large">
-									Earn KWENTA by staking SNX or adding liquidity to the sUSD Curve pool on Optimism.
-								</StyledBody>
-								<StakeGrid />
-								<PoolGrid />
-							</GridsContainer>
-							<Rewards />
-						</MainContainer>
-					</FullHeightContainer>
-				</PageContent>
-			</AppLayout>
+			<PageContent>
+				<FullHeightContainer>
+					<MainContainer>
+						<EmptyColumn />
+						<GridsContainer>
+							<PageHeading variant="h4">Liquidity Mining Program</PageHeading>
+							<StyledBody size="large">
+								Earn KWENTA by staking SNX or adding liquidity to the sUSD Curve pool on Optimism.
+							</StyledBody>
+							<StakeGrid />
+							<PoolGrid />
+						</GridsContainer>
+						<Rewards />
+					</MainContainer>
+				</FullHeightContainer>
+			</PageContent>
 		</>
 	);
 };

--- a/pages/exchange/[[...market]].tsx
+++ b/pages/exchange/[[...market]].tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 import Head from 'next/head';
-import AppLayout from 'sections/shared/Layout/AppLayout';
 
 import { PageContent, FullHeightContainer, MainContent } from 'styles/common';
 
@@ -37,15 +36,13 @@ const Exchange: FC = () => {
 						: t('exchange.page-title')}
 				</title>
 			</Head>
-			<AppLayout>
-				<PageContent>
-					<StyledFullHeightContainer>
-						<MainContent>
-							<BasicSwap />
-						</MainContent>
-					</StyledFullHeightContainer>
-				</PageContent>
-			</AppLayout>
+			<PageContent>
+				<StyledFullHeightContainer>
+					<MainContent>
+						<BasicSwap />
+					</MainContent>
+				</StyledFullHeightContainer>
+			</PageContent>
 		</>
 	);
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react';
 import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
 import { PageContent, FullHeightContainer } from 'styles/common';
 import DashboardContainer from 'sections/dashboard/DashboardContainer';
 
@@ -14,13 +13,11 @@ const Futures: FC = () => {
 			<Head>
 				<title>{t('futures.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<PageContent>
-					<FullHeightContainer>
-						<DashboardContainer />
-					</FullHeightContainer>
-				</PageContent>
-			</AppLayout>
+			<PageContent>
+				<FullHeightContainer>
+					<DashboardContainer />
+				</FullHeightContainer>
+			</PageContent>
 		</>
 	);
 };

--- a/pages/leaderboard/[[...tab]].tsx
+++ b/pages/leaderboard/[[...tab]].tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
-import AppLayout from 'sections/shared/Layout/AppLayout';
 import { PageContent, MainContent, FullHeightContainer } from 'styles/common';
 import Leaderboard from 'sections/leaderboard/Leaderboard';
 
@@ -13,15 +12,13 @@ const Futures: FC = () => {
 			<Head>
 				<title>{t('futures.page-title')}</title>
 			</Head>
-			<AppLayout>
-				<PageContent>
-					<FullHeightContainer>
-						<MainContent>
-							<Leaderboard />
-						</MainContent>
-					</FullHeightContainer>
-				</PageContent>
-			</AppLayout>
+			<PageContent>
+				<FullHeightContainer>
+					<MainContent>
+						<Leaderboard />
+					</MainContent>
+				</FullHeightContainer>
+			</PageContent>
 		</>
 	);
 };

--- a/pages/market/[[...market]].tsx
+++ b/pages/market/[[...market]].tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import AppLayout from 'sections/shared/Layout/AppLayout';
 import { DesktopOnlyView } from 'components/Media';
 
 import {
@@ -53,35 +52,33 @@ const Market = () => {
 			<Head>
 				<title>{t('futures.market.page-title', { pair: router.query.market })}</title>
 			</Head>
-			<AppLayout>
-				<StyledPageContent>
-					<StyledFullHeightContainer>
-						<DesktopOnlyView>
-							<StyledLeftSideContent>
-								<TradingHistory currencyKey={marketAsset} />
-							</StyledLeftSideContent>
-						</DesktopOnlyView>
-						<StyledMainContent>
-							<MarketInfo
-								market={marketAsset}
-								position={futuresMarketPosition}
-								openOrders={openOrders}
+			<StyledPageContent>
+				<StyledFullHeightContainer>
+					<DesktopOnlyView>
+						<StyledLeftSideContent>
+							<TradingHistory currencyKey={marketAsset} />
+						</StyledLeftSideContent>
+					</DesktopOnlyView>
+					<StyledMainContent>
+						<MarketInfo
+							market={marketAsset}
+							position={futuresMarketPosition}
+							openOrders={openOrders}
+							refetch={refetch}
+							potentialTrade={potentialTrade}
+						/>
+					</StyledMainContent>
+					<DesktopOnlyView>
+						<StyledRightSideContent>
+							<Trade
+								onEditPositionInput={setPotentialTrade}
 								refetch={refetch}
-								potentialTrade={potentialTrade}
+								position={futuresMarketPosition}
 							/>
-						</StyledMainContent>
-						<DesktopOnlyView>
-							<StyledRightSideContent>
-								<Trade
-									onEditPositionInput={setPotentialTrade}
-									refetch={refetch}
-									position={futuresMarketPosition}
-								/>
-							</StyledRightSideContent>
-						</DesktopOnlyView>
-					</StyledFullHeightContainer>
-				</StyledPageContent>
-			</AppLayout>
+						</StyledRightSideContent>
+					</DesktopOnlyView>
+				</StyledFullHeightContainer>
+			</StyledPageContent>
 		</>
 	);
 };


### PR DESCRIPTION
the header continuously loads on every page change, causing alot of unnecessary calls to be made.

## Description
 This pr consolidates the layout one layer up into `/pages/_app.ts` - nextjs recommends this for a single layout that is shared across pages.

https://nextjs.org/docs/basic-features/layouts#single-shared-layout-with-custom-app - if we need a different layout there are examples of the best way to go about this in their docs, for now, we only use one layout.

## Related issue
https://github.com/Kwenta/kwenta/issues/688

## Motivation and Context
need to fix reloads

## How Has This Been Tested?
locally, on build

## Screenshots (if appropriate):

current state of switching:
https://user-images.githubusercontent.com/5998100/167944440-cf04160a-5d8d-4593-bd1e-7c6b6ac0934c.mov

see deployed branch to tell the difference