### PR TITLE
To truncate the number without rounding

### DIFF
--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -54,7 +54,7 @@ import { isWalletConnectedState, walletAddressState, isL2State, networkState } f
 import { ordersState } from 'store/orders';
 
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
-import { zeroBN } from 'utils/formatters/number';
+import { truncateNumbers, zeroBN } from 'utils/formatters/number';
 
 import { getTransactionPrice, normalizeGasLimit, GasInfo } from 'utils/network';
 
@@ -564,7 +564,7 @@ const useExchange = ({
 			const baseCurrencyAmountNoFee = wei(quoteCurrencyAmount).mul(rate);
 			const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 			setBaseCurrencyAmount(
-				baseCurrencyAmountNoFee.sub(fee).toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+				truncateNumbers(baseCurrencyAmountNoFee.sub(fee), DEFAULT_CRYPTO_DECIMALS)
 			);
 		}
 		// eslint-disable-next-line
@@ -575,7 +575,7 @@ const useExchange = ({
 			const quoteCurrencyAmountNoFee = wei(baseCurrencyAmount).mul(inverseRate);
 			const fee = quoteCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 			setQuoteCurrencyAmount(
-				quoteCurrencyAmountNoFee.add(fee).toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+				truncateNumbers(quoteCurrencyAmountNoFee.add(fee), DEFAULT_CRYPTO_DECIMALS)
 			);
 		}
 		// eslint-disable-next-line
@@ -948,11 +948,7 @@ const useExchange = ({
 							const baseCurrencyAmountNoFee = wei(value).mul(rate);
 							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setBaseCurrencyAmount(
-								baseCurrencyAmountNoFee
-									.sub(fee)
-									.toNumber()
-									.toFixed(DEFAULT_CRYPTO_DECIMALS)
-									.toString()
+								truncateNumbers(baseCurrencyAmountNoFee.sub(fee), DEFAULT_CRYPTO_DECIMALS)
 							);
 						}
 					}
@@ -966,22 +962,18 @@ const useExchange = ({
 							setQuoteCurrencyAmount(
 								balanceWithBuffer.lt(0)
 									? '0'
-									: balanceWithBuffer.toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+									: truncateNumbers(balanceWithBuffer, DEFAULT_CRYPTO_DECIMALS)
 							);
 						} else {
 							setQuoteCurrencyAmount(
-								quoteCurrencyBalance.toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
+								truncateNumbers(quoteCurrencyBalance, DEFAULT_CRYPTO_DECIMALS)
 							);
 						}
 						if (txProvider === 'synthetix') {
 							const baseCurrencyAmountNoFee = quoteCurrencyBalance.mul(rate);
 							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setBaseCurrencyAmount(
-								baseCurrencyAmountNoFee
-									.sub(fee)
-									.toNumber()
-									.toFixed(DEFAULT_CRYPTO_DECIMALS)
-									.toString()
+								truncateNumbers(baseCurrencyAmountNoFee.sub(fee), DEFAULT_CRYPTO_DECIMALS)
 							);
 						}
 					}
@@ -1063,11 +1055,7 @@ const useExchange = ({
 							const quoteCurrencyAmountNoFee = wei(value).mul(inverseRate);
 							const fee = quoteCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setQuoteCurrencyAmount(
-								quoteCurrencyAmountNoFee
-									.add(fee)
-									.toNumber()
-									.toFixed(DEFAULT_CRYPTO_DECIMALS)
-									.toString()
+								truncateNumbers(quoteCurrencyAmountNoFee.add(fee), DEFAULT_CRYPTO_DECIMALS)
 							);
 						}
 					}
@@ -1075,19 +1063,13 @@ const useExchange = ({
 				walletBalance={baseCurrencyBalance}
 				onBalanceClick={async () => {
 					if (baseCurrencyBalance != null) {
-						setBaseCurrencyAmount(
-							baseCurrencyBalance.toNumber().toFixed(DEFAULT_CRYPTO_DECIMALS).toString()
-						);
+						setBaseCurrencyAmount(truncateNumbers(baseCurrencyBalance, DEFAULT_CRYPTO_DECIMALS));
 
 						if (txProvider === 'synthetix') {
 							const baseCurrencyAmountNoFee = baseCurrencyBalance.mul(inverseRate);
 							const fee = baseCurrencyAmountNoFee.mul(exchangeFeeRate ?? 0);
 							setQuoteCurrencyAmount(
-								baseCurrencyAmountNoFee
-									.add(fee)
-									.toNumber()
-									.toFixed(DEFAULT_CRYPTO_DECIMALS)
-									.toString()
+								truncateNumbers(baseCurrencyAmountNoFee.add(fee), DEFAULT_CRYPTO_DECIMALS)
 							);
 						}
 					}

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -33,6 +33,14 @@ export const getDecimalPlaces = (value: WeiSource) => (value.toString().split('.
 
 export const zeroBN = wei(0);
 
+export const truncateNumbers = (value: WeiSource, maxDecimalDigits: number) => {
+	if (value.toString().includes('.')) {
+		const parts = value.toString().split('.');
+		return parts[0] + '.' + parts[1].slice(0, maxDecimalDigits);
+	}
+	return value.toString();
+};
+
 /**
  * ethers utils.commify method will reduce the decimals of a number to one digit if those decimals are zero.
  * This helper is used to reverse this behavior in order to display the specified decmials in the output.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On the Exchange, clicking `Max` and `Balance` button will round the number automatically, which is not expected.

## Related issue
#975 

## Motivation and Context
To improve the UX.

## How Has This Been Tested?
1. Click on `Max` and `Balance` to check the number is not rounding.

## Screenshots (if appropriate):
In this case, the actual `max` number is `10.728085525011272`. There is no rounding on display.
![image](https://user-images.githubusercontent.com/4819006/173105117-da015228-44c9-49f8-874e-69de884d69c1.png)
