### PR TITLE
Fix atomic exchange by adding all atomic synths

### DIFF
--- a/constants/currency.ts
+++ b/constants/currency.ts
@@ -79,3 +79,15 @@ export const sUSD_EXCHANGE_RATE = new Wei(1);
 export const SYNTH_DECIMALS = 18;
 
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
+export const ATOMIC_EXCHANGES_L1 = [
+	'sBTC',
+	'sETH',
+	'sEUR',
+	'sUSD',
+	'sCHF',
+	'sJPY',
+	'sAUD',
+	'sGBP',
+	'sKRW',
+];


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fully implemented the atomic swaps on L1 by hardcoding all atomic synths

## Related issue
#976 

## Motivation and Context
Improve the UX and trading volume.

## How Has This Been Tested?
1. Kovan testnet: atomic swap [sCHF => sUSD](https://kovan.etherscan.io/tx/0xa857a3b3f688051442ea564b5ce50b49ba384b5988171fd8eb6ac3b88aa21632)
2. Kovan testnet: atomic swap [sUSD => sCHF](https://kovan.etherscan.io/tx/0xb023a9618e145e2e4a9c36e395f4d22fda0566eb1572f676f2067ee24d2520d1)
3. Kovan testnet: non-atomic swap [sUSD => sLINK](https://kovan.etherscan.io/tx/0x7c3b0b80b6e9185de8b3fe1c4e11ce1d3e9df34663d6dbdacea72e3c57266c86)
4. Optimism Kovan: non-atomic swap [sEUR => sUSD](https://kovan-optimistic.etherscan.io/tx/0x1fc663c8178d6802b0ce7c8fd3a57abdc1023927f727748c0d396946c00fc4b4)
5. Optimism Kovan: non-atomic swap [sLINK => sUSD](https://kovan-optimistic.etherscan.io/tx/0x9294371b9afe21f9a1270972d8731342d62a3bc439bf5579fb059e51a348187a)


## Screenshots (if appropriate):
