### PR TITLE
Disabled shorting on L2

### DIFF
--- a/sections/shorting/ManageShort/ManageShort.tsx
+++ b/sections/shorting/ManageShort/ManageShort.tsx
@@ -111,7 +111,6 @@ const ManageShort: FC = () => {
 			: [];
 	}, [t, activeTab, router, short?.id]);
 
-	const leftTabs = useMemo(() => TABS.filter((tab) => !tab.isClosePosition), [TABS]);
 	const closeTab = useMemo(() => TABS.find((tab) => tab.isClosePosition), [TABS]);
 
 	const nextInteractionDate = useMemo(
@@ -154,11 +153,6 @@ const ManageShort: FC = () => {
 					<PositionCard short={short} inputAmount={inputAmount} activeTab={activeTab} />
 					<FlexDivRow>
 						<StyledTabList>
-							{leftTabs.map(({ name, label, active, onClick }) => (
-								<StyledTabButton key={name} name={name} active={active} onClick={onClick}>
-									{label}
-								</StyledTabButton>
-							))}
 							{closeTab != null ? (
 								<CloseTabButton
 									name={closeTab.name}
@@ -213,8 +207,6 @@ const ManageShort: FC = () => {
 };
 
 const Container = styled.div``;
-
-const StyledTabButton = styled(TabButton)``;
 
 const CloseTabButton = styled(TabButton)<{ active: boolean }>`
 	color: ${(props) => (props.active ? props.theme.colors.white : props.theme.colors.red)};

--- a/sections/shorting/ManageShort/ManageShort.tsx
+++ b/sections/shorting/ManageShort/ManageShort.tsx
@@ -167,7 +167,7 @@ const ManageShort: FC = () => {
 					<TabsContainer>
 						<TabPanelsContainer interactionDisabled={interactionDisabled}>
 							{TABS.map(({ name }) => (
-								<TabPanel key={name} name={name} activeTab={activeTab}>
+								<TabPanel key={name} name={name} activeTab={ShortingTab.ClosePosition}>
 									<ManageShortAction
 										tab={name}
 										isActive={name === activeTab}

--- a/sections/shorting/ShortingCard/ShortingCard.tsx
+++ b/sections/shorting/ShortingCard/ShortingCard.tsx
@@ -1,56 +1,28 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 
-import { Synths } from 'constants/currency';
-
 import media from 'styles/media';
 
-import CRatioSelector from './components/CRatioSelector';
-
-import useShort from '../hooks/useShort';
-
-import { CurrencyCardsSelector, ExchangeCardsWithSelector } from 'styles/common';
-
 import { useTranslation, Trans } from 'react-i18next';
-import { useRecoilValue } from 'recoil';
-import { isL2State } from 'store/wallet';
 
 import { MessageContainer, Message, MessageButton } from '../common';
-import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
+import Link from 'next/link';
 
 const ShortingCard: FC = () => {
-	const { quoteCurrencyCard, baseCurrencyCard, footerCard } = useShort({
-		defaultBaseCurrencyKey: Synths.sETH,
-		defaultQuoteCurrencyKey: Synths.sUSD,
-	});
-
 	const { t } = useTranslation();
-	const isL2 = useRecoilValue(isL2State);
-	const { switchToL2 } = useNetworkSwitcher();
 
 	return (
 		<Container>
-			{isL2 ? (
-				<ConvertContainer>
-					<ExchangeCardsWithSelector>
-						{quoteCurrencyCard}
-						{baseCurrencyCard}
-						<StyledCurrencyCardsSelector>
-							<CRatioSelector />
-						</StyledCurrencyCardsSelector>
-					</ExchangeCardsWithSelector>
-					<ExchangeFooter>{footerCard}</ExchangeFooter>
-				</ConvertContainer>
-			) : (
-				<MessageContainer>
-					<Message>
-						<Trans t={t} i18nKey="shorting.l1-deprecated" />
-					</Message>
-					<MessageButton size="lg" variant="primary" isRounded={true} onClick={switchToL2}>
-						{t('header.networks-switcher.l2')}
+			<MessageContainer>
+				<Message>
+					<Trans t={t} i18nKey="shorting.deprecated" />
+				</Message>
+				<Link href="https://v2.beta.kwenta.io/">
+					<MessageButton size="lg" variant="primary" isRounded={true}>
+						{t('shorting.visit-futures')}
 					</MessageButton>
-				</MessageContainer>
-			)}
+				</Link>
+			</MessageContainer>
 		</Container>
 	);
 };
@@ -62,12 +34,6 @@ const Container = styled.div`
 		// TODO: this is needed to cancel the content "push" that comes content from "TradeSummaryCard" (on tablet/mobile)
 		margin-bottom: -50px;
 	`}
-`;
-
-const ConvertContainer = styled.div``;
-
-const StyledCurrencyCardsSelector = styled(CurrencyCardsSelector)`
-	width: 70px;
 `;
 
 export const ExchangeFooter = styled.div`

--- a/translations/en.json
+++ b/translations/en.json
@@ -519,7 +519,8 @@
 				"accrued-interest": "Accrued Interest"
 			}
 		},
-		"l1-deprecated": "Shorting on L1 is deprecated; please switch to L2, or manage your L1 positions below."
+		"deprecated": "Shorting has been disabled; you can short using Futures or manage your existing positions below.",
+		"visit-futures": "Visit Futures"
 
 	},
 	"not-found": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Shorting has been disabled by Synthetix last night on L2, so we should extend our existing L1 message to L2.

## Related issue
#895 

## Motivation and Context
Improve the UX and guide the user to V2 futures.

## How Has This Been Tested?
1. Switch the network to L2/L1 and see the `disabled shorting` message
2. Click the `pencil` icon and show the `closePosition` panel.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/170481921-037449dd-e2a1-42b2-8b1b-34aa9f9f6322.png)
![image](https://user-images.githubusercontent.com/4819006/170481972-89cae594-3d79-4f38-ab8f-36b7c52ed6f1.png)
![image](https://user-images.githubusercontent.com/4819006/170533449-1795c1be-3f0f-49cb-8823-2f4fd5bf30f9.png)

