### PR TITLE
Fix: reject the txn may crash the app

### DIFF
--- a/components/Error/Error.tsx
+++ b/components/Error/Error.tsx
@@ -12,7 +12,7 @@ export const Error: FC<ErrorProps> = ({ message, formatter }) => {
 	const formattedMessage = useMemo(() => {
 		switch (formatter) {
 			case 'revert':
-				return formatRevert(message);
+				return formatRevert(message ?? '');
 			default:
 				return message;
 		}

--- a/components/Error/Error.tsx
+++ b/components/Error/Error.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useMemo } from 'react';
 import styled from 'styled-components';
 
-import { formatRevert } from 'utils/formatters/error';
+import { formatRevert, isUserDeniedError } from 'utils/formatters/error';
 
 type ErrorProps = {
 	message: string;
@@ -12,11 +12,13 @@ export const Error: FC<ErrorProps> = ({ message, formatter }) => {
 	const formattedMessage = useMemo(() => {
 		switch (formatter) {
 			case 'revert':
-				return formatRevert(message ?? '');
+				return formatRevert(message);
 			default:
 				return message;
 		}
 	}, [message, formatter]);
+
+	if (isUserDeniedError(message) || !message) return null;
 
 	return <ErrorContainer>{formattedMessage}</ErrorContainer>;
 };

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -20,11 +20,11 @@ import { currentMarketState, positionState } from 'store/futures';
 import { gasSpeedState } from 'store/wallet';
 import { FlexDivCentered, FlexDivCol } from 'styles/common';
 import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
+import { isUserDeniedError } from 'utils/formatters/error';
 import { formatCurrency, formatNumber, zeroBN } from 'utils/formatters/number';
 import { newGetTransactionPrice } from 'utils/network';
 
 import { PositionSide } from '../types';
-import { isUserDeniedError } from 'utils/formatters/error';
 
 type ClosePositionModalProps = {
 	onDismiss: () => void;

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -24,6 +24,7 @@ import { formatCurrency, formatNumber, zeroBN } from 'utils/formatters/number';
 import { newGetTransactionPrice } from 'utils/network';
 
 import { PositionSide } from '../types';
+import { isUserDeniedError } from 'utils/formatters/error';
 
 type ClosePositionModalProps = {
 	onDismiss: () => void;
@@ -171,7 +172,9 @@ const ClosePositionModal: FC<ClosePositionModalProps> = ({ onDismiss }) => {
 					isRounded
 					size="lg"
 					onClick={() => closeTxn.mutate()}
-					disabled={!!error || !!closeTxn.errorMessage}
+					disabled={
+						!!error || (!!closeTxn.errorMessage && !isUserDeniedError(closeTxn.errorMessage))
+					}
 				>
 					{t('futures.market.user.position.modal.title')}
 				</StyledButton>

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -57,7 +57,7 @@ const ManagePosition: React.FC<ManagePositionProps> = ({ openConfirmationModal }
 		if (error) return error;
 		if (previewTrade?.showStatus) return previewTrade?.statusMessage;
 		return null;
-	}, [orderTxn, previewTrade?.showStatus, error]);
+	}, [orderTxn.error, error, previewTrade?.showStatus, previewTrade?.statusMessage]);
 
 	return (
 		<>

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -53,8 +53,11 @@ const ManagePosition: React.FC<ManagePositionProps> = ({ openConfirmationModal }
 
 	const orderError = useMemo(() => {
 		const orderTxnError = orderTxn.error as OrderTxnError;
-		return orderTxnError?.reason;
-	}, [orderTxn]);
+		if (orderTxnError) return orderTxnError.reason;
+		if (error) return error;
+		if (previewTrade?.showStatus) return previewTrade?.statusMessage;
+		return null;
+	}, [orderTxn, previewTrade?.showStatus, error]);
 
 	return (
 		<>
@@ -110,19 +113,8 @@ const ManagePosition: React.FC<ManagePositionProps> = ({ openConfirmationModal }
 				</ManagePositionContainer>
 			</div>
 
-			{(orderTxn.isError || error || previewTrade?.showStatus) && (
-				<Error
-					message={
-						orderTxn.isError
-							? orderError
-							: error
-							? error
-							: previewTrade?.showStatus
-							? previewTrade?.statusMessage
-							: ''
-					}
-					formatter="revert"
-				/>
+			{orderError && (
+				<Error message={orderError} formatter={orderTxn.error ? 'revert' : undefined} />
 			)}
 
 			{isCancelModalOpen && <ClosePositionModal onDismiss={() => setCancelModalOpen(false)} />}

--- a/utils/formatters/error.ts
+++ b/utils/formatters/error.ts
@@ -1,5 +1,11 @@
 const REVERT_REGEX = /execution reverted: /;
 
 export const formatRevert = (revertMsg: string) => {
+	if (!revertMsg) return '';
 	return revertMsg.replace(REVERT_REGEX, '');
+};
+
+export const isUserDeniedError = (message: string) => {
+	if (!message) return false;
+	return message.includes('User denied transaction signature');
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As @Tburm reported, the app may crash if the user rejects a future market transaction in the wallet.

## Related issue
closes #1165

## Motivation and Context
Improve the UX and stability of app

## How Has This Been Tested?
1. Open the future market page and open a position
2. From `TxConfirmationModal`, choose `Confirm Order`
3. The app is working normally after choosing `Reject` in wallet

## Screenshots (if appropriate):

