### PR TITLE
Bump dependabot limit to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" 
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     target-branch: "v2-dev"
     schedule:
       interval: "daily"
@@ -11,7 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     target-branch: "v2-dev"
     allow:
       - dependency-name: "synthetix-*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumps dependabot daily limit to 3 PRs for both `github-actions` and `npm`.  

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
