### PR TITLE
Removed the max-width

### DIFF
--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -193,7 +193,6 @@ export const FullScreenContainer = styled(FlexDiv)`
 	overflow-y: visible;
 	padding: 25px 25px 0;
 	margin: 0 auto;
-	max-width: 1800px;
 
 	${media.lessThan('sm')`
 		padding: 20px 15px 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
UI doesn't respond to the larger viewport size when zooming out.

## Related issue
#957 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the `future market` page and zoom out. UI adapts the change of zoom level.

## Screenshots (if appropriate):
