### PR TITLE
Fix ETH swaps failing with 1inch

### DIFF
--- a/hooks/useENSs.ts
+++ b/hooks/useENSs.ts
@@ -22,6 +22,7 @@ const useENSs = (addresses: string[], options?: UseQueryOptions<any | null>) => 
 			const ReverseLookup = new Contract(
 				ENS_REVERSE_LOOKUP,
 				reverseRecordsAbi,
+				// @ts-ignore provider type
 				staticMainnetProvider
 			);
 

--- a/sections/exchange/hooks/useExchange.tsx
+++ b/sections/exchange/hooks/useExchange.tsx
@@ -657,6 +657,14 @@ const useExchange = ({
 		]
 	);
 
+	const oneInchSlippage = useMemo(() => {
+		// ETH swaps often fail with lower slippage
+		if (txProvider === '1inch' && (baseCurrencyKey === 'ETH' || quoteCurrencyKey === 'ETH')) {
+			return 3;
+		}
+		return slippage;
+	}, [txProvider, baseCurrencyKey, quoteCurrencyKey, slippage]);
+
 	const getGasEstimateForExchange = useCallback(
 		async (gasPriceInWei: number | null) => {
 			try {
@@ -735,13 +743,13 @@ const useExchange = ({
 						quoteCurrencyTokenAddress!,
 						baseCurrencyTokenAddress!,
 						quoteCurrencyAmount,
-						slippage
+						oneInchSlippage
 					);
 					const metaTx = await swap1Inch(
 						quoteCurrencyTokenAddress!,
 						baseCurrencyTokenAddress!,
 						quoteCurrencyAmount,
-						slippage,
+						oneInchSlippage,
 						true
 					);
 					const l1Fee = await getL1SecurityFee({
@@ -766,6 +774,7 @@ const useExchange = ({
 			baseCurrencyTokenAddress,
 			quoteCurrencyAmount,
 			slippage,
+			oneInchSlippage,
 			txProvider,
 			baseCurrencyKey,
 			quoteCurrencyKey,
@@ -1004,7 +1013,7 @@ const useExchange = ({
 						quoteCurrencyTokenAddress!,
 						baseCurrencyTokenAddress!,
 						quoteCurrencyAmount,
-						slippage
+						oneInchSlippage
 					);
 				} else if (txProvider === 'synthswap') {
 					tx = await swapSynthSwap(
@@ -1092,6 +1101,7 @@ const useExchange = ({
 		txProvider,
 		monitorTransaction,
 		slippage,
+		oneInchSlippage,
 		oneInchTokensMap,
 		synthetixjs,
 		gasPriceWei,


### PR DESCRIPTION
Some 1inch swaps which include ETH sometimes fail when slippage is only 1%. Raising to 3% seems to be the minimum to ensure these swaps don't error.