### PR TITLE
hotfix: handle when `marketSize` is 0

### DIFF
--- a/sections/futures/TradingHistory/SkewInfo.tsx
+++ b/sections/futures/TradingHistory/SkewInfo.tsx
@@ -22,8 +22,12 @@ const SkewInfo: React.FC<SkewInfoProps> = ({ currencyKey }) => {
 					.filter((i: FuturesMarket) => i.asset === currencyKey)
 					.map((i: FuturesMarket) => {
 						return {
-							short: i.marketSize.sub(i.marketSkew).div('2').div(i.marketSize).toNumber(),
-							long: i.marketSize.add(i.marketSkew).div('2').div(i.marketSize).toNumber(),
+							short: i.marketSize.eq(0)
+								? 0
+								: i.marketSize.sub(i.marketSkew).div('2').div(i.marketSize).toNumber(),
+							long: i.marketSize.eq(0)
+								? 0
+								: i.marketSize.add(i.marketSkew).div('2').div(i.marketSize).toNumber(),
 						};
 					})
 			: [


### PR DESCRIPTION
fix division by zero error for new markets