### PR TITLE
various fixes

### DIFF
--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -206,6 +206,6 @@ const DirectionalValue = styled(PriceValue)<{ negative?: boolean; normal?: boole
 		props.normal
 			? props.theme.colors.common.primaryWhite
 			: props.negative
-			? props.theme.colors.common.primaryRed
-			: props.theme.colors.common.primaryGreen};
+			? props.theme.colors.common.primaryGreen
+			: props.theme.colors.common.primaryRed};
 `;

--- a/translations/en.json
+++ b/translations/en.json
@@ -738,7 +738,7 @@
 					"competition-closed": "Competition Closed",
 					"open-position": "Open Position",
 					"modify-position": "Modify Position",
-					"deposit-margin-minimum": "Deposit $50 Margin Minimum",
+					"deposit-margin-minimum": "Deposit Margin",
 					"oi-caps-reached": "Open Interest Cap Reached",
 					"place-next-price-order": "Place Next-Price Order"
 				},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1) Improve Deposit Button text if no margin is deposited to fit within button size restraints
2) Switch color for trading history to correctly paint shorts in red and longs in green

## Related tickets
closes #861 

## Screenshots (if appropriate):

### Before
<img width="366" alt="Screen Shot 2022-05-19 at 19 40 31" src="https://user-images.githubusercontent.com/548702/169415991-14a57461-cfd5-4d5c-905d-5f193c7933cf.png">

### After

<img width="366" alt="Screen Shot 2022-05-19 at 19 42 08" src="https://user-images.githubusercontent.com/548702/169416164-eefb929d-1a74-4e79-98aa-bdd7ce24a739.png">

### Trading History Panel:
![Screen Shot 2022-05-20 at 11 17 05](https://user-images.githubusercontent.com/548702/169547444-ffe604f3-5224-4e9e-8d61-ed89d8550113.png)

Last tx (trade size -20000000000000000000 = -20 ETH): https://optimistic.etherscan.io/tx/0x35079684f469f8eac4ec0dd61ce9db8d60bc4f4a0aa456c623dbd169c35bfebd#eventlog
