### PR TITLE
Fix the height of notification

### DIFF
--- a/components/TransactionNotification/TransactionNotification.tsx
+++ b/components/TransactionNotification/TransactionNotification.tsx
@@ -16,7 +16,7 @@ const NotificationPending = () => {
 	return (
 		<NotificationContainer>
 			<IconContainer>
-				<Spinner width={25} />
+				<Spinner width={35} height={35} />
 			</IconContainer>
 			<TransactionInfo>{i18n.t('common.transaction.transaction-sent')}</TransactionInfo>
 		</NotificationContainer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue #857

## Related issue
https://github.com/Kwenta/kwenta/issues/857

## Motivation and Context
The layout of transaction pending notification not correct, so I change the size of spinner.

## How Has This Been Tested?
Make a deposit or withdraw, then you will see the notification.

## Screenshots (if appropriate):
<img width="621" alt="Screenshot 2022-05-20 at 19 19 42" src="https://user-images.githubusercontent.com/668344/169572304-f54d3b53-eebd-4859-a17d-cbb3fd53b777.png">

