### PR TITLE
Fix the invalid balance and max button click on quote currency card

### DIFF
--- a/sections/exchange/TradeCard/CurrencyCard/CurrencyCard.tsx
+++ b/sections/exchange/TradeCard/CurrencyCard/CurrencyCard.tsx
@@ -114,7 +114,7 @@ const CurrencyCard: FC<CurrencyCardProps> = ({
 								/>
 								{!isBase && (
 									<MaxButton onClick={hasWalletBalance ? onBalanceClick : undefined}>
-										<CapitalizedText>max</CapitalizedText>
+										<CapitalizedText>{t('exchange.currency-card.max-button')}</CapitalizedText>
 									</MaxButton>
 								)}
 							</FlexDivRowCentered>

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -966,18 +966,22 @@ const useExchange = ({
 							setQuoteCurrencyAmount(
 								balanceWithBuffer.lt(0)
 									? '0'
-									: balanceWithBuffer.toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+									: balanceWithBuffer.toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
 							);
 						} else {
 							setQuoteCurrencyAmount(
-								quoteCurrencyBalance.toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+								quoteCurrencyBalance.toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
 							);
 						}
 						if (txProvider === 'synthetix') {
 							const baseCurrencyAmountNoFee = quoteCurrencyBalance.mul(rate);
 							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setBaseCurrencyAmount(
-								baseCurrencyAmountNoFee.sub(fee).toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+								baseCurrencyAmountNoFee
+									.sub(fee)
+									.toNumber()
+									.toFixed(DEFAULT_CRYPTO_DECIMALS)
+									.toString()
 							);
 						}
 					}
@@ -1071,13 +1075,19 @@ const useExchange = ({
 				walletBalance={baseCurrencyBalance}
 				onBalanceClick={async () => {
 					if (baseCurrencyBalance != null) {
-						setBaseCurrencyAmount(baseCurrencyBalance.toString());
+						setBaseCurrencyAmount(
+							baseCurrencyBalance.toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+						);
 
 						if (txProvider === 'synthetix') {
 							const baseCurrencyAmountNoFee = baseCurrencyBalance.mul(inverseRate);
 							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setQuoteCurrencyAmount(
-								baseCurrencyAmountNoFee.add(fee).toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+								baseCurrencyAmountNoFee
+									.add(fee)
+									.toNumber()
+									.toFixed(DEFAULT_CRYPTO_DECIMALS)
+									.toString()
 							);
 						}
 					}

--- a/translations/en.json
+++ b/translations/en.json
@@ -178,7 +178,8 @@
 			"currency-selector": {
 				"select-synth": "select synth",
 				"select-token": "select token"
-			}
+			},
+			"max-button": "max"
 		},
 		"market-details-card": {
 			"title": "Market Details",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the user clicked on the "Max" and "balance" buttons, the input field was not filled automatically. 
The root cause is that the `balanceWithBuffer` and `quoteCurrencyBalance` are strings so the `toFixed` throw the error.

## Related issue
#842 

## Motivation and Context
It affects the UX.

## How Has This Been Tested?
1. Clicked on "Max" and the input was filled automatically
2. Clicked on "balance" and the input was filled automatically

## Screenshots (if appropriate):