### PR TITLE
Fixed PositionCard to not have "-" in leverage.

### DIFF
--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -129,7 +129,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 			positionSide: newSide,
 			positionSize: size?.abs(),
 			notionalValue: previewTradeData.notionalValue,
-			leverage: previewTradeData.notionalValue.div(previewTradeData.margin),
+			leverage: previewTradeData.notionalValue.div(previewTradeData.margin).abs(),
 			liquidationPrice: previewTradeData.liqPrice,
 			avgEntryPrice: modifiedAverage || zeroBN,
 			showStatus: previewTradeData.showStatus,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Going short in leverage would add a - in preview infront of the x amount. Now removed using ".abs()".

## Related issue
#1007 

## Motivation and Context
Removes the "-" from front-end to not confuse users.

## How Has This Been Tested?
Ran in dev enviorment. Tested. Seems to work.

## Screenshots (if appropriate):
![fixed](https://user-images.githubusercontent.com/76062949/174079667-73d606c3-f2c8-4ea1-ac7d-416f2eb3cc20.PNG)

