### PR TITLE
Hotfix: Default table size

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -97,7 +97,7 @@ export const Table: FC<TableProps> = ({
 						: MAX_PAGE_ROWS
 					: showShortList
 					? pageSize ?? 5
-					: data.length,
+					: 15,
 				hiddenColumns: hiddenColumns,
 				sortBy: sortBy,
 			},


### PR DESCRIPTION
Hotfixing an error that results from a page size being determined by the length of data, which can be zero. Setting a default instead to avoid crashes.