### PR TITLE
feat: Show Network Fees in USD on L2

### DIFF
--- a/sections/exchange/FooterCard/TradeSummaryCard/TradeSummaryCard.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/TradeSummaryCard.tsx
@@ -22,7 +22,6 @@ import { SummaryItems, SummaryItem, SummaryItemLabel, SummaryItemValue } from '.
 import GasPriceSelect from 'sections/shared/components/GasPriceSelect';
 import FeeRateSummaryItem from 'sections/shared/components/FeeRateSummary';
 import FeeCostSummaryItem from 'sections/shared/components/FeeCostSummary';
-
 import { GasPrices } from '@synthetixio/queries';
 import PoweredBy1Inch from 'components/PoweredBy1Inch';
 import { Synth } from '@synthetixio/contracts-interface';
@@ -81,16 +80,16 @@ const TradeSummaryCard: FC<TradeSummaryCardProps> = ({
 	const summaryItems = (
 		<SummaryItems attached={attached}>
 			<GasPriceSelect gasPrices={gasPrices} transactionFee={transactionFee} />
-			<SummaryItem>
-				{
+			{isCreateShort && (
+				<SummaryItem>
 					<>
 						<SummaryItemLabel>{t('shorting.common.interestRate')}</SummaryItemLabel>
 						<SummaryItemValue data-testid="short-interest-rate">
 							{formatPercent((shortInterestRate ?? 0).toString())}
 						</SummaryItemValue>
 					</>
-				}
-			</SummaryItem>
+				</SummaryItem>
+			)}
 			{showFee && (
 				<>
 					<FeeRateSummaryItem totalFeeRate={totalFeeRate} baseFeeRate={baseFeeRate} />

--- a/sections/exchange/FooterCard/TradeSummaryCard/TradeSummaryCard.tsx
+++ b/sections/exchange/FooterCard/TradeSummaryCard/TradeSummaryCard.tsx
@@ -23,7 +23,6 @@ import GasPriceSelect from 'sections/shared/components/GasPriceSelect';
 import FeeRateSummaryItem from 'sections/shared/components/FeeRateSummary';
 import FeeCostSummaryItem from 'sections/shared/components/FeeCostSummary';
 
-import TotalTradePriceSummaryItem from './TotalTradePriceSummaryItem';
 import { GasPrices } from '@synthetixio/queries';
 import PoweredBy1Inch from 'components/PoweredBy1Inch';
 import { Synth } from '@synthetixio/contracts-interface';
@@ -83,16 +82,14 @@ const TradeSummaryCard: FC<TradeSummaryCardProps> = ({
 		<SummaryItems attached={attached}>
 			<GasPriceSelect gasPrices={gasPrices} transactionFee={transactionFee} />
 			<SummaryItem>
-				{isCreateShort ? (
+				{
 					<>
 						<SummaryItemLabel>{t('shorting.common.interestRate')}</SummaryItemLabel>
 						<SummaryItemValue data-testid="short-interest-rate">
 							{formatPercent((shortInterestRate ?? 0).toString())}
 						</SummaryItemValue>
 					</>
-				) : (
-					<TotalTradePriceSummaryItem totalTradePrice={totalTradePrice} />
-				)}
+				}
 			</SummaryItem>
 			{showFee && (
 				<>

--- a/sections/exchange/FooterCard/common.tsx
+++ b/sections/exchange/FooterCard/common.tsx
@@ -11,6 +11,7 @@ export const SummaryItems = styled.div<{ attached?: boolean }>`
 	grid-auto-flow: column;
 	flex-grow: 1;
 	padding-left: 32px;
+	justify-content: space-between;
 	${media.lessThan('md')`
 		grid-auto-flow: unset;
 		grid-template-columns: auto auto;

--- a/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
+++ b/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
@@ -12,6 +12,7 @@ import { SummaryItem, SummaryItemValue, SummaryItemLabel } from '../common';
 import { GasPrices } from '@synthetixio/queries';
 
 import { parseGasPriceObject } from 'hooks/useGas';
+import { useMemo } from 'react';
 
 type GasPriceSelectProps = {
 	gasPrices: GasPrices | undefined;
@@ -26,13 +27,19 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 	const isMainnet = useRecoilValue(isMainnetState);
 	const isL2 = useRecoilValue(isL2State);
 
+	const formattedTransactionFee = useMemo(() => {
+		return transactionFee
+			? formatCurrency(Synths.sUSD, transactionFee, { sign: '$', maxDecimals: 1 })
+			: NO_VALUE;
+	}, [transactionFee]);
+
 	const hasCustomGasPrice = customGasPrice !== '';
 	const gasPrice = gasPrices ? parseGasPriceObject(gasPrices[gasSpeed]) : null;
 
 	const gasPriceItem = (
 		<span data-testid="gas-price">
 			{isL2
-				? formatCurrency(Synths.sUSD, transactionFee ?? 0, { sign: '$', maxDecimals: 1 })
+				? formattedTransactionFee
 				: `${formatNumber(hasCustomGasPrice ? +customGasPrice : gasPrice ?? 0, {
 						minDecimals: 2,
 				  })} Gwei`}
@@ -46,9 +53,7 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 					? t('common.summary.gas-prices.max-fee')
 					: t('common.summary.gas-prices.gas-price')}
 			</SummaryItemLabel>
-			<SummaryItemValue>
-				{gasPrice != null && transactionFee != null ? gasPriceItem : NO_VALUE}
-			</SummaryItemValue>
+			<SummaryItemValue>{gasPrice != null ? gasPriceItem : NO_VALUE}</SummaryItemValue>
 		</SummaryItem>
 	);
 };

--- a/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
+++ b/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
@@ -11,12 +11,11 @@ import { NO_VALUE } from 'constants/placeholder';
 import InfoIcon from 'assets/svg/app/info.svg';
 
 import { formatCurrency, formatNumber } from 'utils/formatters/number';
-
+import { Synths } from 'constants/currency';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-
 import { SummaryItem, SummaryItemValue, SummaryItemLabel } from '../common';
 import { GasPrices } from '@synthetixio/queries';
-import { CurrencyKey } from 'constants/currency';
+
 import { parseGasPriceObject } from 'hooks/useGas';
 
 type GasPriceSelectProps = {
@@ -36,15 +35,13 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 	const hasCustomGasPrice = customGasPrice !== '';
 	const gasPrice = gasPrices ? parseGasPriceObject(gasPrices[gasSpeed]) : null;
 
-	const formatGasPrice = (price: number) => {
-		const formattedPrice = formatNumber(price, { minDecimals: 4 });
-		return isL2
-			? formatCurrency(selectedPriceCurrency.name as CurrencyKey, formattedPrice, { sign: '$' })
-			: `${formattedPrice} Gwei`;
-	};
 	const gasPriceItem = (
 		<span data-testid="gas-price">
-			{formatGasPrice(hasCustomGasPrice ? +customGasPrice : gasPrice ?? 0)}
+			{isL2
+				? formatCurrency(Synths.sUSD, transactionFee ?? 0, { sign: '$', maxDecimals: 1 })
+				: `${formatNumber(hasCustomGasPrice ? +customGasPrice : gasPrice ?? 0, {
+						minDecimals: 4,
+				  })} Gwei`}
 		</span>
 	);
 
@@ -55,34 +52,7 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 					? t('common.summary.gas-prices.max-fee')
 					: t('common.summary.gas-prices.gas-price')}
 			</SummaryItemLabel>
-			<SummaryItemValue>
-				{gasPrice != null ? (
-					<>
-						{!isL2 && transactionFee != null ? (
-							<GasPriceCostTooltip
-								content={
-									<span>
-										{formatCurrency(selectedPriceCurrency.name as CurrencyKey, transactionFee, {
-											sign: selectedPriceCurrency.sign,
-											maxDecimals: 1,
-										})}
-									</span>
-								}
-								arrow={false}
-							>
-								<GasPriceItem>
-									{gasPriceItem}
-									<InfoIcon />
-								</GasPriceItem>
-							</GasPriceCostTooltip>
-						) : (
-							gasPriceItem
-						)}
-					</>
-				) : (
-					NO_VALUE
-				)}
-			</SummaryItemValue>
+			<SummaryItemValue>{gasPrice != null ? gasPriceItem : NO_VALUE}</SummaryItemValue>
 		</SummaryItem>
 	);
 };

--- a/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
+++ b/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
@@ -34,7 +34,7 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 			{isL2
 				? formatCurrency(Synths.sUSD, transactionFee ?? 0, { sign: '$', maxDecimals: 1 })
 				: `${formatNumber(hasCustomGasPrice ? +customGasPrice : gasPrice ?? 0, {
-						minDecimals: 4,
+						minDecimals: 2,
 				  })} Gwei`}
 		</span>
 	);

--- a/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
+++ b/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
@@ -1,18 +1,13 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
-import Tippy from '@tippyjs/react';
 import { customGasPriceState, gasSpeedState, isL2State, isMainnetState } from 'store/wallet';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import Wei from '@synthetixio/wei';
 
 import { NO_VALUE } from 'constants/placeholder';
 
-import InfoIcon from 'assets/svg/app/info.svg';
-
 import { formatCurrency, formatNumber } from 'utils/formatters/number';
 import { Synths } from 'constants/currency';
-import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { SummaryItem, SummaryItemValue, SummaryItemLabel } from '../common';
 import { GasPrices } from '@synthetixio/queries';
 
@@ -28,7 +23,6 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 	const { t } = useTranslation();
 	const [gasSpeed] = useRecoilState<keyof GasPrices>(gasSpeedState);
 	const [customGasPrice] = useRecoilState(customGasPriceState);
-	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 	const isMainnet = useRecoilValue(isMainnetState);
 	const isL2 = useRecoilValue(isL2State);
 
@@ -56,32 +50,5 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 		</SummaryItem>
 	);
 };
-
-const GasPriceTooltip = styled(Tippy)`
-	border: ${(props) => props.theme.colors.selectedTheme.border};
-	border-radius: 4px;
-	width: 155px;
-	.tippy-content {
-		padding: 0;
-	}
-`;
-
-const GasPriceCostTooltip = styled(GasPriceTooltip)`
-	width: auto;
-	font-size: 12px;
-	.tippy-content {
-		padding: 5px;
-		font-family: ${(props) => props.theme.fonts.mono};
-	}
-`;
-
-const GasPriceItem = styled.span`
-	display: inline-flex;
-	align-items: center;
-	cursor: pointer;
-	svg {
-		margin-left: 5px;
-	}
-`;
 
 export default GasPriceSelect;

--- a/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
+++ b/sections/shared/components/GasPriceSelect/GasPriceSelect.tsx
@@ -46,7 +46,9 @@ const GasPriceSelect: FC<GasPriceSelectProps> = ({ gasPrices, transactionFee, ..
 					? t('common.summary.gas-prices.max-fee')
 					: t('common.summary.gas-prices.gas-price')}
 			</SummaryItemLabel>
-			<SummaryItemValue>{gasPrice != null ? gasPriceItem : NO_VALUE}</SummaryItemValue>
+			<SummaryItemValue>
+				{gasPrice != null && transactionFee != null ? gasPriceItem : NO_VALUE}
+			</SummaryItemValue>
 		</SummaryItem>
 	);
 };

--- a/translations/en.json
+++ b/translations/en.json
@@ -245,7 +245,7 @@
 		"summary-info": {
 			"gas-price-gwei": "gas price (GWEI)",
 			"max-fee-gwei": "Max Fee (GWEI)",
-			"fee": "fee",
+			"fee": "Exchange fee",
 			"fee-cost": "fee cost",
 			"button": {
 				"approve": "approve",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Network gas fee is now displayed in $ on L2
- USD Value field has been removed for L1 and L2 and tool tip has been removed from L2
- When connected to L1, "Gwei" label has been added 

## Related issue


<!--- If it fixes an open issue, please link to the issue here. -->
PR closes #907
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
L2
![Screen Shot 2022-06-06 at 1 16 09 PM](https://user-images.githubusercontent.com/55772762/172211650-318b8f8b-f06c-4dbd-a577-65e6fd9ce8a6.png)


L1
![Screen Shot 2022-06-06 at 1 19 04 PM](https://user-images.githubusercontent.com/55772762/172212051-acffe706-e8f6-48a1-8913-ca4a78901bbb.png)