### PR TITLE
Update wallet balances after withdraw/deposit event

### DIFF
--- a/contexts/RefetchContext.tsx
+++ b/contexts/RefetchContext.tsx
@@ -8,6 +8,11 @@ import { walletAddressState } from 'store/wallet';
 import useGetFuturesMarket from 'queries/futures/useGetFuturesMarket';
 import useGetFuturesPotentialTradeDetails from 'queries/futures/useGetFuturesPotentialTradeDetails';
 
+import useGetFuturesPositionForMarkets from 'queries/futures/useGetFuturesPositionForMarkets';
+import { getMarketKey } from 'utils/futures';
+import Connector from 'containers/Connector';
+import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
+
 type RefetchType = 'modify-position' | 'new-order' | 'close-position' | 'margin-change';
 
 type RefetchContextType = {
@@ -28,6 +33,13 @@ export const RefetchProvider: React.FC = ({ children }) => {
 	const marketQuery = useGetFuturesMarket();
 	useGetFuturesPotentialTradeDetails();
 
+	const { network } = Connector.useContainer();
+	const futuresMarketsQuery = useGetFuturesMarkets();
+	const futuresMarkets = futuresMarketsQuery?.data ?? [];
+	const futuresPositionQuery = useGetFuturesPositionForMarkets(
+		futuresMarkets.map(({ asset }) => getMarketKey(asset, network.id))
+	);
+
 	const handleRefetch = (refetchType: RefetchType, timeout?: number) => {
 		setTimeout(() => {
 			switch (refetchType) {
@@ -43,6 +55,7 @@ export const RefetchProvider: React.FC = ({ children }) => {
 					openOrdersQuery.refetch();
 					break;
 				case 'margin-change':
+					futuresPositionQuery.refetch();
 					positionQuery.refetch();
 					openOrdersQuery.refetch();
 					synthsBalancesQuery.refetch();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR Allows the sUSD and market balances to be automatically updated after executing transaction. Essentially. This PR adds a refetch query for the futuresPosition if  'margin-change' handleRefetch gets triggered.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Kwenta/kwenta/issues/912

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See ticket above. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Did multiple deposits and withdraws on several markets using OE KOVAN.

## Screenshots (if appropriate):
