### PR TITLE
Fee display conditions

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -209,8 +209,6 @@ const useFuturesData = () => {
 				!synthetixjs ||
 				!marketAsset ||
 				!walletAddress ||
-				!tradeSize ||
-				Number(tradeSize) === 0 ||
 				!isLeverageValueCommitted ||
 				!position?.remainingMargin
 			) {


### PR DESCRIPTION
Removes a condition where the trader needs to input a trade size before displaying the dynamic fee.

## Description
* Remove nonzero trade size as a condition for calculating fees

## Motivation and Context
This will make sure we display the dynamic fee immediately when a futures market is selected.

