### PR TITLE
Fixed the missing market rate for new listing assets

### DIFF
--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -32,16 +32,25 @@ export const getExchangeRatesForCurrencies = (
 
 export const newGetExchangeRatesForCurrencies = (
 	rates: Rates | null,
-	base: CurrencyKey | FuturesMarketKey | null,
+	base: CurrencyKey | FuturesMarketKey | string | null,
 	quote: CurrencyKey | FuturesMarketKey | null
-) =>
-	rates == null ||
-	base == null ||
-	quote == null ||
-	rates[base] === undefined ||
-	rates[quote] === undefined
+) => {
+	base = new Set([
+		FuturesMarketKey.sAPE,
+		FuturesMarketKey.sDYDX,
+		FuturesMarketKey.sXAU,
+		FuturesMarketKey.sXAG,
+	]).has(base as FuturesMarketKey)
+		? synthToAsset(base as CurrencyKey)
+		: base;
+	return rates == null ||
+		base == null ||
+		quote == null ||
+		rates[base] === undefined ||
+		rates[quote] === undefined
 		? wei(0)
 		: rates[base].div(rates[quote]);
+};
 
 export const getCurrencyKeyURLPath = (currencyKey: CurrencyKey) =>
 	`https:///www.synthetix.io/assets/synths/svg/${currencyKey}.svg`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some of the perps (APE/DYDX/XAU/XAG) show 0 in trade size amount in USD. It doesn't affect the open position activity.
![image](https://user-images.githubusercontent.com/4819006/180420594-31a68c86-70c6-469c-8823-9da611176a8f.png)


## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Improve the UX and make the open size clear for traders.

## How Has This Been Tested?
1. Open a position for APE/DYDX/XAU
2. Type the trade size and see the correct amount of USD.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/180421020-8b95067f-8f9f-4c93-a41e-fc93b2313258.png)
![image](https://user-images.githubusercontent.com/4819006/180421069-7aa38d9e-f03f-423e-8833-326150231a6a.png)
