### PR TITLE
Add dydx and ape to coingecko id map

### DIFF
--- a/queries/rates/utils.ts
+++ b/queries/rates/utils.ts
@@ -81,6 +81,8 @@ const markets = [
 	'sXAU',
 	'sXAG',
 	'sWTI',
+	'sDYDX',
+	'sAPE',
 ] as const;
 
 const map: Record<typeof markets[number], string> = {
@@ -96,6 +98,8 @@ const map: Record<typeof markets[number], string> = {
 	sXAU: '',
 	sXAG: '',
 	sWTI: '',
+	sDYDX: 'dydx',
+	sAPE: 'apecoin',
 };
 
 export const synthToCoingeckoPriceId = (synth: any) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The external price of DYDX and APE is wrong. The root cause is that ape and dydx haven't been added to the latest id mapping file `quereris/rates/utils.ts`.

## Related issue
#925 

## Motivation and Context
Improve the UX.

## How Has This Been Tested?
Open the ape and dydx market to check the external price.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/171685623-6fa23a44-2251-42a0-87cd-4eb7372a9340.png)
![image](https://user-images.githubusercontent.com/4819006/171685655-c7aaf8ef-20dc-4240-9494-4e792573e4d0.png)
