### PR TITLE
Close Using Next-Price

### DIFF
--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -102,29 +102,33 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 		if (!position || !currencyKey) return [];
 		return [
 			{
-				label: t('futures.market.user.position.modal-close.side'),
+				label: t('futures.market.user.position.modal.order-type'),
+				value: t('futures.market.user.position.modal.market-order'),
+			},
+			{
+				label: t('futures.market.user.position.modal.side'),
 				value: (position?.side ?? PositionSide.LONG).toUpperCase(),
 			},
 			{
-				label: t('futures.market.user.position.modal-close.size'),
+				label: t('futures.market.user.position.modal.size'),
 				value: formatCurrency(currencyKey || '', position?.size ?? zeroBN, {
 					sign: synthToAsset(currencyKey as CurrencyKey),
 				}),
 			},
 			{
-				label: t('futures.market.user.position.modal-close.leverage'),
+				label: t('futures.market.user.position.modal.leverage'),
 				value: `${formatNumber(position?.leverage ?? zeroBN)}x`,
 			},
 			{
-				label: t('futures.market.user.position.modal-close.ROI'),
+				label: t('futures.market.user.position.modal.ROI'),
 				value: formatCurrency(Synths.sUSD, position?.roi ?? zeroBN, { sign: '$' }),
 			},
 			{
-				label: t('futures.market.user.position.modal-close.fee'),
+				label: t('futures.market.user.position.modal.fee'),
 				value: formatCurrency(Synths.sUSD, orderFee, { sign: '$' }),
 			},
 			{
-				label: t('futures.market.user.position.modal-close.gas-fee'),
+				label: t('futures.market.user.position.modal.gas-fee'),
 				value: formatCurrency(selectedPriceCurrency.name as CurrencyKey, transactionFee ?? zeroBN, {
 					sign: '$',
 				}),
@@ -150,7 +154,7 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 		<StyledBaseModal
 			onDismiss={onDismiss}
 			isOpen={true}
-			title={t('futures.market.user.position.modal-close.title')}
+			title={t('futures.market.user.position.modal.title')}
 		>
 			<>
 				{dataRows.map(({ label, value }, i) => (
@@ -168,7 +172,7 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({
 					onClick={() => closeTxn.mutate()}
 					disabled={!!error || !!closeTxn.errorMessage}
 				>
-					{error || closeTxn.errorMessage || t('futures.market.user.position.modal-close.title')}
+					{error || closeTxn.errorMessage || t('futures.market.user.position.modal.title')}
 				</StyledButton>
 			</>
 		</StyledBaseModal>

--- a/sections/futures/Trade/NextPriceConfirmationModal.tsx
+++ b/sections/futures/Trade/NextPriceConfirmationModal.tsx
@@ -83,7 +83,7 @@ const NextPriceConfirmationModal: FC<NextPriceConfirmationModalProps> = ({
 	);
 
 	const orderDetails = useMemo(() => {
-		const newSize = side === PositionSide.LONG ? tradeSize : -tradeSize;
+		const newSize = side === PositionSide.LONG ? wei(tradeSize) : wei(tradeSize).mul(-1);
 
 		return { newSize, size: (positionSize ?? zeroBN).add(newSize).abs() };
 	}, [side, tradeSize, positionSize]);
@@ -103,25 +103,32 @@ const NextPriceConfirmationModal: FC<NextPriceConfirmationModalProps> = ({
 
 	const dataRows = useMemo(
 		() => [
-			{ label: 'Side', value: (side ?? PositionSide.LONG).toUpperCase() },
 			{
-				label: 'Size',
-				value: formatCurrency(market || '', orderDetails.size ?? zeroBN, {
+				label: t('futures.market.user.position.modal.order-type'),
+				value: t('futures.market.user.position.modal.next-price-order'),
+			},
+			{
+				label: t('futures.market.user.position.modal.side'),
+				value: (side ?? PositionSide.LONG).toUpperCase(),
+			},
+			{
+				label: t('futures.market.user.position.modal.size'),
+				value: formatCurrency(market || '', orderDetails.newSize.abs() ?? zeroBN, {
 					sign: market ? synthsMap[market]?.sign : '',
 				}),
 			},
 			{
-				label: 'Total Deposit',
+				label: t('futures.market.user.position.modal.deposit'),
 				value: formatCurrency(Synths.sUSD, totalDeposit, { sign: '$' }),
 			},
 			{
-				label: 'Next-Price Discount',
+				label: t('futures.market.user.position.modal.np-discount'),
 				value: !!nextPriceDiscount
 					? formatCurrency(Synths.sUSD, nextPriceDiscount, { sign: '$' })
 					: NO_VALUE,
 			},
 			{
-				label: 'Estimated Fees',
+				label: t('futures.market.user.position.modal.fee-total'),
 				value: formatCurrency(
 					selectedPriceCurrency.name,
 					totalDeposit.add(nextPriceDiscount ?? zeroBN),
@@ -133,6 +140,7 @@ const NextPriceConfirmationModal: FC<NextPriceConfirmationModalProps> = ({
 			},
 		],
 		[
+			t,
 			orderDetails,
 			market,
 			synthsMap,

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -70,6 +70,7 @@ const Trade: React.FC<TradeProps> = ({
 	const { synthetixjs, network } = Connector.useContainer();
 
 	const [closePositionModalIsVisible, setClosePositionModalIsVisible] = useState<boolean>(false);
+	const [nextPriceCloseModalIsVisible, setNextPriceCloseModalIsVisible] = useState<boolean>(false);
 	const [orderType, setOrderType] = useState(0);
 
 	const marketAsset = (router.query.market?.[0] as CurrencyKey) ?? null;
@@ -289,7 +290,6 @@ const Trade: React.FC<TradeProps> = ({
 		{
 			enabled:
 				!!marketAsset &&
-				!!leverage &&
 				Number(leverage) >= 0 &&
 				maxLeverageValue.gte(Number(leverage)) &&
 				!sizeDelta.eq(zeroBN),
@@ -430,7 +430,20 @@ const Trade: React.FC<TradeProps> = ({
 						isRounded={true}
 						fullWidth
 						variant="danger"
-						onClick={() => setClosePositionModalIsVisible(true)}
+						onClick={() => {
+							if (orderType === 1 && position?.position?.size) {
+								const newTradeSize = position.position.size;
+								const newLeverageSide =
+									position.position.side === PositionSide.LONG
+										? PositionSide.SHORT
+										: PositionSide.LONG;
+								setLeverageSide(newLeverageSide);
+								setTradeSize(newTradeSize.toString());
+								setNextPriceCloseModalIsVisible(true);
+							} else {
+								setClosePositionModalIsVisible(true);
+							}
+						}}
 						disabled={!positionDetails || isFuturesMarketClosed}
 						noOutline={true}
 					>
@@ -517,6 +530,21 @@ const Trade: React.FC<TradeProps> = ({
 					currencyKey={currencyKey}
 					onPositionClose={onPositionClose}
 					onDismiss={() => setClosePositionModalIsVisible(false)}
+				/>
+			)}
+
+			{nextPriceCloseModalIsVisible && onPositionClose && (
+				<NextPriceConfirmationModal
+					tradeSize={tradeSize}
+					onConfirmOrder={() => orderTxn.mutate()}
+					gasLimit={orderTxn.gasLimit}
+					l1Fee={orderTxn.optimismLayerOneFee}
+					market={marketAsset}
+					side={leverageSide}
+					onDismiss={() => setNextPriceCloseModalIsVisible(false)}
+					feeCost={feeCost}
+					positionSize={position?.position?.size ?? null}
+					isDisclaimerDisplayed={shouldDisplayNextPriceDisclaimer}
 				/>
 			)}
 		</Panel>

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -161,7 +161,7 @@ const Trade: React.FC<TradeProps> = ({
 			const size = fromLeverage ? (value === '' ? '' : wei(value).toNumber().toString()) : value;
 			const sizeSUSD = value === '' ? '' : marketAssetRate.mul(Number(value)).toNumber().toString();
 			const leverage =
-				value === ''
+				value === '' || !position?.remainingMargin
 					? ''
 					: marketAssetRate
 							.mul(Number(value))

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -82,21 +82,19 @@ const OpenOrdersTable: React.FC<OpenOrdersTableProps> = ({
 	}, [cancelOrExecuteOrderTxn.hash]);
 
 	const data = React.useMemo(() => {
-		const positionSize = position?.position?.notionalValue ?? wei(0);
-
 		return openOrders.map((order: any) => ({
 			asset: order.asset,
 			market: getDisplayAsset(order.asset) + '-PERP',
 			orderType: order.orderType === 'NextPrice' ? 'Next-Price' : order.orderType,
-			size: order.size,
-			side: positionSize.add(wei(order.size)).gt(0) ? PositionSide.LONG : PositionSide.SHORT,
+			size: order.size.abs(),
+			side: wei(order.size).gt(0) ? PositionSide.LONG : PositionSide.SHORT,
 			isStale: wei(nextPriceDetails?.currentRoundId ?? 0).gte(wei(order.targetRoundId).add(2)),
 			isExecutable:
 				wei(nextPriceDetails?.currentRoundId ?? 0).eq(order.targetRoundId) ||
 				wei(nextPriceDetails?.currentRoundId ?? 0).eq(order.targetRoundId.add(1)),
 			timestamp: order.timestamp,
 		}));
-	}, [openOrders, position, nextPriceDetails?.currentRoundId]);
+	}, [openOrders, nextPriceDetails?.currentRoundId]);
 
 	return (
 		<StyledTable

--- a/translations/en.json
+++ b/translations/en.json
@@ -934,14 +934,20 @@
 					"accrued-funding-tooltip": "Funding is continuous and accrued over time. Longs pay shorts if market is skewed long and vice versa.",
 					"close-position": "close position",
 					"manage-position": "manage position",
-					"modal-close": {
+					"modal": {
 						"title": "Close position",
 						"size": "Size",
 						"side": "Side",
 						"leverage": "Leverage",
 						"ROI": "ROI",
 						"fee": "Protocol Fee",
-						"gas-fee": "Network Gas Fee"
+						"fee-total": "Total Fees",
+						"gas-fee": "Network Gas Fee",
+						"order-type": "Order Type",
+						"market-order": "Market",
+						"next-price-order": "Next-Price",
+						"deposit": "Total Deposit",
+						"np-discount": "Next-Price Discount"
 					}
 				},
 				"orders": {


### PR DESCRIPTION
Submit a "Next-Price" order when a user has "Next-Price" selected and clicks "Close Position"

## Description
* Submit a "Next-Price" order to close position
* Update the trade confirmation modal to include relevant info (order type)
* Correct the "Open Orders" tab, which was showing resulting _position size_ instead of _order size_

## Related issue
* #849 

## Motivation and Context
Confusing to submit a market order when next-price is selected.

## How Has This Been Tested?
I submitted next-price orders on testnet and checked the values in the modal and "Open Orders" table

## Screenshots (if appropriate):
Modal:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/10401554/172929708-367d87fe-e784-4594-
8838-99190b08e60d.png">

Table:
<img width="873" alt="image" src="https://user-images.githubusercontent.com/10401554/172929839-60beedab-d63d-45a6-bd6b-53c15eec4e3a.png">
