### PR TITLE
Replaced one img tag with Image and disabled the rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,12 @@
 	"plugins": ["prettier"],
 	"rules": {
 		"react/react-in-jsx-scope": "off",
-		"prettier/prettier": "error",
+		"prettier/prettier": [
+			"error",
+			{
+				"endOfLine": "auto"
+			}
+		],
 		"no-mixed-spaces-and-tabs": ["warn", "smart-tabs"],
 		"comma-dangle": [
 			"error",
@@ -17,6 +22,7 @@
 		],
 		"jsx-a11y/anchor-is-valid": "off",
 		"jsx-a11y/alt-text": "off",
-		"import/no-anonymous-default-export": "off"
+		"import/no-anonymous-default-export": "off",
+		"@next/next/no-img-element": "off"
 	}
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,12 +3,7 @@
 	"plugins": ["prettier"],
 	"rules": {
 		"react/react-in-jsx-scope": "off",
-		"prettier/prettier": [
-			"error",
-			{
-				"endOfLine": "auto"
-			}
-		],
+		"prettier/prettier": "error",
 		"no-mixed-spaces-and-tabs": ["warn", "smart-tabs"],
 		"comma-dangle": [
 			"error",

--- a/sections/homepage/Learn/Learn.tsx
+++ b/sections/homepage/Learn/Learn.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import Image from 'next/image';
 
 import ArrowUpRightIcon from 'assets/svg/app/arrow-up-right.svg';
 import FaqIcon from 'assets/png/learn/faq.png';
@@ -44,7 +45,7 @@ const LEARNS = [
 		key: 'faq',
 		title: 'homepage.learn.faq',
 		copy: '',
-		image: <img src={FaqIcon} />,
+		image: <Image src={FaqIcon} width={60} height={60} />,
 		onClick: () => window.open(EXTERNAL_LINKS.Docs.Faq, '_blank'),
 	},
 ];
@@ -198,11 +199,6 @@ const FeatureIconContainer = styled.div`
 
 	&.faq {
 		padding-bottom: 15px;
-	}
-
-	img {
-		width: 60px;
-		height: 60px;
 	}
 
 	&.how-to-stake {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Try to Image as much as possible and disable the rule because img tag is better in most of the cases.

We are using `img` tag in 7 files.
- 3 of them are ens avatars (needs a workaround)
```
C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\sections\homepage\ShortList\ShortList.tsx
  145:13  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\sections\leaderboard\Leaderboard\Leaderboard.tsx
  217:18  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\sections\shared\Layout\AppLayout\Header\WalletActions.tsx
  79:6  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```
All the images need to be loaded from the whitelist domain, which is not possible in our case so we need another workaround to fetch them from the proxy. 
![image](https://user-images.githubusercontent.com/4819006/173672456-163e6adc-1c99-4fb9-a0d1-3bc0251c0bf5.png)

- 2 of them need to overwrite the inline css rules of `Image`
```
C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\sections\homepage\Features\Features.tsx
  54:10  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\components\Currency\CurrencyIcon\CurrencyIcon.tsx
  84:12  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```
Below is the reference.
![image](https://user-images.githubusercontent.com/4819006/173672674-a57ea5ca-f60a-4c9b-99bc-6ad406622b80.png)

- 1 is not in use (it's defined in `Webp.tsx`)
```
C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\components\Webp\Webp.tsx
  16:51  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```
We are using `<StyledImg>` which is an `img` tag but do not get the warning. The warning on line 16 is not in use.
![image](https://user-images.githubusercontent.com/4819006/173672767-19ffd3fb-90d7-4622-a979-65e4b51ad214.png)

- 1 is working directly by replacing the tags (the change has been made)
```
C:\Users\leifu\Desktop\kwenta-dev\kwenta-team\sections\homepage\Learn\Learn.tsx
  47:10  warning  Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```
## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Try to optimize the code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
