### PR TITLE
Deprecate exchange v2

### DIFF
--- a/assets/svg/app/link-white.svg
+++ b/assets/svg/app/link-white.svg
@@ -1,4 +1,4 @@
-<svg width="14" height="14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="14" height="14" viewBox="-4 -5 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g filter="url(#a)">
     <path d="M9.244 3.208H4.812V1.656h7.072V8.84h-1.552V4.312l-6.448 6.48-1.12-1.12 6.48-6.464Z" fill="#fff"/>
   </g>

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -29,4 +29,8 @@ export const EXTERNAL_LINKS = {
 		DocsRoot: 'https://docs.kwenta.io/',
 		FeeReclamation: 'https://docs.kwenta.io/resources/fee-reclamation',
 	},
+	KwentaV2: {
+		Home: 'https://v2.beta.kwenta.io/',
+		Exchange: 'https://v2.beta.kwenta.io/exchange',
+	},
 };

--- a/pages/exchange/[[...market]].tsx
+++ b/pages/exchange/[[...market]].tsx
@@ -2,8 +2,7 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Svg } from 'react-optimized-image';
-import { AnimateSharedLayout, AnimatePresence, motion } from 'framer-motion';
-
+import { EXTERNAL_LINKS } from 'constants/links';
 import ArrowsIcon from 'assets/svg/app/arrows.svg';
 import { zIndex } from 'constants/ui';
 import AppLayout from 'sections/shared/Layout/AppLayout';
@@ -25,6 +24,7 @@ import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import useExchange from 'sections/exchange/hooks/useExchange';
 import { CurrencyKey } from 'constants/currency';
 import { DEFAULT_WIDTH } from 'sections/exchange/TradeCard/constants';
+import Banner from 'sections/shared/Layout/AppLayout/Header/Banner';
 
 const ExchangePage = () => {
 	const { t } = useTranslation();
@@ -37,9 +37,6 @@ const ExchangePage = () => {
 		baseCurrencyCard,
 		handleCurrencySwap,
 		footerCard,
-		combinedPriceChartCard,
-		combinedMarketDetailsCard,
-		wideWidth,
 	} = useExchange({
 		showPriceCard: true,
 		showMarketDetailsCard: true,
@@ -75,6 +72,10 @@ const ExchangePage = () => {
 							</SwapCurrenciesButtonContainer>
 
 							<PageWidthContainer>
+								<Banner
+									copy={t('header.banner.exchange-v2')}
+									link={EXTERNAL_LINKS.KwentaV2.Exchange}
+								/>
 								<DesktopCardsContainer>
 									<LeftCardContainer data-testid="left-side">{quoteCurrencyCard}</LeftCardContainer>
 									<RightCardContainer data-testid="right-side">
@@ -85,38 +86,12 @@ const ExchangePage = () => {
 
 							<PageWidthContainer>{footerCard}</PageWidthContainer>
 
-							<AnimateSharedLayout>
-								<ChartsContainer>
-									<AnimatePresence>
-										<motion.div
-											layout
-											initial={{ width: wideWidth }}
-											animate={{ width: DEFAULT_WIDTH }}
-											exit={{ width: wideWidth }}
-											transition={{ ease: 'easeOut' }}
-										>
-											{combinedPriceChartCard}
-										</motion.div>
-									</AnimatePresence>
-								</ChartsContainer>
-
-								<ChartsContainer>
-									<motion.div
-										layout
-										initial={{ width: wideWidth }}
-										animate={{ width: DEFAULT_WIDTH }}
-										exit={{ width: wideWidth }}
-										transition={{ ease: 'easeOut' }}
-									>
-										{combinedMarketDetailsCard}
-									</motion.div>
-								</ChartsContainer>
-							</AnimateSharedLayout>
 							<GitIDFooter />
 						</DesktopContainer>
 					</DesktopOnlyView>
 					<MobileOrTabletView>
 						<MobileContainer>
+							<Banner copy={t('header.banner.exchange-v2')} link={EXTERNAL_LINKS.KwentaV2.Home} />
 							{quoteCurrencyCard}
 							<VerticalSpacer>
 								<SwapCurrenciesButton onClick={handleCurrencySwap} data-testid="swap-btn">
@@ -125,11 +100,6 @@ const ExchangePage = () => {
 							</VerticalSpacer>
 							{baseCurrencyCard}
 							<FooterContainer>{footerCard}</FooterContainer>
-							<>
-								{combinedPriceChartCard}
-								<FooterSpacer />
-								{combinedMarketDetailsCard}
-							</>
 							<GitIDFooter />
 						</MobileContainer>
 					</MobileOrTabletView>
@@ -161,10 +131,6 @@ const StyledPageContent = styled(PageContent)`
 	}
 `;
 
-const ChartsContainer = styled.div`
-	margin: 0 auto 30px;
-`;
-
 const PageWidthContainer = styled.div`
 	width: ${DEFAULT_WIDTH}px;
 	margin: 0 auto;
@@ -186,7 +152,7 @@ const DesktopCardsContainer = styled.div`
 
 const SwapCurrenciesButtonContainer = styled.div`
 	align-self: flex-start;
-	margin-top: 37px;
+	margin-top: 142px;
 	position: absolute;
 	left: calc(50% - 16px);
 	z-index: ${zIndex.BASE + 10};
@@ -217,10 +183,6 @@ const VerticalSpacer = styled.div`
 		transform: translate(-50%, -50%) rotate(90deg);
 		border: 2px solid ${(props) => props.theme.colors.black};
 	}
-`;
-
-const FooterSpacer = styled.div`
-	margin-top: 20px;
 `;
 
 export default ExchangePage;

--- a/sections/shared/Layout/AppLayout/Header/Banner/Banner.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Banner/Banner.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+import Img from 'react-optimized-image';
+import styled from 'styled-components';
+import LinkWhiteIcon from 'assets/svg/app/link-white.svg';
+import media from 'styles/media';
+import { HEADER_HEIGHT } from 'constants/ui';
+
+type BannerProps = {
+	copy: string;
+	link: string;
+};
+
+const Banner: FC<BannerProps> = ({ copy, link }) => {
+	return (
+		<FuturesBannerContainer>
+			<FuturesLink href={link} target="_blank">
+				{copy}
+				<Img src={LinkWhiteIcon} className="banner" />
+			</FuturesLink>
+		</FuturesBannerContainer>
+	);
+};
+
+export default Banner;
+
+const FuturesBannerContainer = styled.div`
+	height: 65px;
+	width: 100%;
+	font-size: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-family: ${(props) => props.theme.fonts.bold};
+
+	${media.lessThan('md')`
+        text-align: center;
+		top: ${HEADER_HEIGHT};
+		margin-bottom: ${HEADER_HEIGHT};
+	`}
+`;
+
+const FuturesLink = styled.a`
+	${media.lessThan('md')`
+        margin: auto;
+        padding: 0px;
+	`}
+`;

--- a/sections/shared/Layout/AppLayout/Header/Banner/index.ts
+++ b/sections/shared/Layout/AppLayout/Header/Banner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Banner';

--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -17,9 +17,12 @@ import { useRecoilValue } from 'recoil';
 import { isL2State } from 'store/wallet';
 import FuturesBordersSvg from 'assets/svg/app/futures-borders.svg';
 import LinkWhiteIcon from 'assets/svg/app/link-white.svg';
+import { EXTERNAL_LINKS } from 'constants/links';
+import { useTranslation } from 'react-i18next';
 
 const Header: FC = () => {
 	const isL2 = useRecoilValue(isL2State);
+	const { t } = useTranslation();
 
 	const logo = <Logo isL2={isL2} />;
 
@@ -28,8 +31,8 @@ const Header: FC = () => {
 			<FuturesBannerContainer>
 				<FuturesBannerLinkWrapper>
 					<>
-						<FuturesLink href="https://v2.beta.kwenta.io/" target="_blank">
-							Perpetual Futures Beta available now
+						<FuturesLink href={EXTERNAL_LINKS.KwentaV2.Home} target="_blank">
+							{t('header.banner.futures-v2')}
 						</FuturesLink>
 						<Img src={LinkWhiteIcon} />
 					</>

--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -81,7 +81,6 @@ const Container = styled.header`
 `;
 
 const FuturesBannerContainer = styled.div`
-	height: 65px;
 	width: 100%;
 	display: flex;
 	align-items: center;

--- a/translations/en.json
+++ b/translations/en.json
@@ -23,6 +23,10 @@
 			"learn-more": "Learn more",
 			"optimism-mainnet": "Optimism",
 			"optimism-testnet": "OΞ Kovan"
+		},
+		"banner": {
+			"exchange-v2": "This version of the exchange is outdated; please exchange synths using the new exchange on Kwenta",
+			"futures-v2": "Perpetual Futures Beta available now"
 		}
 	},
 	"homepage": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We keep a bare-bone v1 exchange version and add a banner informing the user to use the new Kwenta to exchange synths.
Other irrelevant elements should be removed.

## Related issue
#914 

## Motivation and Context
Prep for the official launch of V2

## How Has This Been Tested?
1. Switch to the exchange page and see the banner. 
2. Click on the banner to the new exchange V2.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/172253884-783592aa-fbce-4446-a324-dda9eecd0653.png)
