### PR TITLE
Fix Nav Highlighting

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/Nav/Nav.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Nav/Nav.tsx
@@ -40,13 +40,10 @@ const Nav: FC = () => {
 		<nav>
 			<MenuLinks>
 				{menuLinks.map(({ i18nLabel, link }) => {
-					const isActive =
-						asPath === link ||
-						(asPath.includes('dashboard') && link.includes('dashboard')) ||
-						(asPath.includes('market') && link.includes('market')) ||
-						(asPath.includes('exchange') && link.includes('exchange')) ||
-						(asPath.includes('leaderboard') && link.includes('leaderboard')) ||
-						(asPath.includes('earn') && link.includes('earn'));
+					const routeBase = asPath.split('/')[1];
+					const linkBase = link.split('/')[1];
+					const isActive = routeBase === linkBase;
+
 					return (
 						<MenuLinkItem key={`${getLink(link)}`} isActive={isActive}>
 							<Link href={`${getLink(link)}`}>


### PR DESCRIPTION
Nav highlights "futures" when the "Markets" section is selected on the dashboard.

<img width="553" alt="image" src="https://user-images.githubusercontent.com/10401554/170104205-602f2117-505d-47ee-8ac8-3053c627d190.png">

## Description
Update the string matching to the root of the route to avoid this collision.

## Screenshots (if appropriate):
<img width="585" alt="image" src="https://user-images.githubusercontent.com/10401554/170104333-0661a635-4321-4b0c-b179-000ca671357a.png">
