### PR TITLE
Adjust max leverage for NP orders

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -35,3 +35,6 @@ export const DEFAULT_SLIPPAGE = 1;
 
 // for Trading History
 export const DEFAULT_NUMBER_OF_TRADES: number = 50;
+
+// leverage adjustment
+export const DEFAULT_NP_LEVERAGE_ADJUSTMENT: number = 0.9975;

--- a/store/futures/index.ts
+++ b/store/futures/index.ts
@@ -11,6 +11,7 @@ import { PositionSide } from 'sections/futures/types';
 import { Rates } from 'queries/rates/types';
 import { zeroBN } from 'utils/formatters/number';
 import { Synths, CurrencyKey } from 'constants/currency';
+import { DEFAULT_NP_LEVERAGE_ADJUSTMENT } from 'constants/defaults';
 
 const DEFAULT_MAX_LEVERAGE = wei(10);
 
@@ -98,18 +99,21 @@ export const maxLeverageState = selector({
 	key: getFuturesKey('maxLeverage'),
 	get: ({ get }) => {
 		const position = get(positionState);
+		const orderType = get(orderTypeState);
 		const market = get(marketInfoState);
 		const leverageSide = get(leverageSideState);
 
 		const positionLeverage = position?.position?.leverage ?? wei(0);
 		const positionSide = position?.position?.side;
 		const marketMaxLeverage = market?.maxLeverage ?? DEFAULT_MAX_LEVERAGE;
+		const adjustedMaxLeverage =
+			orderType === 1 ? marketMaxLeverage.mul(DEFAULT_NP_LEVERAGE_ADJUSTMENT) : marketMaxLeverage;
 
-		if (!positionLeverage || positionLeverage.eq(wei(0))) return marketMaxLeverage;
+		if (!positionLeverage || positionLeverage.eq(wei(0))) return adjustedMaxLeverage;
 		if (positionSide === leverageSide) {
-			return marketMaxLeverage?.sub(positionLeverage);
+			return adjustedMaxLeverage?.sub(positionLeverage);
 		} else {
-			return positionLeverage.add(marketMaxLeverage);
+			return positionLeverage.add(adjustedMaxLeverage);
 		}
 	},
 });


### PR DESCRIPTION
Adds an adjustment to max leverage amount when the user is submitting a next price order.

## Description
* Adds constant for leverage adjustment (99.75% of current leverage)
* Adjusts current max leverage on NP orders by the constant

## Related issue
- [ ] closes #1012 

## Motivation and Context
Trader next price orders fail when the specified position size and next oracle update push them past max leverage. This change will adjust the available max leverage by 99.75% since oracle updates should be <.2%.
