### PR TITLE
Change position card order

### DIFF
--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -241,6 +241,22 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 						<PositionCardTooltip
 							preset="bottom"
 							height={'auto'}
+							content={t('futures.market.position-card.tooltips.u-pnl')}
+						>
+							<StyledSubtitle>{t('futures.market.position-card.u-pnl')}</StyledSubtitle>
+						</PositionCardTooltip>
+						{positionDetails ? (
+							<StyledValue className={data.pnl > zeroBN ? 'green' : data.pnl < zeroBN ? 'red' : ''}>
+								{data.pnlText}
+							</StyledValue>
+						) : (
+							<StyledValue>{NO_VALUE}</StyledValue>
+						)}
+					</InfoRow>
+					<InfoRow>
+						<PositionCardTooltip
+							preset="bottom"
+							height={'auto'}
 							content={t('futures.market.position-card.tooltips.r-pnl')}
 						>
 							<StyledSubtitleWithCursor>
@@ -258,18 +274,6 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 						) : (
 							<StyledValue>{NO_VALUE}</StyledValue>
 						)}
-					</InfoRow>
-					<InfoRow>
-						<PositionCardTooltip
-							preset="bottom"
-							height={'auto'}
-							content={t('futures.market.position-card.tooltips.liquidation-price')}
-						>
-							<StyledSubtitleWithCursor>
-								{t('futures.market.position-card.liquidation-price')}
-							</StyledSubtitleWithCursor>
-						</PositionCardTooltip>
-						<StyledValue>{data.liquidationPrice}</StyledValue>
 					</InfoRow>
 				</DataCol>
 				<DataColDivider />
@@ -290,17 +294,13 @@ const PositionCard: React.FC<PositionCardProps> = ({ currencyKey, position, curr
 						<PositionCardTooltip
 							preset="bottom"
 							height={'auto'}
-							content={t('futures.market.position-card.tooltips.u-pnl')}
+							content={t('futures.market.position-card.tooltips.liquidation-price')}
 						>
-							<StyledSubtitle>{t('futures.market.position-card.u-pnl')}</StyledSubtitle>
+							<StyledSubtitleWithCursor>
+								{t('futures.market.position-card.liquidation-price')}
+							</StyledSubtitleWithCursor>
 						</PositionCardTooltip>
-						{positionDetails ? (
-							<StyledValue className={data.pnl > zeroBN ? 'green' : data.pnl < zeroBN ? 'red' : ''}>
-								{data.pnlText}
-							</StyledValue>
-						) : (
-							<StyledValue>{NO_VALUE}</StyledValue>
-						)}
+						<StyledValue>{data.liquidationPrice}</StyledValue>
 					</InfoRow>
 					<InfoRow>
 						<LeftMarginTooltip


### PR DESCRIPTION
Move the uPnL value to reduce confusion

## Description
The uPnL value was directly above the "avg entry price" value, however the two are not related. It could cause trader confusion for the values to be seated next to each other.

This change moves the uPnL above the rPnL and the liquidation price above the avg entry price.

## Related issue
- #845 

## Screenshots (if appropriate):
<img width="869" alt="image" src="https://user-images.githubusercontent.com/10401554/171698047-5a42ee39-32fe-440a-90bb-01c0bb929539.png">
