### PR TITLE
Fix "no result" on Table component

### DIFF
--- a/components/Currency/CurrencyPrice/CurrencyPrice.tsx
+++ b/components/Currency/CurrencyPrice/CurrencyPrice.tsx
@@ -38,7 +38,9 @@ export const CurrencyPrice: FC<CurrencyPriceProps> = ({
 			<Price className="price">
 				{formatCurrency(
 					currencyKey,
-					conversionRate && wei(conversionRate).gt(0) ? wei(price).div(conversionRate) : price,
+					conversionRate && price && wei(conversionRate).gt(0)
+						? wei(price).div(conversionRate)
+						: price,
 					{
 						sign,
 						currencyKey: showCurrencyKey != null ? currencyKey : undefined,

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -175,7 +175,7 @@ export const Table: FC<TableProps> = ({
 							</TableBody>
 						)
 					)}
-					{!!noResultsMessage && !isLoading && data.length == 0 && noResultsMessage}
+					{!!noResultsMessage && !isLoading && data.length === 0 && noResultsMessage}
 				</ReactTable>
 			</TableContainer>
 			{!showShortList && showPagination && data.length > (pageSize ? pageSize : MAX_PAGE_ROWS) ? (

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -175,7 +175,7 @@ export const Table: FC<TableProps> = ({
 							</TableBody>
 						)
 					)}
-					{!!noResultsMessage && noResultsMessage}
+					{!!noResultsMessage && !isLoading && data.length == 0 && noResultsMessage}
 				</ReactTable>
 			</TableContainer>
 			{!showShortList && showPagination && data.length > (pageSize ? pageSize : MAX_PAGE_ROWS) ? (

--- a/queries/futures/useGetAllFuturesTradesForAccount.ts
+++ b/queries/futures/useGetAllFuturesTradesForAccount.ts
@@ -52,7 +52,7 @@ const useGetAllFuturesTradesForAccount = (
 			);
 			return response ? mapTrades(response) : null;
 		},
-		{ enabled: isWalletConnected ? isL2 && isAppReady && !!account : isAppReady, ...options }
+		{ enabled: isL2 && isAppReady && isWalletConnected && !!account, ...options }
 	);
 };
 

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -62,6 +62,7 @@ const FuturesHistoryTable: FC = () => {
 			<StyledTable
 				data={isL2 ? mappedHistoricalTrades : []}
 				showPagination={true}
+				isLoading={futuresTradesQuery.isLoading || futuresTradesQuery.isIdle}
 				noResultsMessage={
 					!isL2 ? (
 						<TableNoResults>

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -62,6 +62,7 @@ const FuturesHistoryTable: FC = () => {
 			<StyledTable
 				data={isL2 ? mappedHistoricalTrades : []}
 				showPagination={true}
+				pageSize={15}
 				isLoading={futuresTradesQuery.isLoading || futuresTradesQuery.isIdle}
 				noResultsMessage={
 					!isL2 ? (

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -62,7 +62,6 @@ const FuturesHistoryTable: FC = () => {
 			<StyledTable
 				data={isL2 ? mappedHistoricalTrades : []}
 				showPagination={true}
-				pageSize={15}
 				isLoading={futuresTradesQuery.isLoading || futuresTradesQuery.isIdle}
 				noResultsMessage={
 					!isL2 ? (

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -62,7 +62,7 @@ const FuturesHistoryTable: FC = () => {
 			<StyledTable
 				data={isL2 ? mappedHistoricalTrades : []}
 				showPagination={true}
-				isLoading={futuresTradesQuery.isLoading || futuresTradesQuery.isIdle}
+				isLoading={futuresTradesQuery.isLoading}
 				noResultsMessage={
 					!isL2 ? (
 						<TableNoResults>

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -64,6 +64,7 @@ const SpotHistoryTable: FC = () => {
 			<StyledTable
 				data={filteredHistoricalTrades}
 				showPagination={true}
+				pageSize={15}
 				isLoading={walletTradesQuery.isLoading || walletTradesQuery.isIdle}
 				highlightRowsOnHover
 				noResultsMessage={

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -64,6 +64,7 @@ const SpotHistoryTable: FC = () => {
 			<StyledTable
 				data={filteredHistoricalTrades}
 				showPagination={true}
+				isLoading={walletTradesQuery.isLoading || walletTradesQuery.isIdle}
 				highlightRowsOnHover
 				noResultsMessage={
 					<TableNoResults>

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -64,7 +64,6 @@ const SpotHistoryTable: FC = () => {
 			<StyledTable
 				data={filteredHistoricalTrades}
 				showPagination={true}
-				pageSize={15}
 				isLoading={walletTradesQuery.isLoading || walletTradesQuery.isIdle}
 				highlightRowsOnHover
 				noResultsMessage={

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -64,7 +64,7 @@ const SpotHistoryTable: FC = () => {
 			<StyledTable
 				data={filteredHistoricalTrades}
 				showPagination={true}
-				isLoading={walletTradesQuery.isLoading || walletTradesQuery.isIdle}
+				isLoading={walletTradesQuery.isLoading}
 				highlightRowsOnHover
 				noResultsMessage={
 					<TableNoResults>


### PR DESCRIPTION
Fixes a bug in the `Table` component that prevents displaying the "no result" message. Additionally, there are fixes for the spot and futures history tables to improve how and when we display these messages.

## Description
* Adds loading spinner to spot/futures history tables
* Adds check for length of data on "No result" logic in the table component
* Adds a `pageSize` parameter to trigger pagination on the history tables
* Fix an unrelated bug in the `CurrencyPrice` component that results in throwing errors when the `price` value doesn't exist

## Related issue
- #1097 

## Motivation and Context
Bug fixes

## How Has This Been Tested?
* Tested display of tables on accounts that have history, and ones that do not have history

## Screenshots (if appropriate):
No pagination:
<img width="963" alt="image" src="https://user-images.githubusercontent.com/10401554/178042576-ffee94bb-fd27-41ec-a0b5-7c4a69958102.png">

Pagination:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/10401554/178042619-1d5f69fb-9941-4fd5-9303-c641c99890b3.png">

No result:
<img width="956" alt="image" src="https://user-images.githubusercontent.com/10401554/178042683-e2d65c36-18c7-400f-848b-8801709cf482.png">
