### PR TITLE
Fix Dashboard Unrealized Pnl

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -61,9 +61,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 						avgEntryPrice: positionHistory?.entryPrice ?? NO_VALUE,
 						liquidationPrice: position?.position?.liquidationPrice,
 						pnl: position?.position?.profitLoss.add(position?.position?.accruedFunding),
-						pnlPct: position?.position?.profitLoss.div(
-							position?.position?.initialMargin.mul(position?.position?.initialLeverage)
-						),
+						pnlPct: position?.position?.profitLoss
+							.add(position?.position?.accruedFunding)
+							.div(position?.position?.initialMargin),
 						margin: position.accessibleMargin,
 						leverage: position?.position?.leverage,
 						isSuspended: market?.isSuspended,

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -174,9 +174,7 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 							{`${formatCurrency(Synths.sUSD, pnl, {
 								sign: '$',
 								minDecimals: pnl.abs().lt(0.01) ? 4 : 2,
-							})} (${formatPercent(
-								positionDetails.profitLoss.div(positionDetails.initialMargin)
-							)})`}
+							})} (${formatPercent(pnl.div(positionDetails.initialMargin))})`}
 						</HoverTransform>
 					</PositionCardTooltip>
 				) : (


### PR DESCRIPTION
The pnl shown on the `FuturesPositionTable` on the dashboard and user info incorrectly multiplies initial margin by leverage. 

## Description
Update calculations of unrealized pnl to match between the two locations:
- Remove the multiplication of margin by leverage
- Add accrued funding to table pnl

## Related issue
- #845 

## Motivation and Context
Accuracy 🎯 

## How Has This Been Tested?
Opened a testnet position and waited for an oracle update.

## Screenshots (if appropriate):
<img width="868" alt="image" src="https://user-images.githubusercontent.com/10401554/170101716-8c8dcf38-49e7-4f54-b896-18d7fa0dae9d.png">

<img width="932" alt="image" src="https://user-images.githubusercontent.com/10401554/170101765-bd5ec787-0341-433d-8a7c-000895b6f1bf.png">


