### PR TITLE
chore: fix updateDependency workflow

### DIFF
--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.17.1'
+          node-version: '16.15.0'
       - name: npm update
-        run: npm install -g npm@7.19.0
+        run: npm install -g npm@8.6.0
       - name: Update @synthetixio/contracts-interface dependency
         run: |
           npm install --legacy-peer-deps --no-audit
@@ -23,4 +23,4 @@ jobs:
         run: |
           git config --global user.email "team@synthetix.io" && git config --global user.name "Synthetix Team"
           git commit -am 'contracts-interface@${{ github.event.client_payload.version }}'
-          git push origin dev
+          git push origin v2-dev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Blocker
To work, this has to be merged into the default branch once we removed v1

## Description
Dependencies with Synthetix are not upgraded automatically anymore. This PR tries to fix the respective workflow.
