### PR TITLE
Add min amount into atomic exchange (v2-dev)

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -59,13 +59,18 @@ export const QUERY_KEYS = {
 	Synths: {
 		FrozenSynths: ['synths', 'frozenSynths'],
 		Suspension: (currencyKey: CurrencyKey) => ['synths', 'suspension', currencyKey],
-		ExchangeFeeRate: (quoteCurrencyKey: CurrencyKey, baseCurrencyKey: CurrencyKey) => [
+		ExchangeFeeRate: (sourceCurrencyKey: CurrencyKey, destinationCurrencyKey: CurrencyKey) => [
 			'synths',
 			'exchangeFeeRate',
-			quoteCurrencyKey,
-			baseCurrencyKey,
+			sourceCurrencyKey,
+			destinationCurrencyKey,
 		],
-		BaseFeeRate: (currencyKey: CurrencyKey) => ['synths', 'baseFeeRate', currencyKey],
+		BaseFeeRate: (sourceCurrencyKey: CurrencyKey, destinationCurrencyKey: CurrencyKey) => [
+			'synths',
+			'baseFeeRate',
+			sourceCurrencyKey,
+			destinationCurrencyKey,
+		],
 		NumEntries: (walletAddress: string, currencyKey: CurrencyKey) => [
 			'synths',
 			'numEntries',

--- a/queries/synths/useBaseFeeRateQuery.ts
+++ b/queries/synths/useBaseFeeRateQuery.ts
@@ -6,6 +6,7 @@ import { ethers } from 'ethers';
 import { CurrencyKey } from 'constants/currency';
 import { appReadyState } from 'store/app';
 import QUERY_KEYS from 'constants/queryKeys';
+import Wei from '@synthetixio/wei';
 
 const useBaseFeeRateQuery = (
 	sourceCurrencyKey: CurrencyKey | null,
@@ -19,15 +20,16 @@ const useBaseFeeRateQuery = (
 		async () => {
 			const { SystemSettings } = synthetixjs!.contracts;
 
-			const sourceCurrencyFeeRate = await SystemSettings.exchangeFeeRate(
-				ethers.utils.formatBytes32String(sourceCurrencyKey as string)
-			);
+			const [sourceCurrencyFeeRate, destinationCurrencyFeeRate] = (await Promise.all([
+				SystemSettings.exchangeFeeRate(
+					ethers.utils.formatBytes32String(sourceCurrencyKey as string)
+				),
+				SystemSettings.exchangeFeeRate(
+					ethers.utils.formatBytes32String(destinationCurrencyKey as string)
+				),
+			])) as [Wei, Wei];
 
-			const destinationCurrencyFeeRate = await SystemSettings.exchangeFeeRate(
-				ethers.utils.formatBytes32String(destinationCurrencyKey as string)
-			);
-
-			return sourceCurrencyFeeRate || destinationCurrencyFeeRate
+			return sourceCurrencyFeeRate && destinationCurrencyFeeRate
 				? sourceCurrencyFeeRate.add(destinationCurrencyFeeRate)
 				: null;
 		},

--- a/queries/synths/useBaseFeeRateQuery.ts
+++ b/queries/synths/useBaseFeeRateQuery.ts
@@ -20,11 +20,6 @@ const useBaseFeeRateQuery = (
 		async () => {
 			const { SystemSettings } = synthetixjs!.contracts;
 
-			console.log(
-				SystemSettings.exchangeFeeRate(
-					ethers.utils.formatBytes32String(sourceCurrencyKey as string)
-				)
-			);
 			const [sourceCurrencyFeeRate, destinationCurrencyFeeRate] = (await Promise.all([
 				new Wei(
 					SystemSettings.exchangeFeeRate(

--- a/queries/synths/useBaseFeeRateQuery.ts
+++ b/queries/synths/useBaseFeeRateQuery.ts
@@ -20,12 +20,21 @@ const useBaseFeeRateQuery = (
 		async () => {
 			const { SystemSettings } = synthetixjs!.contracts;
 
-			const [sourceCurrencyFeeRate, destinationCurrencyFeeRate] = (await Promise.all([
+			console.log(
 				SystemSettings.exchangeFeeRate(
 					ethers.utils.formatBytes32String(sourceCurrencyKey as string)
+				)
+			);
+			const [sourceCurrencyFeeRate, destinationCurrencyFeeRate] = (await Promise.all([
+				new Wei(
+					SystemSettings.exchangeFeeRate(
+						ethers.utils.formatBytes32String(sourceCurrencyKey as string)
+					)
 				),
-				SystemSettings.exchangeFeeRate(
-					ethers.utils.formatBytes32String(destinationCurrencyKey as string)
+				new Wei(
+					SystemSettings.exchangeFeeRate(
+						ethers.utils.formatBytes32String(destinationCurrencyKey as string)
+					)
 				),
 			])) as [Wei, Wei];
 

--- a/queries/synths/useExchangeFeeRateQuery.ts
+++ b/queries/synths/useExchangeFeeRateQuery.ts
@@ -7,7 +7,7 @@ import { CurrencyKey } from 'constants/currency';
 import { appReadyState } from 'store/app';
 import QUERY_KEYS from 'constants/queryKeys';
 
-const useBaseFeeRateQuery = (
+const useExchangeFeeRateQuery = (
 	sourceCurrencyKey: CurrencyKey | null,
 	destinationCurrencyKey: CurrencyKey | null
 ) => {
@@ -15,21 +15,14 @@ const useBaseFeeRateQuery = (
 	const { synthetixjs } = Connector.useContainer();
 
 	return useQuery(
-		QUERY_KEYS.Synths.BaseFeeRate(sourceCurrencyKey!, destinationCurrencyKey!),
+		QUERY_KEYS.Synths.ExchangeFeeRate(sourceCurrencyKey!, destinationCurrencyKey!),
 		async () => {
-			const { SystemSettings } = synthetixjs!.contracts;
+			const { Exchanger } = synthetixjs!.contracts;
 
-			const sourceCurrencyFeeRate = await SystemSettings.exchangeFeeRate(
-				ethers.utils.formatBytes32String(sourceCurrencyKey as string)
-			);
-
-			const destinationCurrencyFeeRate = await SystemSettings.exchangeFeeRate(
+			return await Exchanger.feeRateForExchange(
+				ethers.utils.formatBytes32String(sourceCurrencyKey as string),
 				ethers.utils.formatBytes32String(destinationCurrencyKey as string)
 			);
-
-			return sourceCurrencyFeeRate || destinationCurrencyFeeRate
-				? sourceCurrencyFeeRate.add(destinationCurrencyFeeRate)
-				: null;
 		},
 		{
 			enabled:
@@ -38,4 +31,4 @@ const useBaseFeeRateQuery = (
 	);
 };
 
-export default useBaseFeeRateQuery;
+export default useExchangeFeeRateQuery;

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -70,6 +70,8 @@ import { wei } from '@synthetixio/wei';
 import Connector from 'containers/Connector';
 import { useGetL1SecurityFee } from 'hooks/useGetL1SecurityGasFee';
 import useGas from 'hooks/useGas';
+import { KWENTA_TRACKING_CODE } from 'queries/futures/constants';
+import useExchangeFeeRateQuery from 'queries/synths/useExchangeFeeRateQuery';
 
 type ExchangeCardProps = {
 	defaultBaseCurrencyKey?: string | null;
@@ -108,7 +110,6 @@ const useExchange = ({
 		useSynthsBalancesQuery,
 		useExchangeRatesQuery,
 		useFeeReclaimPeriodQuery,
-		useExchangeFeeRateQuery,
 	} = useSynthetixQueries();
 
 	const router = useRouter();
@@ -183,7 +184,10 @@ const useExchange = ({
 		baseCurrencyKey as CurrencyKey
 	);
 
-	const baseFeeRateQuery = useBaseFeeRateQuery(baseCurrencyKey as CurrencyKey);
+	const baseFeeRateQuery = useBaseFeeRateQuery(
+		baseCurrencyKey as CurrencyKey,
+		quoteCurrencyKey as CurrencyKey
+	);
 
 	const isBaseCurrencyETH = baseCurrencyKey === CRYPTO_CURRENCY_MAP.ETH;
 	const isQuoteCurrencyETH = quoteCurrencyKey === CRYPTO_CURRENCY_MAP.ETH;
@@ -558,13 +562,15 @@ const useExchange = ({
 		}
 		if (txProvider === 'synthetix' && quoteCurrencyAmount !== '' && baseCurrencyKey != null) {
 			const baseCurrencyAmountNoFee = wei(quoteCurrencyAmount).mul(rate);
-			setBaseCurrencyAmount(baseCurrencyAmountNoFee.toString());
+			const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
+			setBaseCurrencyAmount(baseCurrencyAmountNoFee.sub(fee).toString());
 		}
 	}, [
 		rate,
 		baseCurrencyKey,
 		quoteCurrencyAmount,
 		baseCurrencyAmount,
+		exchangeFeeRate,
 		txProvider,
 		oneInchQuoteQuery.data,
 		oneInchQuoteQuery.isSuccess,
@@ -575,21 +581,27 @@ const useExchange = ({
 			const destinationCurrencyKey = ethers.utils.formatBytes32String(quoteCurrencyKey!);
 			const sourceCurrencyKey = ethers.utils.formatBytes32String(baseCurrencyKey!);
 			const sourceAmount = quoteCurrencyAmountBN.toBN();
-			const trackingCode = ethers.utils.formatBytes32String('KWENTA');
+			const minAmount = baseCurrencyAmountBN.toBN();
 
 			if (isAtomic) {
-				return [destinationCurrencyKey, sourceAmount, sourceCurrencyKey, trackingCode];
+				return [
+					destinationCurrencyKey,
+					sourceAmount,
+					sourceCurrencyKey,
+					KWENTA_TRACKING_CODE,
+					minAmount,
+				];
 			} else {
 				return [
 					destinationCurrencyKey,
 					sourceAmount,
 					sourceCurrencyKey,
 					walletAddress,
-					trackingCode,
+					KWENTA_TRACKING_CODE,
 				];
 			}
 		},
-		[baseCurrencyKey, quoteCurrencyAmountBN, quoteCurrencyKey, walletAddress]
+		[baseCurrencyKey, quoteCurrencyAmountBN, quoteCurrencyKey, walletAddress, baseCurrencyAmountBN]
 	);
 
 	const getGasEstimateForExchange = useCallback(
@@ -597,11 +609,14 @@ const useExchange = ({
 			try {
 				if (isL2 && !gasPrice) return null;
 				if (synthetixjs != null) {
-					const destinationCurrencyKey = getExchangeParams(true)[0];
+					const destinationCurrencyKey = ethers.utils.parseBytes32String(
+						getExchangeParams(true)[0] as string
+					);
 					const isAtomic =
-						destinationCurrencyKey === 'sBTC' ||
-						destinationCurrencyKey === 'sETH' ||
-						destinationCurrencyKey === 'sEUR';
+						!isL2 &&
+						(destinationCurrencyKey === 'sBTC' ||
+							destinationCurrencyKey === 'sETH' ||
+							destinationCurrencyKey === 'sEUR');
 					const exchangeParams = getExchangeParams(isAtomic);
 
 					let gasEstimate, gasLimitNum, metaTx;
@@ -765,11 +780,16 @@ const useExchange = ({
 			setTxError(null);
 			setTxConfirmationModalOpen(true);
 
-			const destinationCurrencyKey = getExchangeParams(true)[0];
+			const destinationCurrencyKey = ethers.utils.parseBytes32String(
+				getExchangeParams(true)[0] as string
+			);
+
 			const isAtomic =
-				destinationCurrencyKey === 'sBTC' ||
-				destinationCurrencyKey === 'sETH' ||
-				destinationCurrencyKey === 'sEUR';
+				!isL2 &&
+				(destinationCurrencyKey === 'sBTC' ||
+					destinationCurrencyKey === 'sETH' ||
+					destinationCurrencyKey === 'sEUR');
+			console.log(`submit`, isAtomic);
 			const exchangeParams = getExchangeParams(isAtomic);
 
 			try {
@@ -868,6 +888,7 @@ const useExchange = ({
 		synthetixjs,
 		gasPriceWei,
 		gasConfig,
+		isL2,
 	]);
 
 	useEffect(() => {

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -789,7 +789,7 @@ const useExchange = ({
 				(destinationCurrencyKey === 'sBTC' ||
 					destinationCurrencyKey === 'sETH' ||
 					destinationCurrencyKey === 'sEUR');
-			console.log(`submit`, isAtomic);
+
 			const exchangeParams = getExchangeParams(isAtomic);
 
 			try {

--- a/sections/shared/components/FeeRateSummary/FeeRateSummary.tsx
+++ b/sections/shared/components/FeeRateSummary/FeeRateSummary.tsx
@@ -34,7 +34,7 @@ const FeeRateSummaryItem: FC<FeeRateSummaryItemProps> = ({ totalFeeRate, baseFee
 							: NO_VALUE}
 					</span>
 					{totalFeeRate != null && baseFeeRate != null ? (
-						totalFeeRate.sub(baseFeeRate).toNumber() > 0 ? (
+						totalFeeRate.sub(baseFeeRate).gt(0) ? (
 							<>
 								<DynamicFeeLabel>+</DynamicFeeLabel>
 								<DynamicFeeRateTooltip
@@ -44,9 +44,7 @@ const FeeRateSummaryItem: FC<FeeRateSummaryItemProps> = ({ totalFeeRate, baseFee
 									placement="bottom"
 								>
 									<DynamicFeeRateItem>
-										<span>
-											{formatPercent(totalFeeRate.sub(baseFeeRate).toNumber(), { minDecimals: 2 })}
-										</span>
+										<span>{formatPercent(totalFeeRate.sub(baseFeeRate), { minDecimals: 2 })}</span>
 										<Svg src={TimerIcon} />
 									</DynamicFeeRateItem>
 								</DynamicFeeRateTooltip>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In `Menkent` release, atomic exchange is adding one more value `minAmount` for slippage control.

## Related issue
#672

## Motivation and Context


## How Has This Been Tested?
1. Make a transaction sEUR => sUSD on L2. It triggers `exchangeWithTracking` method.
https://kovan-optimistic.etherscan.io/tx/0xe9264f2935addb93a63b73fc2c5a10df33f586ef9d3fac54f25a26028f5171f8
2. Make a transaction sEUR => sUSD on L1. It triggers `exchangeAtomically` method with the new parameter `minAmount`.
https://kovan.etherscan.io/tx/0x28a3468e6a1be67000217dd029ca2e9eb564eebb47094644f7d7a335a53b6c40

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/167950261-b8d3ad94-39ef-4f5d-8f6d-a2b818ebe316.png)
