### PR TITLE
Fix Liquidation Pnl

### DIFF
--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -35,6 +35,7 @@ export const FUTURES_POSITION_FRAGMENT = gql`
 		avgEntryPrice
 		totalVolume
 		pnl
+		pnlWithFeesPaid
 		trades
 	}
 `;

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -146,6 +146,7 @@ export type PositionHistory = {
 	leverage: Wei;
 	side: PositionSide;
 	pnl: Wei;
+	pnlWithFeesPaid: Wei;
 	totalVolume: Wei;
 	trades: number;
 };

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -325,6 +325,7 @@ export const mapTradeHistory = (
 					entryPrice,
 					exitPrice,
 					pnl,
+					pnlWithFeesPaid,
 					openTimestamp,
 					closeTimestamp,
 					totalVolume,
@@ -341,6 +342,7 @@ export const mapTradeHistory = (
 					const initialMarginWei = new Wei(initialMargin, 18, true);
 					const marginWei = new Wei(margin, 18, true);
 					const pnlWei = new Wei(pnl, 18, true);
+					const pnlWithFeesPaidWei = new Wei(pnlWithFeesPaid, 18, true);
 					const totalVolumeWei = new Wei(totalVolume, 18, true);
 					const avgEntryPriceWei = new Wei(avgEntryPrice, 18, true);
 					return {
@@ -364,6 +366,7 @@ export const mapTradeHistory = (
 						entryPrice: entryPriceWei,
 						exitPrice: exitPriceWei,
 						pnl: pnlWei,
+						pnlWithFeesPaid: pnlWithFeesPaidWei,
 						totalVolume: totalVolumeWei,
 						trades: trades,
 						avgEntryPrice: avgEntryPriceWei,

--- a/sections/leaderboard/TraderHistory/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory/TraderHistory.tsx
@@ -38,11 +38,6 @@ const TraderHistory: FC<TraderHistoryProps> = ({
 		return positions
 			.sort((a: PositionHistory, b: PositionHistory) => b.timestamp - a.timestamp)
 			.map((stat: PositionHistory, i: number) => {
-				const pnlAfterFees = stat.pnl.sub(stat.feesPaid).add(stat.netFunding);
-				const actualPnl = pnlAfterFees.lt(stat.initialMargin.add(stat.totalDeposits).mul(-1))
-					? stat.initialMargin.add(stat.totalDeposits).mul(-1)
-					: pnlAfterFees;
-
 				return {
 					rank: i + 1,
 					currencyIconKey: stat.asset ? (stat.asset[0] !== 's' ? 's' : '') + stat.asset : '',
@@ -52,8 +47,8 @@ const TraderHistory: FC<TraderHistoryProps> = ({
 					status: stat.isOpen ? 'Open' : stat.isLiquidated ? 'Liquidated' : 'Closed',
 					feesPaid: stat.feesPaid,
 					netFunding: stat.netFunding,
-					pnl: actualPnl,
-					pnlPct: `(${actualPnl
+					pnl: stat.pnlWithFeesPaid,
+					pnlPct: `(${stat.pnlWithFeesPaid
 						.div(stat.initialMargin.add(stat.totalDeposits))
 						.mul(100)
 						.toNumber()


### PR DESCRIPTION
We calculate pnl net of fees on the frontend. New subgraph changes implemented the `pnlWithFeesPaid` value directly to avoid calculations on the frontend.

## Description
* Add `pnlWithFeesPaid` to the position types and queries
* Implement the `pnlWithFeesPaid` value for realized pnl and pnl % values

## Related issue
* [Issue](https://github.com/Kwenta/kwenta-subgraph/issues/58)
