### PR TITLE
Update Subgraph Endpoints

### DIFF
--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -2,10 +2,10 @@ import { gql } from 'graphql-request';
 import { utils as ethersUtils } from 'ethers';
 
 export const FUTURES_ENDPOINT_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures';
 
 export const FUTURES_ENDPOINT_TESTNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-kovan-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-kovan-futures';
 
 export const DAY_PERIOD = 24;
 

--- a/queries/rates/constants.ts
+++ b/queries/rates/constants.ts
@@ -1,8 +1,8 @@
 export const RATES_ENDPOINT_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-latest-rates';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
 
 export const RATES_ENDPOINT_TESTNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-kovan-latest-rates';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-kovan-main';
 
 export const DAY_PERIOD = 24 * 3600;
 

--- a/queries/synths/constants.ts
+++ b/queries/synths/constants.ts
@@ -1,8 +1,7 @@
 export const SYNTHS_ENDPOINT_OPTIMISM_MAIN =
-	'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
 
 export const SYNTHS_ENDPOINT_OPTIMISM_KOVAN =
-	'https://api.thegraph.com/subgraphs/name/synthetixio-team/optimism-kovan-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-kovan-main';
 
-export const SYNTHS_ENDPOINT_MAIN =
-	'https://api.thegraph.com/subgraphs/name/synthetixio-team/mainnet-main';
+export const SYNTHS_ENDPOINT_MAIN = 'https://api.thegraph.com/subgraphs/name/kwenta/mainnet-main';


### PR DESCRIPTION
Update endpoints to get all data from Kwenta-owned subgraphs.

## Description
- Update rates and volume endpoints to Kwenta subgraphs
- Update futures subgraphs to points at `optimism-futures` / `optimism-kovan-futures` to enable quick development. These subgraphs sync faster than `main`, so this will allow changes to reach production quickly.

## Related issue
- #840 
- #1036 

## How Has This Been Tested?
I compared all data on the dashboard (futures markets and spot markets) against the existing kwenta.io deployment, and all rate and volume data matches.