### PR TITLE
Menkent fix add a hardcoded slippage and susd

### DIFF
--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -141,6 +141,7 @@ const useExchange = ({
 	const [selectQuoteTokenModalOpen, setSelectQuoteTokenModalOpen] = useState<boolean>(false);
 	const [selectBaseTokenModalOpen, setSelectBaseTokenModalOpen] = useState<boolean>(false);
 	const [txApproveModalOpen, setTxApproveModalOpen] = useState<boolean>(false);
+	const [atomicExchangeSlippage] = useState<string>('0.01');
 	const setOrders = useSetRecoilState(ordersState);
 	const setHasOrdersNotification = useSetRecoilState(hasOrdersNotificationState);
 	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
@@ -580,7 +581,7 @@ const useExchange = ({
 			const destinationCurrencyKey = ethers.utils.formatBytes32String(quoteCurrencyKey!);
 			const sourceCurrencyKey = ethers.utils.formatBytes32String(baseCurrencyKey!);
 			const sourceAmount = quoteCurrencyAmountBN.toBN();
-			const minAmount = baseCurrencyAmountBN.toBN();
+			const minAmount = baseCurrencyAmountBN.mul(wei(1).sub(atomicExchangeSlippage)).toBN();
 
 			if (isAtomic) {
 				return [
@@ -600,7 +601,14 @@ const useExchange = ({
 				];
 			}
 		},
-		[baseCurrencyKey, quoteCurrencyAmountBN, quoteCurrencyKey, walletAddress, baseCurrencyAmountBN]
+		[
+			baseCurrencyKey,
+			quoteCurrencyAmountBN,
+			quoteCurrencyKey,
+			walletAddress,
+			baseCurrencyAmountBN,
+			atomicExchangeSlippage,
+		]
 	);
 
 	const getGasEstimateForExchange = useCallback(
@@ -615,7 +623,8 @@ const useExchange = ({
 						!isL2 &&
 						(destinationCurrencyKey === 'sBTC' ||
 							destinationCurrencyKey === 'sETH' ||
-							destinationCurrencyKey === 'sEUR');
+							destinationCurrencyKey === 'sEUR' ||
+							destinationCurrencyKey === 'sUSD');
 					const exchangeParams = getExchangeParams(isAtomic);
 
 					let gasEstimate, gasLimitNum, metaTx;
@@ -787,7 +796,8 @@ const useExchange = ({
 				!isL2 &&
 				(destinationCurrencyKey === 'sBTC' ||
 					destinationCurrencyKey === 'sETH' ||
-					destinationCurrencyKey === 'sEUR');
+					destinationCurrencyKey === 'sEUR' ||
+					destinationCurrencyKey === 'sUSD');
 
 			const exchangeParams = getExchangeParams(isAtomic);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Add a hardcoded slippage (1%) into atomic exchange
2. Add `sUSD` into atomic exchange

## Related issue
#848 

## Motivation and Context
A quick fix to the current implementation.

## How Has This Been Tested?
1. Make a swap between sUSD => sEUR on L1
2. Check the transaction function and confirm it is using `exchangeAtomically`

## Screenshots (if appropriate):
https://kovan.etherscan.io/tx/0x8449e7673e458b02d5c2eeea601e3fcae9d9b8eefb83a80670700d7cf23410a2
![image](https://user-images.githubusercontent.com/4819006/168854460-ec858e6b-81e8-4ac5-b550-8579c57df162.png)

