### PR TITLE
Fix TV theme switch issue

### DIFF
--- a/components/TVChart/TVChart.tsx
+++ b/components/TVChart/TVChart.tsx
@@ -12,6 +12,7 @@ import { useRecoilValue } from 'recoil';
 import { networkState } from 'store/wallet';
 import { formatNumber } from 'utils/formatters/number';
 import { ChartPosition } from './types';
+import { currentThemeState } from 'store/ui';
 
 export type ChartProps = {
 	baseCurrencyKey: string;
@@ -45,6 +46,7 @@ export function TVChart({
 }: Props) {
 	const [lastSubscription, setLastSubscription] = useState(0);
 	const [intervalId, setIntervalId] = useState(0);
+	const currentTheme = useRecoilValue(currentThemeState);
 	const _widget = useRef<IChartingLibraryWidget | null>(null);
 	const _entryLine = useRef<IPositionLineAdapter | null | undefined>(null);
 	const _liquidationLine = useRef<IPositionLineAdapter | null | undefined>(null);
@@ -110,7 +112,7 @@ export function TVChart({
 			clearExistingWidget();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [baseCurrencyKey, quoteCurrencyKey, network.id]);
+	}, [baseCurrencyKey, quoteCurrencyKey, network.id, currentTheme]);
 
 	useEffect(() => {
 		_widget.current?.onChartReady(() => {


### PR DESCRIPTION
## Description
This PR fixes a bug that made the TV chart color remain the same when themes were changed.

## Related issue
- #964 

## Motivation and Context
This is part of the light theme/theme switch feature on the Kwenta v2 UI.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
