### PR TITLE
Bug: Futures positions table

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -251,8 +251,8 @@ const TableCellHead = styled(TableCell)<{ hideHeaders: boolean }>`
 	${(props) => (props.hideHeaders ? `display: none` : '')}
 `;
 
-export const TableNoResults = styled(GridDivCenteredRow)<{ wide?: boolean }>`
-	padding: ${(props) => (props.wide ? '50px' : '12px')} 0;
+export const TableNoResults = styled(GridDivCenteredRow)`
+	padding: 50px 0;
 	justify-content: center;
 	margin-top: -2px;
 	justify-items: center;

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -5,7 +5,7 @@ import styled, { css } from 'styled-components';
 import SortDownIcon from 'assets/svg/app/caret-down.svg';
 import SortUpIcon from 'assets/svg/app/caret-up.svg';
 import Spinner from 'assets/svg/app/loader.svg';
-import { FlexDivCentered } from 'styles/common';
+import { FlexDivCentered, GridDivCenteredRow } from 'styles/common';
 
 import Pagination from './Pagination';
 
@@ -249,6 +249,23 @@ const TableCellHead = styled(TableCell)<{ hideHeaders: boolean }>`
 		padding-right: 18px;
 	}
 	${(props) => (props.hideHeaders ? `display: none` : '')}
+`;
+
+export const TableNoResults = styled(GridDivCenteredRow)<{ wide?: boolean }>`
+	padding: ${(props) => (props.wide ? '50px' : '12px')} 0;
+	justify-content: center;
+	margin-top: -2px;
+	justify-items: center;
+	grid-gap: 10px;
+	color: ${(props) => props.theme.colors.selectedTheme.button.text};
+	font-size: 16px;
+	font-family: ${(props) => props.theme.fonts.bold};
+	div {
+		text-decoration: underline;
+		cursor: pointer;
+		font-size: 16px;
+		font-family: ${(props) => props.theme.fonts.regular};
+	}
 `;
 
 const SortIconContainer = styled.span`

--- a/components/Table/index.ts
+++ b/components/Table/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Table';
+export { default, TableNoResults } from './Table';

--- a/contexts/RefetchContext.tsx
+++ b/contexts/RefetchContext.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import useGetFuturesMarket from 'queries/futures/useGetFuturesMarket';
+import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesOpenOrders from 'queries/futures/useGetFuturesOpenOrders';
 import useGetFuturesPositionForMarket from 'queries/futures/useGetFuturesPositionForMarket';
 import useGetFuturesPositionForMarkets from 'queries/futures/useGetFuturesPositionForMarkets';
@@ -23,6 +24,7 @@ export const RefetchProvider: React.FC = ({ children }) => {
 	const positionQuery = useGetFuturesPositionForMarket();
 	const positionsQuery = useGetFuturesPositionForMarkets([]);
 	const marketQuery = useGetFuturesMarket();
+	useGetFuturesMarkets();
 	useGetFuturesPotentialTradeDetails();
 
 	const handleRefetch = (refetchType: RefetchType, timeout?: number) => {

--- a/queries/futures/useGetFuturesPositionForMarkets.ts
+++ b/queries/futures/useGetFuturesPositionForMarkets.ts
@@ -23,7 +23,7 @@ const useGetFuturesPositionForMarkets = (
 	const { synthetixjs } = Connector.useContainer();
 	const [, setFuturesPositions] = useRecoilState(positionsState);
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
-	const assets = futuresMarkets?.map(({ asset }) => asset) ?? [];
+	const assets = futuresMarkets.map(({ asset }) => asset);
 
 	return useQuery<FuturesPosition[] | []>(
 		QUERY_KEYS.Futures.MarketsPositions(network.id, walletAddress, assets || []),

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -9,7 +9,7 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import Currency from 'components/Currency';
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import PositionType from 'components/Text/PositionType';
 import { Synths } from 'constants/currency';
 import { ETH_UNIT } from 'constants/network';
@@ -21,7 +21,6 @@ import { FuturesTrade } from 'queries/futures/types';
 import useGetAllFuturesTradesForAccount from 'queries/futures/useGetAllFuturesTradesForAccount';
 import { TradeStatus } from 'sections/futures/types';
 import { isL2State, walletAddressState } from 'store/wallet';
-import { GridDivCenteredRow } from 'styles/common';
 import { formatCryptoCurrency, formatCurrency } from 'utils/formatters/number';
 import { FuturesMarketAsset, getDisplayAsset, MarketKeyByAsset } from 'utils/futures';
 
@@ -71,12 +70,12 @@ const FuturesHistoryTable: FC = () => {
 				isLoading={futuresTradesQuery.isLoading}
 				noResultsMessage={
 					!isL2 ? (
-						<TableNoResults>
+						<TableNoResults wide>
 							{t('common.l2-cta')}
 							<div onClick={switchToL2}>{t('homepage.l2.cta-buttons.switch-l2')}</div>
 						</TableNoResults>
 					) : (
-						<TableNoResults>
+						<TableNoResults wide>
 							{t('dashboard.history.futures-history-table.no-result')}
 							<Link href={ROUTES.Markets.Home}>
 								<div>{t('common.perp-cta')}</div>
@@ -266,23 +265,6 @@ const PNL = styled.div<{ negative?: boolean; normal?: boolean }>`
 			: props.negative
 			? props.theme.colors.selectedTheme.red
 			: props.theme.colors.selectedTheme.green};
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	margin-top: -2px;
-	justify-items: center;
-	grid-gap: 10px;
-	color: ${(props) => props.theme.colors.selectedTheme.button.text};
-	font-size: 20px;
-	font-family: ${(props) => props.theme.fonts.bold};
-	div {
-		text-decoration: underline;
-		cursor: pointer;
-		font-size: 16px;
-		font-family: ${(props) => props.theme.fonts.regular};
-	}
 `;
 
 export default FuturesHistoryTable;

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -70,12 +70,12 @@ const FuturesHistoryTable: FC = () => {
 				isLoading={futuresTradesQuery.isLoading}
 				noResultsMessage={
 					!isL2 ? (
-						<TableNoResults wide>
+						<TableNoResults>
 							{t('common.l2-cta')}
 							<div onClick={switchToL2}>{t('homepage.l2.cta-buttons.switch-l2')}</div>
 						</TableNoResults>
 					) : (
-						<TableNoResults wide>
+						<TableNoResults>
 							{t('dashboard.history.futures-history-table.no-result')}
 							<Link href={ROUTES.Markets.Home}>
 								<div>{t('common.perp-cta')}</div>

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -72,14 +72,14 @@ const FuturesHistoryTable: FC = () => {
 				noResultsMessage={
 					!isL2 ? (
 						<TableNoResults>
-							{t('dashboard.history.futures-history-table.no-results')}
+							{t('common.l2-cta')}
 							<div onClick={switchToL2}>{t('homepage.l2.cta-buttons.switch-l2')}</div>
 						</TableNoResults>
 					) : (
 						<TableNoResults>
-							{t('dashboard.history.futures-history-table.no-trade-history')}
+							{t('dashboard.history.futures-history-table.no-result')}
 							<Link href={ROUTES.Markets.Home}>
-								<div>{t('dashboard.history.futures-history-table.no-trade-history-link')}</div>
+								<div>{t('common.perp-cta')}</div>
 							</Link>
 						</TableNoResults>
 					)

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -35,17 +35,17 @@ const FuturesMarketsTable: FC = () => {
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const synthList = futuresMarkets?.map(({ asset }) => asset) ?? [];
+	const synthList = futuresMarkets.map(({ asset }) => asset);
 	const dailyPriceChangesQuery = useLaggedDailyPrice(synthList);
 
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();
 
 	const fundingRates = useGetAverageFundingRateForMarkets(
-		futuresMarkets?.map(({ asset, price, currentFundingRate }) => ({
+		futuresMarkets.map(({ asset, price, currentFundingRate }) => ({
 			currencyKey: asset,
 			assetPrice: price.toNumber(),
 			currentFundingRate: currentFundingRate.toNumber(),
-		})) ?? [],
+		})),
 		PERIOD_IN_SECONDS[Period.ONE_HOUR]
 	);
 
@@ -53,35 +53,33 @@ const FuturesMarketsTable: FC = () => {
 		const dailyPriceChanges = dailyPriceChangesQuery.data ?? [];
 		const futuresVolume = futuresVolumeQuery.data ?? {};
 
-		return (
-			futuresMarkets?.map((market) => {
-				const description = getSynthDescription(market.asset, synthsMap, t);
-				const volume = futuresVolume[market.assetHex];
-				const pastPrice = dailyPriceChanges.find((price) => price.synth === market.asset);
-				const fundingRateResponse = fundingRates.find(
-					({ data: fundingData }) => (fundingData as FundingRateResponse)?.asset === market.asset
-				);
+		return futuresMarkets.map((market) => {
+			const description = getSynthDescription(market.asset, synthsMap, t);
+			const volume = futuresVolume[market.assetHex];
+			const pastPrice = dailyPriceChanges.find((price) => price.synth === market.asset);
+			const fundingRateResponse = fundingRates.find(
+				({ data: fundingData }) => (fundingData as FundingRateResponse)?.asset === market.asset
+			);
 
-				return {
-					asset: market.asset,
-					market: getDisplayAsset(market.asset) + '-PERP',
-					synth: synthsMap[market.asset],
-					description,
-					price: market.price,
-					volume: volume?.toNumber() ?? 0,
-					pastPrice: pastPrice?.price,
-					priceChange: market.price.sub(pastPrice?.price ?? 0).div(market.price),
-					fundingRate: (fundingRateResponse?.data as FundingRateResponse)?.fundingRate ?? null,
-					openInterest: market.marketSize.mul(market.price),
-					openInterestNative: market.marketSize,
-					longInterest: market.marketSize.add(market.marketSkew).div('2').abs().mul(market.price),
-					shortInterest: market.marketSize.sub(market.marketSkew).div('2').abs().mul(market.price),
-					marketSkew: market.marketSkew,
-					isSuspended: market.isSuspended,
-					marketClosureReason: market.marketClosureReason,
-				};
-			}) ?? []
-		);
+			return {
+				asset: market.asset,
+				market: getDisplayAsset(market.asset) + '-PERP',
+				synth: synthsMap[market.asset],
+				description,
+				price: market.price,
+				volume: volume?.toNumber() ?? 0,
+				pastPrice: pastPrice?.price,
+				priceChange: market.price.sub(pastPrice?.price ?? 0).div(market.price),
+				fundingRate: (fundingRateResponse?.data as FundingRateResponse)?.fundingRate ?? null,
+				openInterest: market.marketSize.mul(market.price),
+				openInterestNative: market.marketSize,
+				longInterest: market.marketSize.add(market.marketSkew).div('2').abs().mul(market.price),
+				shortInterest: market.marketSize.sub(market.marketSkew).div('2').abs().mul(market.price),
+				marketSkew: market.marketSkew,
+				isSuspended: market.isSuspended,
+				marketClosureReason: market.marketClosureReason,
+			};
+		});
 	}, [
 		synthsMap,
 		futuresMarkets,

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -10,7 +10,7 @@ import MarketBadge from 'components/Badge/MarketBadge';
 import ChangePercent from 'components/ChangePercent';
 import Currency from 'components/Currency';
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import PositionType from 'components/Text/PositionType';
 import { Synths } from 'constants/currency';
 import { DEFAULT_FIAT_EURO_DECIMALS } from 'constants/defaults';
@@ -21,7 +21,6 @@ import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
 import { PositionHistory } from 'queries/futures/types';
 import { currentMarketState, futuresMarketsState, positionsState } from 'store/futures';
 import { isL2State } from 'store/wallet';
-import { GridDivCenteredRow } from 'styles/common';
 import { formatNumber } from 'utils/formatters/number';
 import {
 	FuturesMarketAsset,
@@ -374,22 +373,6 @@ const NoPositionsText = styled.div`
 	font-size: 16px;
 	text-align: center;
 	text-decoration: underline;
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 12px 0;
-	justify-content: center;
-	margin-top: -2px;
-	justify-items: center;
-	grid-gap: 10px;
-	color: ${(props) => props.theme.colors.selectedTheme.button.text};
-	font-size: 16px;
-	div {
-		text-decoration: underline;
-		cursor: pointer;
-		font-size: 16px;
-		font-family: ${(props) => props.theme.fonts.regular};
-	}
 `;
 
 export default FuturesPositionsTable;

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -57,7 +57,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 
 		return activePositions
 			.map((position) => {
-				const market = futuresMarkets?.find((market) => market.asset === position.asset);
+				const market = futuresMarkets.find((market) => market.asset === position.asset);
 				const description = getSynthDescription(position.asset, synthsMap, t);
 				const positionHistory = futuresPositionHistory?.find((positionHistory) => {
 					return positionHistory.isOpen && positionHistory.asset === position.asset;

--- a/sections/dashboard/Markets/Markets.tsx
+++ b/sections/dashboard/Markets/Markets.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import TabButton from 'components/Button/TabButton';
 import { TabPanel } from 'components/Tab';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 
 import FuturesMarketsTable from '../FuturesMarketsTable';
@@ -17,9 +16,6 @@ enum MarketsTab {
 
 const Markets: FC = () => {
 	const { t } = useTranslation();
-
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
 
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
@@ -56,7 +52,7 @@ const Markets: FC = () => {
 				))}
 			</TabButtonsContainer>
 			<TabPanel name={MarketsTab.FUTURES} activeTab={activeMarketsTab}>
-				<FuturesMarketsTable futuresMarkets={futuresMarkets} />
+				<FuturesMarketsTable />
 			</TabPanel>
 
 			<TabPanel name={MarketsTab.SPOT} activeTab={activeMarketsTab}>

--- a/sections/dashboard/MobileDashboard/FuturesMarkets.tsx
+++ b/sections/dashboard/MobileDashboard/FuturesMarkets.tsx
@@ -18,7 +18,7 @@ const FuturesMarkets = () => {
 	const openInterest = useMemo(() => {
 		return (
 			futuresMarkets
-				?.map((market) => market.marketSize.mul(market.price).toNumber())
+				.map((market) => market.marketSize.mul(market.price).toNumber())
 				.reduce((total, openInterest) => total + openInterest, 0) ?? null
 		);
 	}, [futuresMarkets]);

--- a/sections/dashboard/MobileDashboard/FuturesMarkets.tsx
+++ b/sections/dashboard/MobileDashboard/FuturesMarkets.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { Synths } from 'constants/currency';
 import useGetFuturesDailyTradeStats from 'queries/futures/useGetFuturesDailyTradeStats';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
+import { futuresMarketsState } from 'store/futures';
 import { formatCurrency, formatNumber, zeroBN } from 'utils/formatters/number';
 
 import FuturesMarketsTable from '../FuturesMarketsTable';
 import { HeaderContainer, MarketStatsContainer, MarketStat } from './common';
 
 const FuturesMarkets = () => {
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = React.useMemo(() => futuresMarketsQuery?.data ?? [], [
-		futuresMarketsQuery?.data,
-	]);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
 	const dailyTradeStats = useGetFuturesDailyTradeStats();
 
-	const openInterest = React.useMemo(() => {
-		return futuresMarkets
-			.map((market) => market.marketSize.mul(market.price).toNumber())
-			.reduce((total, openInterest) => total + openInterest, 0);
+	const openInterest = useMemo(() => {
+		return (
+			futuresMarkets
+				?.map((market) => market.marketSize.mul(market.price).toNumber())
+				.reduce((total, openInterest) => total + openInterest, 0) ?? null
+		);
 	}, [futuresMarkets]);
 
 	return (
@@ -57,7 +57,7 @@ const FuturesMarkets = () => {
 				</MarketStatsContainer>
 			</HeaderContainer>
 
-			<FuturesMarketsTable futuresMarkets={futuresMarkets} />
+			<FuturesMarketsTable />
 		</div>
 	);
 };

--- a/sections/dashboard/MobileDashboard/OpenPositions.tsx
+++ b/sections/dashboard/MobileDashboard/OpenPositions.tsx
@@ -31,7 +31,7 @@ const OpenPositions: React.FC = () => {
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
+	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
 	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 

--- a/sections/dashboard/MobileDashboard/OpenPositions.tsx
+++ b/sections/dashboard/MobileDashboard/OpenPositions.tsx
@@ -9,9 +9,9 @@ import TabButton from 'components/Button/TabButton';
 import { TabPanel } from 'components/Tab';
 import { Synths } from 'constants/currency';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
+import { futuresMarketsState } from 'store/futures';
 import { walletAddressState } from 'store/wallet';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
 import { MarketKeyByAsset } from 'utils/futures';
@@ -29,10 +29,9 @@ const OpenPositions: React.FC = () => {
 
 	const { useExchangeRatesQuery, useSynthsBalancesQuery } = useSynthetixQueries();
 
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
+	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
 	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 
@@ -112,8 +111,8 @@ const OpenPositions: React.FC = () => {
 
 			<TabPanel name={PositionsTab.FUTURES} activeTab={activePositionsTab}>
 				<FuturesPositionsTable
-					futuresMarkets={futuresMarkets}
 					futuresPositionHistory={futuresPositionHistory}
+					showCurrentMarket={true}
 				/>
 			</TabPanel>
 

--- a/sections/dashboard/MobileDashboard/SynthMarkets.tsx
+++ b/sections/dashboard/MobileDashboard/SynthMarkets.tsx
@@ -23,7 +23,7 @@ const SynthMarkets: React.FC = () => {
 
 	const openInterest = React.useMemo(() => {
 		return futuresMarkets
-			?.map((market) => market.marketSize.mul(market.price).toNumber())
+			.map((market) => market.marketSize.mul(market.price).toNumber())
 			.reduce((total, openInterest) => total + openInterest, 0);
 	}, [futuresMarkets]);
 

--- a/sections/dashboard/MobileDashboard/SynthMarkets.tsx
+++ b/sections/dashboard/MobileDashboard/SynthMarkets.tsx
@@ -1,20 +1,18 @@
 import useSynthetixQueries from '@synthetixio/queries';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { Synths } from 'constants/currency';
 import useGetFuturesDailyTradeStats from 'queries/futures/useGetFuturesDailyTradeStats';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
+import { futuresMarketsState } from 'store/futures';
 import { formatCurrency, formatNumber, zeroBN } from 'utils/formatters/number';
 
 import SpotMarketsTable from '../SpotMarketsTable';
 import { HeaderContainer, MarketStatsContainer, MarketStat } from './common';
 
 const SynthMarkets: React.FC = () => {
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = React.useMemo(() => futuresMarketsQuery?.data ?? [], [
-		futuresMarketsQuery?.data,
-	]);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
 	const { useExchangeRatesQuery } = useSynthetixQueries();
 
@@ -25,7 +23,7 @@ const SynthMarkets: React.FC = () => {
 
 	const openInterest = React.useMemo(() => {
 		return futuresMarkets
-			.map((market) => market.marketSize.mul(market.price).toNumber())
+			?.map((market) => market.marketSize.mul(market.price).toNumber())
 			.reduce((total, openInterest) => total + openInterest, 0);
 	}, [futuresMarkets]);
 

--- a/sections/dashboard/Overview/Overview.tsx
+++ b/sections/dashboard/Overview/Overview.tsx
@@ -39,7 +39,7 @@ const Overview: FC = () => {
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
+	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
 	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 

--- a/sections/dashboard/Overview/Overview.tsx
+++ b/sections/dashboard/Overview/Overview.tsx
@@ -9,8 +9,8 @@ import styled from 'styled-components';
 import TabButton from 'components/Button/TabButton';
 import { TabPanel } from 'components/Tab';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
+import { futuresMarketsState } from 'store/futures';
 import { walletAddressState } from 'store/wallet';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
 import { MarketKeyByAsset } from 'utils/futures';
@@ -37,10 +37,9 @@ const Overview: FC = () => {
 
 	const { useExchangeRatesQuery, useSynthsBalancesQuery } = useSynthetixQueries();
 
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
+	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
 	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 
@@ -93,15 +92,6 @@ const Overview: FC = () => {
 					setActivePositionsTab(PositionsTab.SPOT);
 				},
 			},
-			// {
-			// 	name: PositionsTab.SHORTS,
-			// 	label: t('dashboard.overview.positions-tabs.shorts'),
-			// 	disabled: true,
-			// 	active: activePositionsTab === PositionsTab.SHORTS,
-			// 	onClick: () => {
-			// 		setActivePositionsTab(PositionsTab.SHORTS);
-			// 	},
-			// },
 		],
 		[
 			activePositionsTab,
@@ -144,10 +134,7 @@ const Overview: FC = () => {
 				))}
 			</TabButtonsContainer>
 			<TabPanel name={PositionsTab.FUTURES} activeTab={activePositionsTab}>
-				<FuturesPositionsTable
-					futuresMarkets={futuresMarkets}
-					futuresPositionHistory={futuresPositionHistory}
-				/>
+				<FuturesPositionsTable futuresPositionHistory={futuresPositionHistory} />
 			</TabPanel>
 
 			<TabPanel name={PositionsTab.SPOT} activeTab={activePositionsTab}>
@@ -163,7 +150,7 @@ const Overview: FC = () => {
 				))}
 			</TabButtonsContainer>
 			<TabPanel name={MarketsTab.FUTURES} activeTab={activeMarketsTab}>
-				<FuturesMarketsTable futuresMarkets={futuresMarkets} />
+				<FuturesMarketsTable />
 			</TabPanel>
 
 			<TabPanel name={MarketsTab.SPOT} activeTab={activeMarketsTab}>

--- a/sections/dashboard/PortfolioChart/PortfolioChart.tsx
+++ b/sections/dashboard/PortfolioChart/PortfolioChart.tsx
@@ -15,7 +15,7 @@ import { MarketKeyByAsset } from 'utils/futures';
 const PortfolioChart: FC = () => {
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
+	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
 	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 

--- a/sections/dashboard/PortfolioChart/PortfolioChart.tsx
+++ b/sections/dashboard/PortfolioChart/PortfolioChart.tsx
@@ -7,16 +7,15 @@ import Currency from 'components/Currency';
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
 import { Synths } from 'constants/currency';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
+import { futuresMarketsState } from 'store/futures';
 import { walletAddressState } from 'store/wallet';
 import { zeroBN } from 'utils/formatters/number';
 import { MarketKeyByAsset } from 'utils/futures';
 
 const PortfolioChart: FC = () => {
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
+	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
 	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -72,7 +72,7 @@ const SpotHistoryTable: FC = () => {
 				isLoading={walletTradesQuery.isLoading}
 				highlightRowsOnHover
 				noResultsMessage={
-					<TableNoResults wide>
+					<TableNoResults>
 						{t('dashboard.history.spot-history-table.no-trade-history')}
 						<Link href={ROUTES.Exchange.Home}>
 							<div>{t('dashboard.history.spot-history-table.no-trade-history-link')}</div>

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 
 import LinkIcon from 'assets/svg/app/link.svg';
 import Currency from 'components/Currency';
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import { CurrencyKey } from 'constants/currency';
 import { NO_VALUE } from 'constants/placeholder';
 import ROUTES from 'constants/routes';
@@ -21,7 +21,6 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import useGetWalletTrades from 'queries/synths/useGetWalletTrades';
 import { walletAddressState } from 'store/wallet';
 import { ExternalLink } from 'styles/common';
-import { GridDivCenteredRow } from 'styles/common';
 import { isFiatCurrency } from 'utils/currencies';
 
 import TimeDisplay from '../../futures/Trades/TimeDisplay';
@@ -73,7 +72,7 @@ const SpotHistoryTable: FC = () => {
 				isLoading={walletTradesQuery.isLoading}
 				highlightRowsOnHover
 				noResultsMessage={
-					<TableNoResults>
+					<TableNoResults wide>
 						{t('dashboard.history.spot-history-table.no-trade-history')}
 						<Link href={ROUTES.Exchange.Home}>
 							<div>{t('dashboard.history.spot-history-table.no-trade-history-link')}</div>
@@ -265,23 +264,6 @@ const StyledText = styled.div`
 	grid-column: 2;
 	grid-row: 1;
 	color: ${(props) => props.theme.colors.common.secondaryGray};
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	margin-top: -2px;
-	justify-items: center;
-	grid-gap: 10px;
-	color: ${(props) => props.theme.colors.selectedTheme.button.text};
-	font-size: 20px;
-	font-family: ${(props) => props.theme.fonts.bold};
-	div {
-		text-decoration: underline;
-		cursor: pointer;
-		font-size: 16px;
-		font-family: ${(props) => props.theme.fonts.regular};
-	}
 `;
 
 const SynthContainer = styled.div`

--- a/sections/dashboard/SynthBalancesTable/SynthBalancesTable.tsx
+++ b/sections/dashboard/SynthBalancesTable/SynthBalancesTable.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import ChangePercent from 'components/ChangePercent';
 import Currency from 'components/Currency';
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import { NO_VALUE } from 'constants/placeholder';
 import Connector from 'containers/Connector';
 import { Price } from 'queries/rates/types';
@@ -83,6 +83,11 @@ const SynthBalancesTable: FC<SynthBalancesTableProps> = ({
 						data={data}
 						showPagination
 						highlightRowsOnHover
+						noResultsMessage={
+							<TableNoResults>
+								{t('dashboard.overview.synth-balances-table.no-result')}
+							</TableNoResults>
+						}
 						columns={[
 							{
 								Header: (
@@ -229,9 +234,9 @@ const SynthBalancesTable: FC<SynthBalancesTableProps> = ({
 				<StyledMobileTable
 					data={data}
 					noResultsMessage={
-						data.length === 0 ? (
-							<EmptyTableMessage>There are no synth balances.</EmptyTableMessage>
-						) : null
+						<TableNoResults>
+							{t('dashboard.overview.synth-balances-table.no-result')}
+						</TableNoResults>
 					}
 					columns={[
 						{
@@ -373,13 +378,6 @@ const StyledMobileTable = styled(Table)`
 	border-top: none;
 	border-right: none;
 	border-left: none;
-`;
-
-const EmptyTableMessage = styled.div`
-	color: ${(props) => props.theme.colors.selectedTheme.text.value};
-	font-size: 16px;
-	text-align: center;
-	margin: 20px 0;
 `;
 
 export default SynthBalancesTable;

--- a/sections/futures/FuturesMarketTabs/FuturesMarketTab.tsx
+++ b/sections/futures/FuturesMarketTabs/FuturesMarketTab.tsx
@@ -33,7 +33,7 @@ const FuturesMarketsTable: FC = () => {
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const synthList = futuresMarkets?.map(({ asset }) => asset) ?? [];
+	const synthList = futuresMarkets.map(({ asset }) => asset);
 	const dailyPriceChangesQuery = useLaggedDailyPrice(synthList);
 
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();

--- a/sections/futures/FuturesMarketTabs/FuturesMarketTab.tsx
+++ b/sections/futures/FuturesMarketTabs/FuturesMarketTab.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CellProps } from 'react-table';
+import { useRecoilValue } from 'recoil';
 import styled, { css } from 'styled-components';
 
 import MarketBadge from 'components/Badge/MarketBadge';
@@ -11,15 +12,11 @@ import Table from 'components/Table';
 import { Synths } from 'constants/currency';
 import { DEFAULT_FIAT_EURO_DECIMALS } from 'constants/defaults';
 import ROUTES from 'constants/routes';
-import { FuturesMarket } from 'queries/futures/types';
 import useGetFuturesTradingVolumeForAllMarkets from 'queries/futures/useGetFuturesTradingVolumeForAllMarkets';
 import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
+import { futuresMarketsState } from 'store/futures';
 import { FlexDivCol } from 'styles/common';
 import { FuturesMarketAsset, getDisplayAsset, isEurForex, MarketKeyByAsset } from 'utils/futures';
-
-type FuturesMarketsTableProps = {
-	futuresMarkets: FuturesMarket[];
-};
 
 enum TableColumnAccessor {
 	Market = 'market',
@@ -30,13 +27,13 @@ function setLastVisited(baseCurrencyPair: string): void {
 	localStorage.setItem('lastVisited', ROUTES.Markets.MarketPair(baseCurrencyPair));
 }
 
-const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
-	futuresMarkets,
-}: FuturesMarketsTableProps) => {
+const FuturesMarketsTable: FC = () => {
 	const { t } = useTranslation();
 	const router = useRouter();
 
-	const synthList = futuresMarkets.map(({ asset }) => asset);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
+
+	const synthList = futuresMarkets?.map(({ asset }) => asset) ?? [];
 	const dailyPriceChangesQuery = useLaggedDailyPrice(synthList);
 
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();
@@ -45,18 +42,20 @@ const FuturesMarketsTable: FC<FuturesMarketsTableProps> = ({
 		const dailyPriceChanges = dailyPriceChangesQuery?.data ?? [];
 		const futuresVolume = futuresVolumeQuery?.data ?? {};
 
-		return futuresMarkets.map((market) => {
-			const volume = futuresVolume[market.assetHex];
-			const pastPrice = dailyPriceChanges.find((price) => price.synth === market.asset);
+		return (
+			futuresMarkets?.map((market) => {
+				const volume = futuresVolume[market.assetHex];
+				const pastPrice = dailyPriceChanges.find((price) => price.synth === market.asset);
 
-			return {
-				asset: market.asset,
-				market: getDisplayAsset(market.asset) + '-PERP',
-				price: market.price,
-				volume: volume?.toNumber() ?? 0,
-				priceChange: market.price.sub(pastPrice?.price ?? 0).div(market.price) || 0,
-			};
-		});
+				return {
+					asset: market.asset,
+					market: getDisplayAsset(market.asset) + '-PERP',
+					price: market.price,
+					volume: volume?.toNumber() ?? 0,
+					priceChange: market.price.sub(pastPrice?.price ?? 0).div(market.price) || 0,
+				};
+			}) ?? []
+		);
 	}, [futuresMarkets, dailyPriceChangesQuery?.data, futuresVolumeQuery?.data]);
 
 	return (

--- a/sections/futures/FuturesMarketTabs/FuturesMarketTabs.tsx
+++ b/sections/futures/FuturesMarketTabs/FuturesMarketTabs.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 import { TabPanel } from 'components/Tab';
 import { DEFAULT_NUMBER_OF_TRADES } from 'constants/defaults';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 
 import SegmentedControl from '../../../components/SegmentedControl';
 import { activeTabState } from '../../../store/futures';
@@ -14,9 +13,6 @@ import FuturesMarketTab from './FuturesMarketTab';
 
 const FuturesMarketTabs: FC = () => {
 	const { t } = useTranslation();
-
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
 
 	const [activeTab, setActiveTab] = useRecoilState(activeTabState);
 
@@ -33,7 +29,7 @@ const FuturesMarketTabs: FC = () => {
 				onChange={setActiveTab}
 			/>
 			<TabPanel name={DETAIL_TABS[0]} activeTab={DETAIL_TABS[activeTab]}>
-				<FuturesMarketTab futuresMarkets={futuresMarkets} />
+				<FuturesMarketTab />
 			</TabPanel>
 			<TabPanel name={DETAIL_TABS[1]} activeTab={DETAIL_TABS[activeTab]}>
 				<TradesHistoryTable numberOfTrades={DEFAULT_NUMBER_OF_TRADES} />

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -39,14 +39,13 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 
 	const futuresTradingVolumeQuery = useGetFuturesTradingVolume(marketAsset);
 
-	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
-	const marketSummary = futuresMarkets?.find(({ asset }) => asset === marketAsset);
+	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
+	const marketSummary = futuresMarkets.find(({ asset }) => asset === marketAsset);
 
-	const futureRates =
-		futuresMarkets?.reduce((acc: Rates, { asset, price }) => {
-			acc[MarketKeyByAsset[asset]] = price;
-			return acc;
-		}, {}) ?? null;
+	const futureRates = futuresMarkets.reduce((acc: Rates, { asset, price }) => {
+		acc[MarketKeyByAsset[asset]] = price;
+		return acc;
+	}, {});
 
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -13,13 +13,12 @@ import { NO_VALUE } from 'constants/placeholder';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import useGetAverageFundingRateForMarket from 'queries/futures/useGetAverageFundingRateForMarket';
 import useGetFuturesDailyTradeStatsForMarket from 'queries/futures/useGetFuturesDailyTrades';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesTradingVolume from 'queries/futures/useGetFuturesTradingVolume';
 import { Rates } from 'queries/rates/types';
 import useExternalPriceQuery from 'queries/rates/useExternalPriceQuery';
 import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
 import useRateUpdateQuery from 'queries/rates/useRateUpdateQuery';
-import { currentMarketState, marketKeyState } from 'store/futures';
+import { currentMarketState, futuresMarketsState, marketKeyState } from 'store/futures';
 import media from 'styles/media';
 import { isFiatCurrency } from 'utils/currencies';
 import { formatCurrency, formatPercent, zeroBN } from 'utils/formatters/number';
@@ -36,18 +35,18 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 
 	const marketAsset = useRecoilValue(currentMarketState);
 	const marketKey = useRecoilValue(marketKeyState);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
-	const futuresMarketsQuery = useGetFuturesMarkets();
 	const futuresTradingVolumeQuery = useGetFuturesTradingVolume(marketAsset);
 
-	const marketSummary = futuresMarketsQuery.data?.find(({ asset }) => asset === marketAsset);
+	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
+	const marketSummary = futuresMarkets?.find(({ asset }) => asset === marketAsset);
 
-	const futureRates = futuresMarketsQuery.isSuccess
-		? futuresMarketsQuery.data?.reduce((acc: Rates, { asset, price }) => {
-				acc[MarketKeyByAsset[asset]] = price;
-				return acc;
-		  }, {})
-		: null;
+	const futureRates =
+		futuresMarkets?.reduce((acc: Rates, { asset, price }) => {
+			acc[MarketKeyByAsset[asset]] = price;
+			return acc;
+		}, {}) ?? null;
 
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 
@@ -84,9 +83,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 			? DEFAULT_FIAT_EURO_DECIMALS
 			: undefined;
 
-	const dailyPriceChangesQuery = useLaggedDailyPrice(
-		futuresMarketsQuery.data?.map(({ asset }) => asset) ?? []
-	);
+	const dailyPriceChangesQuery = useLaggedDailyPrice(markets);
 	const dailyPriceChanges = dailyPriceChangesQuery.data ?? [];
 
 	const pastPrice = dailyPriceChanges.find((price) => price.synth === marketAsset);

--- a/sections/futures/MobileTrade/UserTabs/OrdersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/OrdersTab.tsx
@@ -7,14 +7,13 @@ import { CellProps } from 'react-table';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import PositionType from 'components/Text/PositionType';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { PositionSide } from 'queries/futures/types';
 import useGetNextPriceDetails from 'queries/futures/useGetNextPriceDetails';
 import { positionState, currentMarketState, openOrdersState } from 'store/futures';
 import { gasSpeedState, walletAddressState } from 'store/wallet';
-import { GridDivCenteredRow } from 'styles/common';
 import { formatCurrency } from 'utils/formatters/number';
 import { getDisplayAsset } from 'utils/futures';
 
@@ -104,6 +103,9 @@ const OrdersTab: React.FC = () => {
 				onTableRowClick={(row) => {
 					setSelectedOrder(row.original);
 				}}
+				noResultsMessage={
+					<TableNoResults>{t('futures.market.user.open-orders.table.no-result')}</TableNoResults>
+				}
 				columns={[
 					{
 						Header: <StyledTableHeader>Side/Type</StyledTableHeader>,
@@ -159,11 +161,6 @@ const OrdersTab: React.FC = () => {
 						width: 100,
 					},
 				]}
-				noResultsMessage={
-					openOrders.length === 0 ? (
-						<TableNoResults>You have no open orders.</TableNoResults>
-					) : undefined
-				}
 			/>
 
 			<OrderDrawer
@@ -201,16 +198,6 @@ const CancelButton = styled(EditButton)`
 	border: 1px solid ${(props) => props.theme.colors.common.primaryRed};
 	color: ${(props) => props.theme.colors.common.primaryRed};
 	margin-right: 8px;
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	margin-top: -2px;
-	justify-items: center;
-	grid-gap: 10px;
-	color: ${(props) => props.theme.colors.common.primaryWhite};
-	font-size: 16px;
 `;
 
 export default OrdersTab;

--- a/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
@@ -4,7 +4,7 @@ import { CellProps } from 'react-table';
 import { useRecoilValue } from 'recoil';
 import styled, { css } from 'styled-components';
 
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import { ETH_UNIT } from 'constants/network';
 import { FuturesTrade } from 'queries/futures/types';
 import useGetFuturesTradesForAccount from 'queries/futures/useGetFuturesTradesForAccount';
@@ -144,14 +144,4 @@ const StyledPositionSide = styled.div<{ side: PositionSide }>`
 		css`
 			color: ${props.theme.colors.common.primaryRed};
 		`}
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	margin-top: -2px;
-	justify-items: center;
-	grid-gap: 10px;
-	color: ${(props) => props.theme.colors.common.primaryWhite};
-	font-size: 16px;
 `;

--- a/sections/futures/MobileTrade/UserTabs/TransfersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/TransfersTab.tsx
@@ -3,10 +3,9 @@ import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import useGetFuturesMarginTransfers from 'queries/futures/useGetFuturesMarginTransfers';
 import { currentMarketState } from 'store/futures';
-import { GridDivCenteredRow } from 'styles/common';
 import { timePresentation } from 'utils/formatters/date';
 
 import { SectionHeader, SectionTitle } from '../common';
@@ -112,14 +111,6 @@ const StyledAmountCell = styled(DefaultCell)<{ isPositive: boolean }>`
 const StyledTableHeader = styled.div`
 	font-family: ${(props) => props.theme.fonts.regular};
 	text-transform: capitalize;
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	background-color: transparent;
-	margin-top: -2px;
-	justify-items: center;
 `;
 
 export default TransfersTab;

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -66,7 +66,7 @@ type MarketsDropdownProps = {
 
 const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
-	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
+	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
 
 	const dailyPriceChangesQuery = useLaggedDailyPrice(markets);
 

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -12,10 +12,9 @@ import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
 import useFuturesMarketClosed, { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import { Price, Rates } from 'queries/rates/types';
 import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
-import { currentMarketState } from 'store/futures';
+import { currentMarketState, futuresMarketsState } from 'store/futures';
 import { assetToSynth, iStandardSynth } from 'utils/currencies';
 import { formatCurrency, formatPercent, zeroBN } from 'utils/formatters/number';
 import {
@@ -66,10 +65,10 @@ type MarketsDropdownProps = {
 };
 
 const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const dailyPriceChangesQuery = useLaggedDailyPrice(
-		futuresMarketsQuery.data?.map(({ asset }) => asset) ?? []
-	);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
+	const markets = futuresMarkets?.map(({ asset }) => MarketKeyByAsset[asset]) ?? [];
+
+	const dailyPriceChangesQuery = useLaggedDailyPrice(markets);
 
 	const dailyPriceChanges = React.useMemo(() => dailyPriceChangesQuery?.data ?? [], [
 		dailyPriceChangesQuery,
@@ -86,15 +85,14 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	const { synthsMap } = Connector.useContainer();
 	const { t } = useTranslation();
 
-	const futureRates = futuresMarketsQuery.isSuccess
-		? futuresMarketsQuery?.data?.reduce((acc: Rates, { asset, price }) => {
-				const currencyKey = iStandardSynth(asset as CurrencyKey)
-					? asset
-					: assetToSynth(asset as CurrencyKey);
-				acc[currencyKey] = price;
-				return acc;
-		  }, {})
-		: null;
+	const futureRates =
+		futuresMarkets?.reduce((acc: Rates, { asset, price }) => {
+			const currencyKey = iStandardSynth(asset as CurrencyKey)
+				? asset
+				: assetToSynth(asset as CurrencyKey);
+			acc[currencyKey] = price;
+			return acc;
+		}, {}) ?? null;
 
 	const getBasePriceRate = React.useCallback(
 		(asset: FuturesMarketAsset) => {
@@ -121,32 +119,32 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	);
 
 	const options = React.useMemo(() => {
-		const markets = futuresMarketsQuery?.data ?? [];
+		return (
+			futuresMarkets?.map((market) => {
+				const pastPrice = getPastPrice(market.asset);
+				const basePriceRate = getBasePriceRate(market.asset);
 
-		return markets.map((market) => {
-			const pastPrice = getPastPrice(market.asset);
-			const basePriceRate = getBasePriceRate(market.asset);
-
-			return assetToCurrencyOption({
-				asset: market.asset,
-				description: getSynthDescription(market.asset, synthsMap, t),
-				price: formatCurrency(selectedPriceCurrency.name, basePriceRate, {
-					sign: '$',
-					minDecimals: getMinDecimals(market.asset),
-				}),
-				change: formatPercent(
-					basePriceRate && pastPrice?.price
-						? wei(basePriceRate).sub(pastPrice?.price).div(basePriceRate)
-						: zeroBN
-				),
-				negativeChange:
-					basePriceRate && pastPrice?.price ? wei(basePriceRate).lt(pastPrice?.price) : false,
-				isMarketClosed: market.isSuspended,
-				closureReason: market.marketClosureReason,
-			});
-		});
+				return assetToCurrencyOption({
+					asset: market.asset,
+					description: getSynthDescription(market.asset, synthsMap, t),
+					price: formatCurrency(selectedPriceCurrency.name, basePriceRate, {
+						sign: '$',
+						minDecimals: getMinDecimals(market.asset),
+					}),
+					change: formatPercent(
+						basePriceRate && pastPrice?.price
+							? wei(basePriceRate).sub(pastPrice?.price).div(basePriceRate)
+							: zeroBN
+					),
+					negativeChange:
+						basePriceRate && pastPrice?.price ? wei(basePriceRate).lt(pastPrice?.price) : false,
+					isMarketClosed: market.isSuspended,
+					closureReason: market.marketClosureReason,
+				});
+			}) ?? []
+		);
 	}, [
-		futuresMarketsQuery?.data,
+		futuresMarkets,
 		selectedPriceCurrency.name,
 		synthsMap,
 		t,

--- a/sections/futures/Trades/Trades.tsx
+++ b/sections/futures/Trades/Trades.tsx
@@ -6,7 +6,7 @@ import styled, { css } from 'styled-components';
 
 import LinkIcon from 'assets/svg/app/link-blue.svg';
 import Card from 'components/Card';
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import { Synths } from 'constants/currency';
 import { ETH_UNIT } from 'constants/network';
 import BlockExplorer from 'containers/BlockExplorer';
@@ -213,16 +213,6 @@ const PNL = styled.div<{ negative?: boolean; normal?: boolean }>`
 			: props.negative
 			? props.theme.colors.selectedTheme.red
 			: props.theme.colors.selectedTheme.green};
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	margin-top: -2px;
-	justify-items: center;
-	grid-gap: 10px;
-	color: ${(props) => props.theme.colors.selectedTheme.button.text};
-	font-size: 16px;
 `;
 
 const StyledExternalLink = styled(ExternalLink)`

--- a/sections/futures/TradingHistory/SkewInfo.tsx
+++ b/sections/futures/TradingHistory/SkewInfo.tsx
@@ -41,7 +41,7 @@ const SkewInfo: React.FC = () => {
 			};
 		};
 
-		const market = futuresMarkets?.find((i: FuturesMarket) => i.asset === currencyKey);
+		const market = futuresMarkets.find((i: FuturesMarket) => i.asset === currencyKey);
 		return market
 			? cleanMarket(market)
 			: {

--- a/sections/futures/TradingHistory/SkewInfo.tsx
+++ b/sections/futures/TradingHistory/SkewInfo.tsx
@@ -8,8 +8,7 @@ import styled from 'styled-components';
 import StyledTooltip from 'components/Tooltip/StyledTooltip';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { FuturesMarket } from 'queries/futures/types';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
-import { currentMarketState } from 'store/futures';
+import { currentMarketState, futuresMarketsState } from 'store/futures';
 import { CapitalizedText, NumericValue } from 'styles/common';
 import { formatCurrency, formatPercent } from 'utils/formatters/number';
 
@@ -18,12 +17,11 @@ import OpenInterestBar from './OpenInterestBar';
 const SkewInfo: React.FC = () => {
 	const { t } = useTranslation();
 
-	const futuresMarketsQuery = useGetFuturesMarkets();
 	const currencyKey = useRecoilValue(currentMarketState);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 
-	const futuresMarkets = useMemo(() => futuresMarketsQuery?.data ?? [], [futuresMarketsQuery]);
 	const data = useMemo(() => {
 		const cleanMarket = (i: FuturesMarket) => {
 			const basePriceRate = _.defaultTo(0, Number(i.price));
@@ -43,7 +41,7 @@ const SkewInfo: React.FC = () => {
 			};
 		};
 
-		const market = futuresMarkets.find((i: FuturesMarket) => i.asset === currencyKey);
+		const market = futuresMarkets?.find((i: FuturesMarket) => i.asset === currencyKey);
 		return market
 			? cleanMarket(market)
 			: {

--- a/sections/futures/Transfers/Transfers.tsx
+++ b/sections/futures/Transfers/Transfers.tsx
@@ -2,10 +2,10 @@ import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import BlockExplorer from 'containers/BlockExplorer';
 import { MarginTransfer } from 'queries/futures/types';
-import { ExternalLink, GridDivCenteredRow } from 'styles/common';
+import { ExternalLink } from 'styles/common';
 import { timePresentation } from 'utils/formatters/date';
 import { truncateAddress } from 'utils/formatters/string';
 
@@ -79,11 +79,9 @@ const Transfers: FC<TransferProps> = ({ marginTransfers, isLoading, isLoaded }: 
 			columnsDeps={columnsDeps}
 			isLoading={isLoading && !isLoaded}
 			noResultsMessage={
-				marginTransfers?.length === 0 ? (
-					<TableNoResults>
-						<StyledTitle>{t('futures.market.user.transfers.table.no-results')}</StyledTitle>
-					</TableNoResults>
-				) : undefined
+				<TableNoResults>
+					<StyledTitle>{t('futures.market.user.transfers.table.no-results')}</StyledTitle>
+				</TableNoResults>
 			}
 			showPagination
 		/>
@@ -124,12 +122,4 @@ const StyledAmountCell = styled(DefaultCell)<{ isPositive: boolean }>`
 const StyledTableHeader = styled.div`
 	font-family: ${(props) => props.theme.fonts.regular};
 	text-transform: capitalize;
-`;
-
-const TableNoResults = styled(GridDivCenteredRow)`
-	padding: 50px 0;
-	justify-content: center;
-	background-color: transparent;
-	margin-top: -2px;
-	justify-items: center;
 `;

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 
 import Badge from 'components/Badge';
 import Currency from 'components/Currency';
-import Table from 'components/Table';
+import Table, { TableNoResults } from 'components/Table';
 import PositionType from 'components/Text/PositionType';
 import Connector from 'containers/Connector';
 import TransactionNotifier from 'containers/TransactionNotifier';
@@ -99,6 +99,9 @@ const OpenOrdersTable: React.FC = () => {
 			data={data}
 			highlightRowsOnHover
 			showPagination
+			noResultsMessage={
+				<TableNoResults>{t('futures.market.user.open-orders.table.no-result')}</TableNoResults>
+			}
 			columns={[
 				{
 					Header: (

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -18,7 +18,6 @@ import ROUTES from 'constants/routes';
 import { PositionHistory } from 'queries/futures/types';
 import { FuturesTrade } from 'queries/futures/types';
 import useGetFuturesMarginTransfers from 'queries/futures/useGetFuturesMarginTransfers';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
 import useGetFuturesTradesForAccount from 'queries/futures/useGetFuturesTradesForAccount';
 import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
@@ -55,10 +54,6 @@ const UserInfo: React.FC = () => {
 	const exchangeRatesQuery = useExchangeRatesQuery({
 		refetchInterval: 15000,
 	});
-
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
-	const otherFuturesMarkets = futuresMarkets.filter((market) => market.asset !== marketAsset) ?? [];
 
 	const futuresPositionQuery = useGetFuturesPositionForAccount();
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -213,8 +208,8 @@ const UserInfo: React.FC = () => {
 			<TabPanel name={FuturesTab.POSITION} activeTab={activeTab}>
 				<PositionCard currencyKeyRate={marketAssetRate} />
 				<FuturesPositionsTable
-					futuresMarkets={otherFuturesMarkets}
 					futuresPositionHistory={futuresPositionHistory}
+					showCurrentMarket={false}
 				/>
 			</TabPanel>
 			<TabPanel name={FuturesTab.ORDERS} activeTab={activeTab}>

--- a/sections/homepage/Assets/Assets.tsx
+++ b/sections/homepage/Assets/Assets.tsx
@@ -177,7 +177,7 @@ const Assets = () => {
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
 
-	const synthList = futuresMarkets?.map(({ asset }) => asset) ?? [];
+	const synthList = futuresMarkets.map(({ asset }) => asset);
 
 	const dailyPriceChangesQuery = useLaggedDailyPrice(synthList);
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();

--- a/sections/homepage/Assets/Assets.tsx
+++ b/sections/homepage/Assets/Assets.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import Slider from 'react-slick';
+import { useRecoilValue } from 'recoil';
 import styled, { css } from 'styled-components';
 
 import GridSvg from 'assets/svg/app/grid.svg';
@@ -15,13 +16,13 @@ import Currency from 'components/Currency';
 import { TabPanel } from 'components/Tab';
 import { CurrencyKey, Synths } from 'constants/currency';
 import Connector from 'containers/Connector';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetFuturesTradingVolumeForAllMarkets from 'queries/futures/useGetFuturesTradingVolumeForAllMarkets';
 import { Price } from 'queries/rates/types';
 import { requestCandlesticks } from 'queries/rates/useCandlesticksQuery';
 import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import useLaggedDailyPrice from 'queries/rates/useLaggedDailyPrice';
 import useGetSynthsTradingVolumeForAllMarkets from 'queries/synths/useGetSynthsTradingVolumeForAllMarkets';
+import { futuresMarketsState } from 'store/futures';
 import {
 	FlexDiv,
 	FlexDivColCentered,
@@ -147,6 +148,8 @@ const Assets = () => {
 	const { synthsMap } = Connector.useContainer();
 	const [activeMarketsTab, setActiveMarketsTab] = useState<MarketsTab>(MarketsTab.FUTURES);
 
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
+
 	const MARKETS_TABS = useMemo(
 		() => [
 			{
@@ -174,9 +177,7 @@ const Assets = () => {
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
 
-	const futuresMarketsQuery = useGetFuturesMarkets();
-	const futuresMarkets = futuresMarketsQuery?.data ?? [];
-	const synthList = futuresMarkets.map(({ asset }) => asset);
+	const synthList = futuresMarkets?.map(({ asset }) => asset) ?? [];
 
 	const dailyPriceChangesQuery = useLaggedDailyPrice(synthList);
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();
@@ -202,28 +203,30 @@ const Assets = () => {
 		const dailyPriceChanges = dailyPriceChangesQuery?.data ?? [];
 		const futuresVolume = futuresVolumeQuery?.data ?? {};
 
-		return futuresMarkets.map((market, i) => {
-			const description = getSynthDescription(market.asset, synthsMap, t);
-			const volume = futuresVolume[market.assetHex];
-			const pastPrice = dailyPriceChanges.find(
-				(price: Price) => price.synth === market.asset || price.synth === market.asset.slice(1)
-			);
-			return {
-				key: market.asset,
-				name: market.asset[0] === 's' ? market.asset.slice(1) : market.asset,
-				description: description.split(' ')[0],
-				price: market.price.toNumber(),
-				volume: volume?.toNumber() || 0,
-				priceChange:
-					(market.price.toNumber() - (pastPrice?.price ?? 0)) / market.price.toNumber() || 0,
-				image: <PriceChart asset={market.asset} />,
-				icon: (
-					<StyledCurrencyIcon currencyKey={(market.asset[0] !== 's' ? 's' : '') + market.asset} />
-				),
-			};
-		});
+		return (
+			futuresMarkets?.map((market, i) => {
+				const description = getSynthDescription(market.asset, synthsMap, t);
+				const volume = futuresVolume[market.assetHex];
+				const pastPrice = dailyPriceChanges.find(
+					(price: Price) => price.synth === market.asset || price.synth === market.asset.slice(1)
+				);
+				return {
+					key: market.asset,
+					name: market.asset[0] === 's' ? market.asset.slice(1) : market.asset,
+					description: description.split(' ')[0],
+					price: market.price.toNumber(),
+					volume: volume?.toNumber() || 0,
+					priceChange:
+						(market.price.toNumber() - (pastPrice?.price ?? 0)) / market.price.toNumber() || 0,
+					image: <PriceChart asset={market.asset} />,
+					icon: (
+						<StyledCurrencyIcon currencyKey={(market.asset[0] !== 's' ? 's' : '') + market.asset} />
+					),
+				};
+			}) ?? []
+		);
 		// eslint-disable-next-line
-	}, [synthsMap, dailyPriceChangesQuery?.data, futuresVolumeQuery?.data, t]);
+	}, [futuresMarkets, synthsMap, dailyPriceChangesQuery?.data, futuresVolumeQuery?.data, t]);
 
 	const SPOTS = useMemo(() => {
 		const spotDailyPriceChanges = spotDailyPriceChangesQuery?.data ?? [];

--- a/sections/homepage/ShortList/ShortList.tsx
+++ b/sections/homepage/ShortList/ShortList.tsx
@@ -109,7 +109,7 @@ const ShortList = () => {
 
 	const openInterest = useMemo(() => {
 		return futuresMarkets
-			?.map((market) => market.marketSize.mul(market.price).toNumber())
+			.map((market) => market.marketSize.mul(market.price).toNumber())
 			.reduce((total, openInterest) => total + openInterest, 0);
 	}, [futuresMarkets]);
 

--- a/sections/homepage/ShortList/ShortList.tsx
+++ b/sections/homepage/ShortList/ShortList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CellProps } from 'react-table';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import GridSvg from 'assets/svg/app/grid.svg';
@@ -15,8 +16,8 @@ import ROUTES from 'constants/routes';
 import useENS from 'hooks/useENS';
 import { FuturesStat } from 'queries/futures/types';
 import useGetFuturesDailyTradeStats from 'queries/futures/useGetFuturesDailyTradeStats';
-import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
 import useGetStats from 'queries/futures/useGetStats';
+import { futuresMarketsState } from 'store/futures';
 import { FlexDivColCentered, FlexDivRow, SmallGoldenHeader, WhiteHeader } from 'styles/common';
 import media, { Media } from 'styles/media';
 import { formatCurrency, formatNumber, zeroBN } from 'utils/formatters/number';
@@ -33,6 +34,8 @@ type Stat = {
 
 const ShortList = () => {
 	const { t } = useTranslation();
+
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 
 	const statsQuery = useGetStats(true);
 	const stats = useMemo(() => statsQuery.data ?? [], [statsQuery]);
@@ -104,13 +107,11 @@ const ShortList = () => {
 
 	const dailyTradeStats = useGetFuturesDailyTradeStats();
 
-	const futuresMarketsQuery = useGetFuturesMarkets();
 	const openInterest = useMemo(() => {
-		const futuresMarkets = futuresMarketsQuery?.data ?? [];
 		return futuresMarkets
-			.map((market) => market.marketSize.mul(market.price).toNumber())
+			?.map((market) => market.marketSize.mul(market.price).toNumber())
 			.reduce((total, openInterest) => total + openInterest, 0);
-	}, [futuresMarketsQuery?.data]);
+	}, [futuresMarkets]);
 
 	return (
 		<StackSection>
@@ -279,7 +280,7 @@ const ShortList = () => {
 					<StatsCard>
 						<StatsName>{t('homepage.shortlist.stats.open-interest')}</StatsName>
 						<StatsValue>
-							{futuresMarketsQuery.isLoading ? (
+							{!openInterest ? (
 								<Loader />
 							) : (
 								formatCurrency(Synths.sUSD, openInterest ?? 0, {

--- a/store/futures/index.ts
+++ b/store/futures/index.ts
@@ -46,7 +46,7 @@ export const positionsState = atom<FuturesPosition[] | null>({
 	default: null,
 });
 
-export const futuresMarketsState = atom<FuturesMarket[] | null>({
+export const futuresMarketsState = atom<FuturesMarket[]>({
 	key: getFuturesKey('markets'),
 	default: [],
 });

--- a/translations/en.json
+++ b/translations/en.json
@@ -709,17 +709,6 @@
 						"np-discount": "Next-Price Discount"
 					}
 				},
-				"orders": {
-					"tab": "Orders",
-					"table": {
-						"id": "ID",
-						"position": "position",
-						"leverage": "leverage",
-						"fee": "fee",
-						"status": "status",
-						"cancel": "cancel"
-					}
-				},
 				"open-orders": {
 					"tab": "Open Orders",
 					"table": {
@@ -727,7 +716,8 @@
 						"side": "Side",
 						"size": "Size",
 						"parameters": "Parameters",
-						"actions": "Actions"
+						"actions": "Actions",
+						"no-result": "You have no open orders"
 					},
 					"actions": {
 						"cancel": "Cancel",

--- a/translations/en.json
+++ b/translations/en.json
@@ -431,7 +431,8 @@
 				"amount": "Amount",
 				"value-in-usd": "Value in USD",
 				"oracle-price": "Oracle Price",
-				"daily-change": "24H Change"
+				"daily-change": "24H Change",
+				"no-result": "You have no synths"
 			},
 			"futures-markets-table": {
 				"market": "Market",

--- a/translations/en.json
+++ b/translations/en.json
@@ -418,7 +418,13 @@
 				"leverage": "Leverage",
 				"pnl": "Unrealized P&L",
 				"notionalValue": "Size",
-				"liquidationPrice": "Liq. Price"
+				"liquidationPrice": "Liq. Price",
+				"no-result": "You have no other open positions",
+				"mobile": {
+					"market": "Market/Side",
+					"price": "Oracle/Entry",
+					"pnl": "Unrealized P&L"
+				}
 			},
 			"synth-balances-table": {
 				"market": "Market",
@@ -462,8 +468,8 @@
 				"from": "From",
 				"to": "To",
 				"usd-value": "USD Value",
-				"no-trade-history": "You have no trades yet.",
-				"no-trade-history-link": "Visit the Kwenta exchange to swap synths."
+				"no-trade-history": "You have no synth trading history",
+				"no-trade-history-link": "Visit the Kwenta exchange to swap synths"
 			},
 			"futures-history-table": {
 				"size": "Size",
@@ -474,9 +480,7 @@
 				"side": "Side",
 				"market": "Market",
 				"order-type": "Type",
-				"no-results": "Perpetual Futures are available on Optimism L2",
-				"no-trade-history": "You have no trades yet.",
-				"no-trade-history-link": "Trade Perpetual Futures on Kwenta now!"
+				"no-result": "You have no futures trading history"
 			}
 		},
 		"deprecated": {
@@ -745,7 +749,7 @@
 						"fees": "fees",
 						"price": "price",
 						"side": "side",
-						"no-results": "You have no trades yet.",
+						"no-results": "You have no trade history",
 						"order-type": "order type",
 						"trade-types": {
 							"exit": "exit",
@@ -936,6 +940,8 @@
 			"market": "market",
 			"limit": "limit"
 		},
+		"l2-cta": "Perpetual futures are available on Optimism L2",
+		"perp-cta": "Trade perpetual futures now!",
 		"currency": {
 			"currency-amount": "<0>{{currencyKey}}</0> Amount",
 			"exchange-fee": "Exchange Fee",


### PR DESCRIPTION
Updates the futures positions table component to filter the current market if specified. This required other changes to state management and translations, including some opinionated copy changes.

## Description
* Add `showCurrentMarket` parameter to `FuturesPositionsTable`
* Remove all `useGetFuturesMarkets` hooks from components
* Use `futuresMarkets` recoil value where relevant
* Changes to copy on empty table states

## Related issue
* #1078 
* #1155 

## Motivation and Context
1. A bug causing the current market's position to show on the "markets" page
2. Some inconsistent copy between tables
3. Improved state management, reducing refetching significantly since the `useGetFuturesMarkets` hook will be called only once at the context level.

## How Has This Been Tested?
* Tested desktop table states with and without open positions
* Tested mobile table states with and without open positions

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10401554/180497402-1b0cff1a-6ac6-46f8-b2c9-01bbf189c8f1.png)

![image](https://user-images.githubusercontent.com/10401554/180497429-ca4eac88-d8e1-423e-8557-d5f2dd44a0e6.png)

![image](https://user-images.githubusercontent.com/10401554/180497478-8f64324f-60a5-4f5d-b220-e2642b9cbf43.png)

![image](https://user-images.githubusercontent.com/10401554/180497511-2159aadc-3f64-4781-a8e2-ce792f5d31c1.png)
