### PR TITLE
Add timeframes

### DIFF
--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -15,7 +15,21 @@ import { combineDataToPair } from 'sections/exchange/TradeCard/Charts/hooks/useC
 import { getDisplayAsset } from 'utils/futures';
 import { resolutionToSeconds } from './utils';
 
-const supportedResolutions = ['1', '5', '15', '60', '1D'] as ResolutionString[];
+const supportedResolutions = [
+	'1',
+	'5',
+	'15',
+	'30',
+	'60',
+	'120',
+	'240',
+	'480',
+	'720',
+	'1D',
+	'3D',
+	'7D',
+	'30D',
+] as ResolutionString[];
 
 const config = {
 	supports_search: false,

--- a/components/TVChart/utils.ts
+++ b/components/TVChart/utils.ts
@@ -1,10 +1,19 @@
 import { ResolutionString } from 'public/static/charting_library/charting_library';
 
 export const resolutionToSeconds = (resolution: ResolutionString): number => {
-	if (!Number.isNaN(resolution)) {
+	if (!isNaN(Number(resolution))) {
 		return Number(resolution) * 60;
 	} else {
-		const period = resolution === '1D' ? 86400 : 3600;
+		const period =
+			resolution === '1D'
+				? 86400
+				: resolution === '3D'
+				? 86400 * 3
+				: resolution === '7D'
+				? 86400 * 7
+				: resolution === '30D'
+				? 86400 * 30
+				: 3600;
 		return period;
 	}
 };


### PR DESCRIPTION
Add timeframes to the TradingView chart

## Description
Adding new resolutions to the Tradingview config

## Related issue
- #773 

## How Has This Been Tested?
At the moment this was tested pointing at my personal deployment of the subgraph ([link](https://thegraph.com/hosted-service/subgraph/tburm/optimism-latest-rates))

Will test again when the production subgraph is synced ([link](https://thegraph.com/hosted-service/subgraph/kwenta/optimism-latest-rates))

## Screenshots (if appropriate):
<img width="858" alt="image" src="https://user-images.githubusercontent.com/10401554/171285742-381c0b4a-c36f-4cac-97cb-111a9b2c9f3e.png">
