### PR TITLE
Trades Table Reset

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -102,6 +102,7 @@ export const Table: FC<TableProps> = ({
 				hiddenColumns: hiddenColumns,
 				sortBy: sortBy,
 			},
+			autoResetPage: false,
 			...options,
 		},
 		useSortBy,


### PR DESCRIPTION
Fixing a bug where the trades table resets when the data refreshes.

## Description
Changing a default setting on the table component to not reset page on data refresh. This will apply to all tables.

## Related issue
- #954 
