### PR TITLE
Improve Data Responsiveness

### DIFF
--- a/pages/market/[[...market]].tsx
+++ b/pages/market/[[...market]].tsx
@@ -33,13 +33,12 @@ const Market = () => {
 	const { network } = Connector.useContainer();
 
 	const futuresMarketPositionQuery = useGetFuturesPositionForMarket(
-		getMarketKey(marketAsset, network.id),
-		{ refetchInterval: 6000 }
+		getMarketKey(marketAsset, network.id)
 	);
 
 	const futuresMarketPosition = futuresMarketPositionQuery?.data ?? null;
 
-	const openOrdersQuery = useGetFuturesOpenOrders(marketAsset, { refetchInterval: 6000 });
+	const openOrdersQuery = useGetFuturesOpenOrders(marketAsset);
 	const openOrders = openOrdersQuery?.data ?? [];
 
 	const refetch = useCallback(() => {

--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -82,6 +82,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 		},
 		{
 			enabled: isWalletConnected ? isL2 && isReady : isReady,
+			refetchInterval: 15000,
 			...options,
 		}
 	);

--- a/queries/futures/useGetFuturesOpenOrders.ts
+++ b/queries/futures/useGetFuturesOpenOrders.ts
@@ -59,7 +59,11 @@ const useGetFuturesOpenOrders = (currencyKey: string | null, options?: UseQueryO
 				return null;
 			}
 		},
-		{ enabled: isAppReady && isL2 && !!currencyKey && !!walletAddress, ...options }
+		{
+			enabled: isAppReady && isL2 && !!currencyKey && !!walletAddress,
+			refetchInterval: 5000,
+			...options,
+		}
 	);
 };
 

--- a/queries/futures/useGetFuturesPositionForAccount.ts
+++ b/queries/futures/useGetFuturesPositionForAccount.ts
@@ -39,6 +39,7 @@ const useGetFuturesPositionForAccount = (options?: UseQueryOptions<any>) => {
 		},
 		{
 			enabled: isAppReady && isL2 && !!walletAddress,
+			refetchInterval: 5000,
 			...options,
 		}
 	);

--- a/queries/futures/useGetFuturesPositionForMarket.ts
+++ b/queries/futures/useGetFuturesPositionForMarket.ts
@@ -45,6 +45,7 @@ const useGetFuturesPositionForMarket = (
 		},
 		{
 			enabled: isAppReady && isL2 && !!walletAddress && !!market && !!synthetixjs,
+			refetchInterval: 5000,
 			...options,
 		}
 	);

--- a/queries/futures/useGetFuturesTrades.ts
+++ b/queries/futures/useGetFuturesTrades.ts
@@ -60,7 +60,7 @@ const useGetFuturesTrades = (
 		},
 		{
 			enabled: isWalletConnected ? isL2 && isAppReady : isAppReady,
-			refetchInterval: 1500,
+			refetchInterval: 15000,
 			...options,
 		}
 	);

--- a/queries/futures/useGetFuturesTrades.ts
+++ b/queries/futures/useGetFuturesTrades.ts
@@ -58,7 +58,11 @@ const useGetFuturesTrades = (
 				return null;
 			}
 		},
-		{ enabled: isWalletConnected ? isL2 && isAppReady : isAppReady, ...options }
+		{
+			enabled: isWalletConnected ? isL2 && isAppReady : isAppReady,
+			refetchInterval: 1500,
+			...options,
+		}
 	);
 };
 

--- a/queries/futures/useGetNextPriceDetails.ts
+++ b/queries/futures/useGetNextPriceDetails.ts
@@ -76,7 +76,11 @@ const useGetNextPriceDetails = (
 				return null;
 			}
 		},
-		{ enabled: isAppReady && isL2 && !!currencyKey && !!walletAddress, ...options }
+		{
+			enabled: isAppReady && isL2 && !!currencyKey && !!walletAddress,
+			refetchInterval: 5000,
+			...options,
+		}
 	);
 };
 

--- a/queries/rates/useExchangeRatesQuery.ts
+++ b/queries/rates/useExchangeRatesQuery.ts
@@ -55,6 +55,7 @@ const useExchangeRatesQuery = (options?: UseQueryOptions<Rates>) => {
 		},
 		{
 			enabled: isAppReady && !!synthetixjs,
+			refetchInterval: 60000,
 			...options,
 		}
 	);

--- a/queries/rates/useExternalPriceQuery.ts
+++ b/queries/rates/useExternalPriceQuery.ts
@@ -57,6 +57,7 @@ const useExternalPriceQuery = (
 		},
 		{
 			enabled: !!baseCurrencyKey,
+			refetchInterval: 6000,
 			...options,
 		}
 	);

--- a/queries/rates/useExternalPriceQuery.ts
+++ b/queries/rates/useExternalPriceQuery.ts
@@ -57,7 +57,7 @@ const useExternalPriceQuery = (
 		},
 		{
 			enabled: !!baseCurrencyKey,
-			refetchInterval: 6000,
+			refetchInterval: 60000,
 			...options,
 		}
 	);

--- a/queries/rates/useLaggedDailyPrice.ts
+++ b/queries/rates/useLaggedDailyPrice.ts
@@ -57,7 +57,7 @@ const useLaggedDailyPrice = (synths: string[], options?: UseQueryOptions<any | n
 				return null;
 			}
 		},
-		{ enabled: isAppReady && synths.length > 0, ...options }
+		{ enabled: isAppReady && synths.length > 0, refetchInterval: 60000, ...options }
 	);
 };
 

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -36,7 +36,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ baseCurrencyKey }) => {
 	const { t } = useTranslation();
 	const { network } = Connector.useContainer();
 
-	const futuresMarketsQuery = useGetFuturesMarkets({ refetchInterval: 6000 });
+	const futuresMarketsQuery = useGetFuturesMarkets();
 	const futuresTradingVolumeQuery = useGetFuturesTradingVolume(baseCurrencyKey);
 
 	const marketSummary: FuturesMarket | null =

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -54,9 +54,7 @@ type PositionData = {
 const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, currencyKeyRate }) => {
 	const { t } = useTranslation();
 	const positionDetails = position?.position ?? null;
-	const futuresPositionsQuery = useGetFuturesPositionForAccount({
-		refetchInterval: 6000,
-	});
+	const futuresPositionsQuery = useGetFuturesPositionForAccount();
 	const { isFuturesMarketClosed } = useFuturesMarketClosed(currencyKey as CurrencyKey);
 
 	const futuresPositions = futuresPositionsQuery?.data ?? null;

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -80,7 +80,9 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 
 	const data: PositionData = React.useMemo(() => {
 		const pnl = positionDetails?.profitLoss.add(positionDetails?.accruedFunding) ?? zeroBN;
-		const realizedPnl = positionHistory?.pnl.add(positionHistory?.netFunding).sub(positionHistory?.feesPaid) ?? zeroBN;
+		const realizedPnl =
+			positionHistory?.pnl.add(positionHistory?.netFunding).sub(positionHistory?.feesPaid) ??
+			zeroBN;
 		const netFunding =
 			positionDetails?.accruedFunding.add(positionHistory?.netFunding ?? zeroBN) ?? zeroBN;
 		const lastPriceWei = wei(currencyKeyRate) ?? zeroBN;

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -80,7 +80,7 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 
 	const data: PositionData = React.useMemo(() => {
 		const pnl = positionDetails?.profitLoss.add(positionDetails?.accruedFunding) ?? zeroBN;
-		const realizedPnl = positionHistory?.pnl.add(positionHistory?.netFunding) ?? zeroBN;
+		const realizedPnl = positionHistory?.pnl.add(positionHistory?.netFunding).sub(positionHistory?.feesPaid) ?? zeroBN;
 		const netFunding =
 			positionDetails?.accruedFunding.add(positionHistory?.netFunding ?? zeroBN) ?? zeroBN;
 		const lastPriceWei = wei(currencyKeyRate) ?? zeroBN;

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -54,7 +54,9 @@ type PositionData = {
 const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, currencyKeyRate }) => {
 	const { t } = useTranslation();
 	const positionDetails = position?.position ?? null;
-	const futuresPositionsQuery = useGetFuturesPositionForAccount();
+	const futuresPositionsQuery = useGetFuturesPositionForAccount({
+		refetchInterval: 6000,
+	});
 	const { isFuturesMarketClosed } = useFuturesMarketClosed(currencyKey as CurrencyKey);
 
 	const futuresPositions = futuresPositionsQuery?.data ?? null;
@@ -261,9 +263,7 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 				<DataCol>
 					<InfoRow>
 						<StyledSubtitle>{data.marketShortName}</StyledSubtitle>
-						<StyledValue>
-							{data.marketPrice}
-						</StyledValue>
+						<StyledValue>{data.marketPrice}</StyledValue>
 					</InfoRow>
 					<InfoRow>
 						<StyledSubtitle>{t('futures.market.position-card.position-side')}</StyledSubtitle>

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -261,9 +261,7 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 				<DataCol>
 					<InfoRow>
 						<StyledSubtitle>{data.marketShortName}</StyledSubtitle>
-						<StyledValue
-							className={data.price24h > zeroBN ? 'green' : data.price24h < zeroBN ? 'red' : ''}
-						>
+						<StyledValue>
 							{data.marketPrice}
 						</StyledValue>
 					</InfoRow>

--- a/sections/futures/PositionChart/PositionChart.tsx
+++ b/sections/futures/PositionChart/PositionChart.tsx
@@ -24,7 +24,7 @@ export default function PositionChart({ marketAsset, potentialTrade }: Props) {
 	);
 	const potentialTradeDetails = useGetFuturesPotentialTradeDetails(marketAsset, potentialTrade);
 
-	const futuresPositionsQuery = useGetFuturesPositionForAccount({ refetchInterval: 5000 });
+	const futuresPositionsQuery = useGetFuturesPositionForAccount();
 	const positionHistory = futuresPositionsQuery?.data ?? [];
 	const subgraphPosition = positionHistory.find((p) => p.isOpen && p.asset === marketAsset);
 	const futuresMarketsPosition = futuresMarketPositionQuery?.data ?? null;

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -43,7 +43,7 @@ const OpenOrdersTable: React.FC<OpenOrdersTableProps> = ({
 
 	const gasPrice = ethGasPriceQuery.data != null ? ethGasPriceQuery.data[gasSpeed] : undefined;
 
-	const nextPriceDetailsQuery = useGetNextPriceDetails(currencyKey, { refetchInterval: 6000 });
+	const nextPriceDetailsQuery = useGetNextPriceDetails(currencyKey);
 	const nextPriceDetails = nextPriceDetailsQuery.data;
 
 	const cancelOrExecuteOrderTxn = useSynthetixTxn(

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-foreign-prop-types */
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { castArray } from 'lodash';
 import { useRouter } from 'next/router';
@@ -106,6 +106,17 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset, position, openOrders, 
 	const handleOpenProfitCalc = useCallback(() => {
 		setOpenProfitCalcModal(!openProfitCalcModal);
 	}, [openProfitCalcModal]);
+
+	const refetchTrades = useCallback(() => {
+		futuresTradesQuery.refetch();
+		marginTransfersQuery.refetch();
+	}, [futuresTradesQuery, marginTransfersQuery]);
+
+	useEffect(() => {
+		refetchTrades();
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [position]);
 
 	const TABS = useMemo(
 		() => [

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -56,18 +56,14 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset, position, openOrders, 
 
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery({
-		refetchInterval: 6000,
+		refetchInterval: 15000,
 	});
 
-	const futuresMarketsQuery = useGetFuturesMarkets({
-		refetchInterval: 6000,
-	});
+	const futuresMarketsQuery = useGetFuturesMarkets();
 	const futuresMarkets = futuresMarketsQuery?.data ?? [];
 	const otherFuturesMarkets = futuresMarkets.filter((market) => market.asset !== marketAsset) ?? [];
 
-	const futuresPositionQuery = useGetFuturesPositionForAccount({
-		refetchInterval: 6000,
-	});
+	const futuresPositionQuery = useGetFuturesPositionForAccount();
 	const futuresPositionHistory = futuresPositionQuery?.data ?? [];
 
 	const [openProfitCalcModal, setOpenProfitCalcModal] = useState<boolean>(false);

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -52,14 +52,22 @@ type UserInfoProps = {
 
 const UserInfo: React.FC<UserInfoProps> = ({ marketAsset, position, openOrders, refetch }) => {
 	const router = useRouter();
-	const { useExchangeRatesQuery } = useSynthetixQueries();
-	const exchangeRatesQuery = useExchangeRatesQuery();
 	const walletAddress = useRecoilValue(walletAddressState);
-	const futuresMarketsQuery = useGetFuturesMarkets();
+
+	const { useExchangeRatesQuery } = useSynthetixQueries();
+	const exchangeRatesQuery = useExchangeRatesQuery({
+		refetchInterval: 6000,
+	});
+
+	const futuresMarketsQuery = useGetFuturesMarkets({
+		refetchInterval: 6000,
+	});
 	const futuresMarkets = futuresMarketsQuery?.data ?? [];
 	const otherFuturesMarkets = futuresMarkets.filter((market) => market.asset !== marketAsset) ?? [];
 
-	const futuresPositionQuery = useGetFuturesPositionForAccount();
+	const futuresPositionQuery = useGetFuturesPositionForAccount({
+		refetchInterval: 6000,
+	});
 	const futuresPositionHistory = futuresPositionQuery?.data ?? [];
 
 	const [openProfitCalcModal, setOpenProfitCalcModal] = useState<boolean>(false);


### PR DESCRIPTION
Improving data responsiveness by adding incremental refetching of data where necessary. This PR also includes some small changes to the position card that were discovered during this work.

## Description
- Added default refetching intervals for important data hooks (markets, trades, positions, orders, etc.)
- Removed refetch interval specification from components
- Changed price color on position card to white
- Subtracting fees from realized pnl on the position card

## Related issue
- #871 

## Motivation and Context
The data on the interface is unresponsive in a lot of cases. Simple examples are the trades/transfers tables not updating when a user submits a transaction. Other issues are prices getting out of sync since some oracle prices update regularly but others remain constant.  

## How Has This Been Tested?
I tested by taking out testnet positions and ensuring that all data updates within ~15 seconds of the transaction confirmation. I also left the page open for a long period of time (~15 minutes, or until at least one oracle update) to check that all data updates over time.
