### PR TITLE
Fixed the price display of position card for dydx and ape

### DIFF
--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -3,7 +3,6 @@ import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { castArray } from 'lodash';
 import { useRouter } from 'next/router';
-import useSynthetixQueries from '@synthetixio/queries';
 
 import { TabPanel } from 'components/Tab';
 import TabButton from 'components/Button/TabButton';
@@ -32,6 +31,7 @@ import { FuturesTrade } from 'queries/futures/types';
 import { useRecoilValue } from 'recoil';
 import { walletAddressState } from 'store/wallet';
 import useGetFuturesTradesForAccount from 'queries/futures/useGetFuturesTradesForAccount';
+import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 
 enum FuturesTab {
 	POSITION = 'position',
@@ -54,7 +54,6 @@ const UserInfo: React.FC<UserInfoProps> = ({ marketAsset, position, openOrders, 
 	const router = useRouter();
 	const walletAddress = useRecoilValue(walletAddressState);
 
-	const { useExchangeRatesQuery } = useSynthetixQueries();
 	const exchangeRatesQuery = useExchangeRatesQuery({
 		refetchInterval: 15000,
 	});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The price of new listing assets is not displayed on the position card.

## Related issue
#925 

## Motivation and Context
For the better UX

## How Has This Been Tested?
1. Open the position and see if the price is displayed correctly on the position card.
2. Open the profit calculator and see if the price is displayed correctly

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/171669010-da84fa9b-cba9-4a66-9d94-1839d0221bea.png)
![image](https://user-images.githubusercontent.com/4819006/171669284-daf8d040-d305-4219-afbe-6dd4157d15c1.png)


