### PR TITLE
add --legacy-peer-deps flag to updateDependency

### DIFF
--- a/.github/workflows/updateDependency.yml
+++ b/.github/workflows/updateDependency.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update @synthetixio/contracts-interface dependency
         run: |
           npm install --legacy-peer-deps --no-audit
-          npm install @synthetixio/contracts-interface@${{ github.event.client_payload.version }} --save-exact
+          npm install @synthetixio/contracts-interface@${{ github.event.client_payload.version }} --save-exact --legacy-peer-deps
       - name: Commit changes
         run: |
           git config --global user.email "team@synthetix.io" && git config --global user.name "Synthetix Team"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixes a peer dependency error when running `updateDependency` workflow

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
