### PR TITLE
Fix the padding space of first column on mobile

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -9,7 +9,6 @@ import { FlexDivCentered } from 'styles/common';
 
 import Spinner from 'assets/svg/app/loader.svg';
 import Pagination from './Pagination';
-import media from 'styles/media';
 
 export type TablePalette = 'primary';
 

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -241,17 +241,6 @@ const TableCell = styled(FlexDivCentered)`
 	&:last-child {
 		padding-right: 14px;
 	}
-
-	${media.lessThan('sm')`
-		&:first-child {
-			margin: auto;
-			padding: 0px;
-		}
-		&:last-child {
-			margin: auto;
-			padding: 0px;
-		}
-	`}
 `;
 
 const TableCellHead = styled(TableCell)<{ hideHeaders: boolean }>`

--- a/sections/homepage/ShortList/ShortList.tsx
+++ b/sections/homepage/ShortList/ShortList.tsx
@@ -371,6 +371,9 @@ const StyledTable = styled(Table)`
 	width: 1160px;
 	${media.lessThan('sm')`
 		width: 345px;
+		& > .table-body >.table-body-row >.table-body-cell {
+			padding-left: 0px;
+		}
 	`}
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The css change in the common table component broke the padding space of the trade history table on mobile. Move the css change into the landing page's leaderboard component. So it won't affect the other tables.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Align the table layout.

## How Has This Been Tested?
1. Check the alignment of the trade history table on mobile.
2. Check the alignment of the landing page's leaderboard on mobile.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/175277367-a47e70c6-e382-46f4-afa2-4b05793ec248.png)
![image](https://user-images.githubusercontent.com/4819006/175277435-8a286458-5996-4320-aa51-002c365c4635.png)
