### PR TITLE
Hotfix: L1 atomic swaps

### DIFF
--- a/sections/exchange/hooks/useExchange.ts
+++ b/sections/exchange/hooks/useExchange.ts
@@ -599,7 +599,7 @@ const useExchange = ({
 		'Synthetix',
 		isAtomic ? 'exchangeAtomically' : 'exchangeWithTracking',
 		exchangeParams!,
-		gasPrice ?? undefined,
+		undefined,
 		{
 			enabled: (needsApproval ? isApproved : true) && !!exchangeParams && !!walletAddress,
 		}
@@ -707,7 +707,7 @@ const useExchange = ({
 		'SynthRedeemer',
 		'redeemAll',
 		[redeemableDeprecatedSynths?.balances.map((b) => b.proxyAddress)],
-		gasPrice ?? undefined,
+		undefined,
 		{ enabled: !!redeemableDeprecatedSynths && redeemableDeprecatedSynths?.totalUSDBalance.gt(0) }
 	);
 
@@ -787,7 +787,7 @@ const useExchange = ({
 		quoteCurrencyContract,
 		'approve',
 		[approveAddress, ethers.constants.MaxUint256],
-		gasPrice ?? undefined,
+		undefined,
 		{ enabled: !!approveAddress && !!quoteCurrencyKey && !!oneInchTokensMap && needsApproval }
 	);
 
@@ -795,7 +795,7 @@ const useExchange = ({
 		'Exchanger',
 		'settle',
 		[walletAddress, destinationCurrencyKey],
-		gasPrice ?? undefined,
+		undefined,
 		{ enabled: !isL2 && numEntries >= 12 }
 	);
 


### PR DESCRIPTION
L1 atomic swaps are failing due to an error thrown by `useSynthetixTxn` with our gas object. The transaction estimates gas itself, so we can remove our gas specification completely and the transaction will succeed.

[Test txn](https://etherscan.io/tx/0x46dda8b75fbad85c0609de3ebabb81991d300e6dc6034d9c2847e04ebf66f1cc)