### PR TITLE
Fixed the broken APE and DYDX exchange rate

### DIFF
--- a/queries/rates/useExchangeRatesQuery.ts
+++ b/queries/rates/useExchangeRatesQuery.ts
@@ -18,7 +18,7 @@ type CurrencyRate = BigNumberish;
 type SynthRatesTuple = [string[], CurrencyRate[]];
 
 // Additional commonly used currencies to fetch, besides the one returned by the SynthUtil.synthsRates
-const additionalCurrencies = [CRYPTO_CURRENCY_MAP.SNX, 'XAU', 'XAG'].map(
+const additionalCurrencies = [CRYPTO_CURRENCY_MAP.SNX, 'XAU', 'XAG', 'DYDX', 'APE'].map(
 	ethers.utils.formatBytes32String
 );
 

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -174,7 +174,7 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position, c
 	}, [router.events]);
 
 	const onTradeAmountSUSDChange = (value: string) => {
-		const valueIsNull = value === '' || Number(value) === 0;
+		const valueIsNull = marketAssetRate.eq(0) || value === '' || Number(value) === 0;
 		const size = valueIsNull ? '' : wei(value).div(marketAssetRate).toNumber().toString();
 		const leverage = valueIsNull
 			? ''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
APE and DYDX markets inputs do not work because of missing `marketAssetRate`.

## Related issue
#924 

## Motivation and Context
Add the price feed for the new listing asset.

## How Has This Been Tested?
1. Open the position for APE and DYDX

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/171651563-0ee85c58-a0e3-4523-aa53-feb454557071.png)
