### PR TITLE
fix: align trading history table

### DIFF
--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -192,16 +192,15 @@ const TableHeader = styled(CapitalizedText)`
 
 const PriceValue = styled(NumericValue)`
 	font-size: 11px;
-	padding-left: 5px;
 `;
 
 const TimeValue = styled.p`
 	font-family: ${(props) => props.theme.fonts.regular};
 	text-decoration: underline;
-	padding-left: 10px;
 `;
 
 const DirectionalValue = styled(PriceValue)<{ negative?: boolean; normal?: boolean }>`
+	padding-left: 4px;
 	color: ${(props) =>
 		props.normal
 			? props.theme.colors.common.primaryWhite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Align Trading history table rows and header

## Related issue
PR closes #884 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screen Shot 2022-05-26 at 10 19 13 PM](https://user-images.githubusercontent.com/11361147/170507115-fbf9a62d-0c80-457c-89a7-1bd357116db7.png)

