### PR TITLE
Fix Buying Power Bug

### DIFF
--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -326,8 +326,8 @@ const Trade: React.FC<TradeProps> = ({ refetch, onEditPositionInput, position, c
 				totalMargin={position?.remainingMargin ?? zeroBN}
 				availableMargin={position?.accessibleMargin ?? zeroBN}
 				buyingPower={
-					position && position?.remainingMargin.gt(zeroBN)
-						? position?.remainingMargin?.mul(market?.maxLeverage ?? zeroBN)
+					position && position?.accessibleMargin.gt(zeroBN)
+						? position?.accessibleMargin?.mul(market?.maxLeverage ?? zeroBN)
 						: zeroBN
 				}
 				marginUsage={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bugfix to show correct calculation of Buying Power

## Related issue
closes #944

## Motivation and Context
Buying Power was wrongly calculated by using the total margin, however it should be calculated by available margin as explained in issue #944.
