### PR TITLE
Fix the broken input issue for into field

### DIFF
--- a/queries/synths/useBaseFeeRateQuery.ts
+++ b/queries/synths/useBaseFeeRateQuery.ts
@@ -6,7 +6,6 @@ import { ethers } from 'ethers';
 import { CurrencyKey } from 'constants/currency';
 import { appReadyState } from 'store/app';
 import QUERY_KEYS from 'constants/queryKeys';
-import Wei from '@synthetixio/wei';
 
 const useBaseFeeRateQuery = (
 	sourceCurrencyKey: CurrencyKey | null,
@@ -20,18 +19,14 @@ const useBaseFeeRateQuery = (
 		async () => {
 			const { SystemSettings } = synthetixjs!.contracts;
 
-			const [sourceCurrencyFeeRate, destinationCurrencyFeeRate] = (await Promise.all([
-				new Wei(
-					SystemSettings.exchangeFeeRate(
-						ethers.utils.formatBytes32String(sourceCurrencyKey as string)
-					)
+			const [sourceCurrencyFeeRate, destinationCurrencyFeeRate] = await Promise.all([
+				SystemSettings.exchangeFeeRate(
+					ethers.utils.formatBytes32String(sourceCurrencyKey as string)
 				),
-				new Wei(
-					SystemSettings.exchangeFeeRate(
-						ethers.utils.formatBytes32String(destinationCurrencyKey as string)
-					)
+				SystemSettings.exchangeFeeRate(
+					ethers.utils.formatBytes32String(destinationCurrencyKey as string)
 				),
-			])) as [Wei, Wei];
+			]);
 
 			return sourceCurrencyFeeRate && destinationCurrencyFeeRate
 				? sourceCurrencyFeeRate.add(destinationCurrencyFeeRate)

--- a/sections/exchange/TradeCard/CurrencyCard/CurrencyCard.tsx
+++ b/sections/exchange/TradeCard/CurrencyCard/CurrencyCard.tsx
@@ -26,7 +26,6 @@ import { Side } from '../types';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { TxProvider } from 'sections/shared/modals/TxConfirmationModal/TxConfirmationModal';
 import Wei, { wei } from '@synthetixio/wei';
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import Connector from 'containers/Connector';
 import Button from 'components/Button';
@@ -108,11 +107,7 @@ const CurrencyCard: FC<CurrencyCardProps> = ({
 						>
 							<FlexDivRowCentered>
 								<CurrencyAmount
-									value={
-										isBase && Number(amount) > 0
-											? Number(amount).toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
-											: amount
-									}
+									value={amount}
 									onChange={(_, value) => onAmountChange(value)}
 									placeholder={t('exchange.currency-card.amount-placeholder')}
 									data-testid="currency-amount"

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -71,6 +71,7 @@ import { useGetL1SecurityFee } from 'hooks/useGetL1SecurityGasFee';
 import useGas from 'hooks/useGas';
 import { KWENTA_TRACKING_CODE } from 'queries/futures/constants';
 import useExchangeFeeRateQuery from 'queries/synths/useExchangeFeeRateQuery';
+import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 
 type ExchangeCardProps = {
 	defaultBaseCurrencyKey?: string | null;
@@ -559,21 +560,7 @@ const useExchange = ({
 				setBaseCurrencyAmount(oneInchQuoteQuery.data);
 			}
 		}
-		if (txProvider === 'synthetix' && quoteCurrencyAmount !== '' && baseCurrencyKey != null) {
-			const baseCurrencyAmountNoFee = wei(quoteCurrencyAmount).mul(rate);
-			const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
-			setBaseCurrencyAmount(baseCurrencyAmountNoFee.sub(fee).toString());
-		}
-	}, [
-		rate,
-		baseCurrencyKey,
-		quoteCurrencyAmount,
-		baseCurrencyAmount,
-		exchangeFeeRate,
-		txProvider,
-		oneInchQuoteQuery.data,
-		oneInchQuoteQuery.isSuccess,
-	]);
+	}, [quoteCurrencyAmount, txProvider, oneInchQuoteQuery.data, oneInchQuoteQuery.isSuccess]);
 
 	const getExchangeParams = useCallback(
 		(isAtomic: boolean) => {
@@ -931,7 +918,13 @@ const useExchange = ({
 						if (txProvider === 'synthetix' && baseCurrencyKey != null) {
 							const baseCurrencyAmountNoFee = wei(value).mul(rate);
 							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
-							setBaseCurrencyAmount(baseCurrencyAmountNoFee.sub(fee).toString());
+							setBaseCurrencyAmount(
+								baseCurrencyAmountNoFee
+									.sub(fee)
+									.toNumber()
+									.toFixed(DEFAULT_CRYPTO_DECIMALS)
+									.toString()
+							);
 						}
 					}
 				}}
@@ -1027,7 +1020,13 @@ const useExchange = ({
 						if (txProvider === 'synthetix' && baseCurrencyKey != null) {
 							const quoteCurrencyAmountNoFee = wei(value).mul(inverseRate);
 							const fee = quoteCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
-							setQuoteCurrencyAmount(quoteCurrencyAmountNoFee.add(fee).toString());
+							setQuoteCurrencyAmount(
+								quoteCurrencyAmountNoFee
+									.add(fee)
+									.toNumber()
+									.toFixed(DEFAULT_CRYPTO_DECIMALS)
+									.toString()
+							);
 						}
 					}
 				}}

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -492,7 +492,6 @@ const useExchange = ({
 			: false;
 
 	const handleCurrencySwap = () => {
-		const baseAmount = baseCurrencyAmount;
 		const quoteAmount = quoteCurrencyAmount;
 
 		setCurrencyPair({
@@ -501,7 +500,7 @@ const useExchange = ({
 		});
 
 		setBaseCurrencyAmount(quoteAmount);
-		setQuoteCurrencyAmount(baseAmount);
+		setQuoteCurrencyAmount('');
 
 		if (quoteCurrencyKey != null && baseCurrencyKey != null) {
 			routeToMarketPair(quoteCurrencyKey, baseCurrencyKey);
@@ -560,7 +559,26 @@ const useExchange = ({
 				setBaseCurrencyAmount(oneInchQuoteQuery.data);
 			}
 		}
-	}, [quoteCurrencyAmount, txProvider, oneInchQuoteQuery.data, oneInchQuoteQuery.isSuccess]);
+		if (txProvider === 'synthetix' && quoteCurrencyAmount !== '' && baseCurrencyKey != null) {
+			const baseCurrencyAmountNoFee = wei(quoteCurrencyAmount).mul(rate);
+			const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
+			setBaseCurrencyAmount(
+				baseCurrencyAmountNoFee.sub(fee).toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+			);
+		}
+		// eslint-disable-next-line
+	}, [quoteCurrencyKey, exchangeFeeRate, oneInchQuoteQuery.isSuccess, oneInchQuoteQuery.data]);
+
+	useEffect(() => {
+		if (txProvider === 'synthetix' && baseCurrencyAmount !== '' && quoteCurrencyKey != null) {
+			const quoteCurrencyAmountNoFee = wei(baseCurrencyAmount).mul(inverseRate);
+			const fee = quoteCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
+			setQuoteCurrencyAmount(
+				quoteCurrencyAmountNoFee.add(fee).toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+			);
+		}
+		// eslint-disable-next-line
+	}, [baseCurrencyKey, exchangeFeeRate]);
 
 	const getExchangeParams = useCallback(
 		(isAtomic: boolean) => {
@@ -913,11 +931,12 @@ const useExchange = ({
 				onAmountChange={async (value) => {
 					if (value === '') {
 						setQuoteCurrencyAmount('');
+						setBaseCurrencyAmount('');
 					} else {
 						setQuoteCurrencyAmount(value);
 						if (txProvider === 'synthetix' && baseCurrencyKey != null) {
 							const baseCurrencyAmountNoFee = wei(value).mul(rate);
-							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
+							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setBaseCurrencyAmount(
 								baseCurrencyAmountNoFee
 									.sub(fee)
@@ -934,14 +953,22 @@ const useExchange = ({
 						if (quoteCurrencyKey === 'ETH') {
 							const ETH_TX_BUFFER = 0.1;
 							const balanceWithBuffer = quoteCurrencyBalance.sub(wei(ETH_TX_BUFFER));
-							setQuoteCurrencyAmount(balanceWithBuffer.lt(0) ? '0' : balanceWithBuffer.toString());
+							setQuoteCurrencyAmount(
+								balanceWithBuffer.lt(0)
+									? '0'
+									: balanceWithBuffer.toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+							);
 						} else {
-							setQuoteCurrencyAmount(quoteCurrencyBalance.toString());
+							setQuoteCurrencyAmount(
+								quoteCurrencyBalance.toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+							);
 						}
 						if (txProvider === 'synthetix') {
 							const baseCurrencyAmountNoFee = quoteCurrencyBalance.mul(rate);
-							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
-							setBaseCurrencyAmount(baseCurrencyAmountNoFee.sub(fee).toString());
+							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
+							setBaseCurrencyAmount(
+								baseCurrencyAmountNoFee.sub(fee).toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+							);
 						}
 					}
 				}}
@@ -1015,11 +1042,12 @@ const useExchange = ({
 				onAmountChange={async (value) => {
 					if (value === '') {
 						setBaseCurrencyAmount('');
+						setQuoteCurrencyAmount('');
 					} else {
 						setBaseCurrencyAmount(value);
 						if (txProvider === 'synthetix' && baseCurrencyKey != null) {
 							const quoteCurrencyAmountNoFee = wei(value).mul(inverseRate);
-							const fee = quoteCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
+							const fee = quoteCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setQuoteCurrencyAmount(
 								quoteCurrencyAmountNoFee
 									.add(fee)
@@ -1037,8 +1065,10 @@ const useExchange = ({
 
 						if (txProvider === 'synthetix') {
 							const baseCurrencyAmountNoFee = baseCurrencyBalance.mul(inverseRate);
-							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 1);
-							setQuoteCurrencyAmount(baseCurrencyAmountNoFee.add(fee).toString());
+							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
+							setQuoteCurrencyAmount(
+								baseCurrencyAmountNoFee.add(fee).toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+							);
 						}
 					}
 				}}
@@ -1060,7 +1090,7 @@ const useExchange = ({
 				<SelectCurrencyModal
 					onDismiss={() => setSelectBaseCurrencyModalOpen(false)}
 					onSelect={(currencyKey) => {
-						setBaseCurrencyAmount('');
+						setQuoteCurrencyAmount('');
 						// @ts-ignore
 						setCurrencyPair((pair) => ({
 							base: currencyKey,
@@ -1081,7 +1111,7 @@ const useExchange = ({
 				<SelectCurrencyModal
 					onDismiss={() => setSelectBaseTokenModalOpen(false)}
 					onSelect={(currencyKey) => {
-						setBaseCurrencyAmount('');
+						setQuoteCurrencyAmount('');
 						// @ts-ignore
 						setCurrencyPair((pair) => ({
 							base: currencyKey,

--- a/translations/en.json
+++ b/translations/en.json
@@ -172,7 +172,7 @@
 		"page-title-currency-pair": "{{baseCurrencyKey}}/{{quoteCurrencyKey}} - {{rate}} | Kwenta",
 		"synth-exchange": "Synth Exchange",
 		"currency-card": {
-			"synth-name": "Synth Name",
+			"synth-name": "Synthetic Asset",
 			"amount-placeholder": "0.0000",
 			"wallet-balance": "balance:",
 			"currency-selector": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user can't use the backspace button to remove the values and enter new values in the `into` fields.

## Related issue
#842

## Motivation and Context
It affects the UX, especially for the user who wants to receive the exact amount of the `into` currency.

## How Has This Been Tested?
1. Select `sLink` as the `baseCurrency` and type `500` in the `into` field.
2. Select `sLink` as the `quoteCurrency` and type `500` in the `from` field.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/168877050-4f616c47-c8e3-4c74-86d6-b16fbcfab59a.png)
![image](https://user-images.githubusercontent.com/4819006/168877188-7ba433ea-2426-4f85-8d03-73d8354b5c22.png)
