### PR TITLE
Fix the market tab on the smaller screen

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -207,7 +207,6 @@ export const TableRow = styled.div``;
 const TableBody = styled.div`
 	overflow-y: auto;
 	overflow-x: hidden;
-	min-width: fit-content;
 `;
 
 const TableBodyRow = styled.div<{ $highlightRowsOnHover?: boolean }>`

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -181,7 +181,6 @@ const TableAlignment = css`
 	}
 	& > div:nth-child(2) {
 		flex: 100 100 0 !important;
-		display: flex;
 		justify-content: center;
 	}
 	& > div:last-child {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The text in the table might be cut out on a smaller screen.
![image](https://user-images.githubusercontent.com/4819006/176420141-bc3580f9-5b1d-4fd2-9ebe-227b019fdb6c.png)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Make the text in table adapt the smaller screen.

## How Has This Been Tested?
1. Switch to responsive mode and change the size of the container. No cut out of the texts are observed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/176420632-fe4ed801-dbfb-4cb3-81c7-1e7f87a0e747.png)
![image](https://user-images.githubusercontent.com/4819006/176420676-4677b591-f1a0-4252-aaf0-c4cf12193696.png)
