### PR TITLE
Bug: Locale error

### DIFF
--- a/utils/formatters/getLocale.ts
+++ b/utils/formatters/getLocale.ts
@@ -332,7 +332,8 @@ function getLocale() {
 			break;
 
 		default:
-			console.error('Locale could not be detected.');
+			locale_ = enUS;
+			break;
 	}
 
 	return locale_;

--- a/utils/formatters/getLocale.ts
+++ b/utils/formatters/getLocale.ts
@@ -333,7 +333,6 @@ function getLocale() {
 
 		default:
 			locale_ = enUS;
-			break;
 	}
 
 	return locale_;


### PR DESCRIPTION
Currently we throw an error when the browser can't find a locale for a user. This is increasingly common on browsers that block tracking, and causes the console to flood with errors.

## Description
* Remove `console.error` when we can't find a locale
* Set the default locale to `enUS` when a locale is not found 🇺🇸 
