### PR TITLE
Fix 24h volume on L2

### DIFF
--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -170,12 +170,16 @@ export const calculateTradeVolumeForAll = (futuresTrades: FuturesTradeResult[]):
 };
 
 export const calculateTradeVolumeForAllSynths = (SynthTrades: SynthsTrades): SynthsVolumes => {
-	const result = SynthTrades.synthExchanges.reduce((acc: any, curr: any) => {
-		acc[curr.fromSynth.symbol] = acc[curr.fromSynth.symbol]
-			? acc[curr.fromSynth.symbol] + Number(curr.fromAmountInUSD)
-			: Number(curr.fromAmountInUSD);
-		return acc;
-	}, {});
+	const result = SynthTrades.synthExchanges
+		.filter((i) => i.fromSynth !== null)
+		.reduce((acc: any, curr: any) => {
+			if (curr.fromSynth.symbol) {
+				acc[curr.fromSynth.symbol] = acc[curr.fromSynth.symbol]
+					? acc[curr.fromSynth.symbol] + Number(curr.fromAmountInUSD)
+					: Number(curr.fromAmountInUSD);
+			}
+			return acc;
+		}, {});
 	return result;
 };
 

--- a/sections/dashboard/Markets/Markets.tsx
+++ b/sections/dashboard/Markets/Markets.tsx
@@ -5,6 +5,8 @@ import { TabPanel } from 'components/Tab';
 import TabButton from 'components/Button/TabButton';
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import FuturesMarketsTable from '../FuturesMarketsTable';
+import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
+import SpotMarketsTable from '../SpotMarketsTable';
 
 enum MarketsTab {
 	FUTURES = 'futures',
@@ -16,6 +18,9 @@ const Markets: FC = () => {
 
 	const futuresMarketsQuery = useGetFuturesMarkets();
 	const futuresMarkets = futuresMarketsQuery?.data ?? [];
+
+	const exchangeRatesQuery = useExchangeRatesQuery();
+	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
 
 	const [activeMarketsTab, setActiveMarketsTab] = useState<MarketsTab>(MarketsTab.FUTURES);
 
@@ -33,7 +38,6 @@ const Markets: FC = () => {
 				name: MarketsTab.SPOT,
 				label: t('dashboard.overview.markets-tabs.spot'),
 				active: activeMarketsTab === MarketsTab.SPOT,
-				disabled: true,
 				onClick: () => {
 					setActiveMarketsTab(MarketsTab.SPOT);
 				},
@@ -45,21 +49,17 @@ const Markets: FC = () => {
 	return (
 		<>
 			<TabButtonsContainer>
-				{MARKETS_TABS.map(({ name, label, active, disabled, onClick }) => (
-					<TabButton
-						key={name}
-						title={label}
-						active={active}
-						disabled={disabled}
-						onClick={onClick}
-					/>
+				{MARKETS_TABS.map(({ name, label, active, onClick }) => (
+					<TabButton key={name} title={label} active={active} onClick={onClick} />
 				))}
 			</TabButtonsContainer>
 			<TabPanel name={MarketsTab.FUTURES} activeTab={activeMarketsTab}>
 				<FuturesMarketsTable futuresMarkets={futuresMarkets} />
 			</TabPanel>
 
-			<TabPanel name={MarketsTab.SPOT} activeTab={activeMarketsTab}></TabPanel>
+			<TabPanel name={MarketsTab.SPOT} activeTab={activeMarketsTab}>
+				<SpotMarketsTable exchangeRates={exchangeRates} />
+			</TabPanel>
 		</>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The original code in #783 couldn't process the trades without a currency symbol. Here is the fix to handle this issue.
![image](https://user-images.githubusercontent.com/4819006/168146902-88a3de89-6900-46b5-8d70-364b69cedc33.png)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
To try our best to show the 24h volume on L2 with the broken subgraph.

## How Has This Been Tested?
1. Open the page and check the 24 volume column

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/168148414-0e304990-5c9d-4013-8f1a-3e695510f478.png)
