### PR TITLE
Added the missing commodity price

### DIFF
--- a/queries/rates/useExternalPriceQuery.ts
+++ b/queries/rates/useExternalPriceQuery.ts
@@ -3,6 +3,7 @@ import { UseQueryOptions, useQuery } from 'react-query';
 
 import { FIAT_SYNTHS, COMMODITY_SYNTHS, CurrencyKey } from 'constants/currency';
 import QUERY_KEYS from 'constants/queryKeys';
+import { synthToAsset } from 'utils/currencies';
 import { FuturesMarketKey } from 'utils/futures';
 
 import { CG_BASE_API_URL } from './constants';
@@ -44,8 +45,8 @@ const useExternalPriceQuery = (
 	return useQuery<number | null>(
 		QUERY_KEYS.Rates.ExternalPrice(marketKey),
 		async () => {
-			return COMMODITY_SYNTHS.has(marketKey as any)
-				? getCommodityPrice(marketKey as any)
+			return COMMODITY_SYNTHS.has(synthToAsset(marketKey) as any)
+				? getCommodityPrice(synthToAsset(marketKey) as any)
 				: FIAT_SYNTHS.has(marketKey as any)
 				? getForexPrice(marketKey as any)
 				: getCoinGeckoPrice(marketKey);

--- a/utils/currencies.ts
+++ b/utils/currencies.ts
@@ -12,7 +12,9 @@ export const isFiatCurrency = (currencyKey: CurrencyKey) => FIAT_SYNTHS.has(curr
 // TODO: replace this with a more robust logic (like checking the asset field)
 export const toInverseSynth = (currencyKey: CurrencyKey) => currencyKey.replace(/^s/i, 'i');
 export const toStandardSynth = (currencyKey: CurrencyKey) => currencyKey.replace(/^i/i, 's');
-export const synthToAsset = (currencyKey: CurrencyKey) => currencyKey.replace(/^(i|s)/, '');
+export const synthToAsset = (currencyKey: CurrencyKey | FuturesMarketKey) => {
+	return currencyKey.replace(/^(i|s)/, '');
+};
 export const assetToSynth = (currencyKey: CurrencyKey) => `s${currencyKey}`;
 export const iStandardSynth = (currencyKey: CurrencyKey) => currencyKey.startsWith('s');
 export const synthToContractName = (currencyKey: CurrencyKey) => `Synth${currencyKey}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The external price for XAG and XAU is not displayed in the current version of Kwenta.

## Related issue
#1172 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the market page and switch to the XAU/XAG/EUR/ETH
2. The external price is displayed normally.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/180843376-6cc32dab-6224-410a-83cd-68592a5b683c.png)
