### PR TITLE
Update the font color of wallet connect

### DIFF
--- a/sections/shared/Layout/Layout.tsx
+++ b/sections/shared/Layout/Layout.tsx
@@ -68,7 +68,7 @@ const GlobalStyle = createGlobalStyle`
 	.bn-onboard-custom {
 		&&& {
 			font-family: ${(props) => props.theme.fonts.regular};
-			color: ${(props) => props.theme.colors.selectedTheme.button.text};
+			color: ${(props) => props.theme.colors.common.primaryWhite};
 			
 		}
 		&&.bn-onboard-modal {
@@ -83,7 +83,7 @@ const GlobalStyle = createGlobalStyle`
 		}
 		&&.bn-onboard-selected-wallet {
 			background-color: ${(props) => props.theme.colors.navy};
-			color: ${(props) => props.theme.colors.common.primaryWhite };
+			color: ${(props) => props.theme.colors.common.primaryWhite};
 		}
 		&&.bn-onboard-modal-content {
 			background-color: ${(props) => props.theme.colors.elderberry};

--- a/sections/shared/Layout/Layout.tsx
+++ b/sections/shared/Layout/Layout.tsx
@@ -83,7 +83,7 @@ const GlobalStyle = createGlobalStyle`
 		}
 		&&.bn-onboard-selected-wallet {
 			background-color: ${(props) => props.theme.colors.navy};
-			color: ${(props) => props.theme.colors.selectedTheme.button.text};
+			color: ${(props) => props.theme.colors.common.primaryWhite };
 		}
 		&&.bn-onboard-modal-content {
 			background-color: ${(props) => props.theme.colors.elderberry};
@@ -93,7 +93,7 @@ const GlobalStyle = createGlobalStyle`
 		}
 		&&.bn-onboard-select-wallet-info {
 			cursor: pointer;
-			color: ${(props) => props.theme.colors.selectedTheme.button.text};
+			color: ${(props) => props.theme.colors.common.primaryWhite};
 		}
 		&&.bn-onboard-dark-mode-background-hover {
 			&:hover {
@@ -102,12 +102,12 @@ const GlobalStyle = createGlobalStyle`
 		}
 		&&.bn-onboard-prepare-button {
 			border-radius: 2px;
-			color: ${(props) => props.theme.colors.selectedTheme.button.text} ;
+			color: ${(props) => props.theme.colors.common.primaryWhite} ;
 			background-color: ${(props) => props.theme.colors.elderberry} ;
 			border: 1px solid ${(props) => props.theme.colors.navy} ;
 		}
 		.bn-onboard-clickable {
-			color: ${(props) => props.theme.colors.selectedTheme.button.text} !important;
+			color: ${(props) => props.theme.colors.common.primaryWhite} !important;
 		}		
 	}
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The text on wallet connect is not readable in the light theme.

## Related issue
#992 

## Motivation and Context
Improve the UX

## How Has This Been Tested?
1. Switch to the light theme 
2. Click on the connect wallet

## Screenshots (if appropriate):
wallet connect in light theme
![image](https://user-images.githubusercontent.com/4819006/173409858-696bb8b7-933b-4851-b807-5b06556d6833.png)

wallet connect in dark theme
![image](https://user-images.githubusercontent.com/4819006/173409744-f8e2f98c-003d-4f8a-bee8-fa9ec3466b47.png)
