### PR TITLE
Add atomic swap check back and remove the duplicated redeem button

### DIFF
--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -977,9 +977,21 @@ const useExchange = ({
 			setTxError(null);
 			setTxConfirmationModalOpen(true);
 
+			const sourceCurrencyKey = ethers.utils.parseBytes32String(
+				getExchangeParams(true)[0] as string
+			);
+
 			const destinationCurrencyKey = ethers.utils.parseBytes32String(
 				getExchangeParams(true)[2] as string
 			);
+
+			const isAtomic =
+				!isL2 &&
+				[sourceCurrencyKey, destinationCurrencyKey].every((currency) =>
+					ATOMIC_EXCHANGES_L1.includes(currency)
+				);
+
+			const exchangeParams = getExchangeParams(isAtomic);
 
 			try {
 				setIsSubmitting(true);
@@ -1010,14 +1022,6 @@ const useExchange = ({
 						gasLimit: gasInfo?.limit,
 						...gasConfig,
 					};
-					const isAtomic =
-						!isL2 &&
-						(destinationCurrencyKey === 'sBTC' ||
-							destinationCurrencyKey === 'sETH' ||
-							destinationCurrencyKey === 'sEUR' ||
-							destinationCurrencyKey === 'sUSD');
-
-					const exchangeParams = getExchangeParams(isAtomic);
 
 					if (isAtomic) {
 						tx = await synthetixjs.contracts.Synthetix.exchangeAtomically(...exchangeParams, gas);
@@ -1342,26 +1346,6 @@ const useExchange = ({
 					// show fee's only for "synthetix" (provider)
 					showFee={txProvider === 'synthetix'}
 					isApproved={needsApproval ? isApproved : undefined}
-				/>
-			)}
-			{balances.length !== 0 && totalUSDBalance.gt(0) && (
-				<Button
-					variant="primary"
-					isRounded={true}
-					disabled={false}
-					onClick={handleRedeem}
-					size="lg"
-					data-testid="submit-order"
-					fullWidth={true}
-				>
-					{t('dashboard.deprecated.button.redeem-synths')}
-				</Button>
-			)}
-			{!redeemTxModalOpen ? null : (
-				<RedeemTxModal
-					{...{ txError, balances, totalUSDBalance }}
-					onDismiss={handleDismiss}
-					attemptRetry={handleRedeem}
 				/>
 			)}
 			{balances.length !== 0 && totalUSDBalance.gt(0) && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Atomic swap check has been reverted in the #1038 
2. Remove the duplicated redeem button introduced by #1028 

## Related issue
#1038
#1028

## Motivation and Context

## How Has This Been Tested?
1. Atomic swap check has been reverted
- sETH => sUSD (atomic swap): https://kovan.etherscan.io/tx/0xdc333a29182b8eaa00dc04f6f931c4c34e7e739ce8b51bb3cbe677b8e72b278c
- sLINK => sUSD  (fee recl.):
https://kovan.etherscan.io/tx/0xbd108dd5278e17090e146747fbc1af158954d08d5ca414b3ad51b88b9ecf0dd6

3. Remove the duplicated redeem button
- Open the exchange page and connected the wallet with deprecated synths.
- Only see one button.
 
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/178552529-dc6ad830-661e-40f6-9716-c607fab36717.png)
