### PR TITLE
remove obsolete imagemin-* packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,8 +114,6 @@
 				"eslint-plugin-ui-testing": "^2.0.0",
 				"html-to-image": "^1.9.0",
 				"husky": "5.0.9",
-				"imagemin-optipng": "8.0.0",
-				"imagemin-svgo": "8.0.0",
 				"jest": "27.3.1",
 				"lint-staged": "^13.0.3",
 				"pinst": "3.0.0",
@@ -15507,11 +15505,6 @@
 				"@types/puppeteer": "*"
 			}
 		},
-		"node_modules/@types/q": {
-			"version": "1.5.5",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/qrcode.react": {
 			"version": "1.0.2",
 			"license": "MIT",
@@ -21666,19 +21659,6 @@
 				"node": ">= 0.12.0"
 			}
 		},
-		"node_modules/coa": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/q": "^1.5.1",
-				"chalk": "^2.4.1",
-				"q": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 4.0"
-			}
-		},
 		"node_modules/code-point-at": {
 			"version": "1.1.0",
 			"license": "MIT",
@@ -22876,11 +22856,6 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
-		"node_modules/css-select-base-adapter": {
-			"version": "0.1.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/css-to-react-native": {
 			"version": "3.0.0",
 			"license": "MIT",
@@ -22893,26 +22868,6 @@
 		"node_modules/css-to-react-native/node_modules/postcss-value-parser": {
 			"version": "4.2.0",
 			"license": "MIT"
-		},
-		"node_modules/css-tree": {
-			"version": "1.0.0-alpha.37",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.0.4",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/css-tree/node_modules/source-map": {
-			"version": "0.6.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/css-unit-converter": {
 			"version": "1.1.2",
@@ -27631,21 +27586,6 @@
 				"punycode": "^1.3.2"
 			}
 		},
-		"node_modules/fast-xml-parser": {
-			"version": "3.21.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"strnum": "^1.0.4"
-			},
-			"bin": {
-				"xml2js": "cli.js"
-			},
-			"funding": {
-				"type": "paypal",
-				"url": "https://paypal.me/naturalintelligence"
-			}
-		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
 			"dev": true,
@@ -29818,34 +29758,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/imagemin-optipng": {
-			"version": "8.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"exec-buffer": "^3.0.0",
-				"is-png": "^2.0.0",
-				"optipng-bin": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/imagemin-svgo": {
-			"version": "8.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-svg": "^4.2.1",
-				"svgo": "^1.3.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/imagemin-svgo?sponsor=1"
-			}
-		},
 		"node_modules/imagemin-webp": {
 			"version": "5.1.0",
 			"dev": true,
@@ -30996,14 +30908,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-png": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"dev": true,
@@ -31069,20 +30973,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-svg": {
-			"version": "4.3.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-xml-parser": "^3.19.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-symbol": {
@@ -35108,11 +34998,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdn-data": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
 		"node_modules/mdurl": {
 			"version": "1.0.1",
 			"dev": true,
@@ -37137,22 +37022,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/optipng-bin": {
-			"version": "7.0.1",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"dependencies": {
-				"bin-build": "^3.0.0",
-				"bin-wrapper": "^4.0.0"
-			},
-			"bin": {
-				"optipng": "cli.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/os-browserify": {
 			"version": "0.3.0",
 			"dev": true,
@@ -38629,15 +38498,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"bitcoin-ops": "^1.3.0"
-			}
-		},
-		"node_modules/q": {
-			"version": "1.5.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6.0",
-				"teleport": ">=0.2.0"
 			}
 		},
 		"node_modules/qr.js": {
@@ -40641,11 +40501,6 @@
 				"which": "bin/which"
 			}
 		},
-		"node_modules/sax": {
-			"version": "1.2.4",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/saxes": {
 			"version": "5.0.1",
 			"dev": true,
@@ -42568,11 +42423,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/strnum": {
-			"version": "1.0.5",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/sturdy-websocket": {
 			"version": "0.1.12",
 			"license": "MIT",
@@ -42791,85 +42641,6 @@
 			"version": "2.0.4",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/svgo": {
-			"version": "1.3.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.37",
-				"csso": "^4.0.2",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
-			},
-			"bin": {
-				"svgo": "bin/svgo"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/svgo/node_modules/css-select": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^3.2.1",
-				"domutils": "^1.7.0",
-				"nth-check": "^1.0.2"
-			}
-		},
-		"node_modules/svgo/node_modules/css-what": {
-			"version": "3.4.2",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/svgo/node_modules/dom-serializer": {
-			"version": "0.2.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			}
-		},
-		"node_modules/svgo/node_modules/domutils": {
-			"version": "1.7.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
-		"node_modules/svgo/node_modules/domutils/node_modules/domelementtype": {
-			"version": "1.3.1",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/svgo/node_modules/nth-check": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"boolbase": "~1.0.0"
-			}
 		},
 		"node_modules/swap-case": {
 			"version": "1.1.2",
@@ -44488,11 +44259,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/unquote": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/unset-value": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -44773,20 +44539,6 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"license": "MIT"
-		},
-		"node_modules/util.promisify": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/utila": {
 			"version": "0.4.0",
@@ -57213,10 +56965,6 @@
 				"@types/puppeteer": "*"
 			}
 		},
-		"@types/q": {
-			"version": "1.5.5",
-			"dev": true
-		},
 		"@types/qrcode.react": {
 			"version": "1.0.2",
 			"requires": {
@@ -61659,15 +61407,6 @@
 			"version": "4.6.0",
 			"dev": true
 		},
-		"coa": {
-			"version": "2.0.2",
-			"dev": true,
-			"requires": {
-				"@types/q": "^1.5.1",
-				"chalk": "^2.4.1",
-				"q": "^1.1.2"
-			}
-		},
 		"code-point-at": {
 			"version": "1.1.0"
 		},
@@ -62506,10 +62245,6 @@
 				"nth-check": "^2.0.1"
 			}
 		},
-		"css-select-base-adapter": {
-			"version": "0.1.1",
-			"dev": true
-		},
 		"css-to-react-native": {
 			"version": "3.0.0",
 			"requires": {
@@ -62520,20 +62255,6 @@
 			"dependencies": {
 				"postcss-value-parser": {
 					"version": "4.2.0"
-				}
-			}
-		},
-		"css-tree": {
-			"version": "1.0.0-alpha.37",
-			"dev": true,
-			"requires": {
-				"mdn-data": "2.0.4",
-				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"dev": true
 				}
 			}
 		},
@@ -65815,13 +65536,6 @@
 				"punycode": "^1.3.2"
 			}
 		},
-		"fast-xml-parser": {
-			"version": "3.21.1",
-			"dev": true,
-			"requires": {
-				"strnum": "^1.0.4"
-			}
-		},
 		"fastq": {
 			"version": "1.13.0",
 			"dev": true,
@@ -67409,23 +67123,6 @@
 				}
 			}
 		},
-		"imagemin-optipng": {
-			"version": "8.0.0",
-			"dev": true,
-			"requires": {
-				"exec-buffer": "^3.0.0",
-				"is-png": "^2.0.0",
-				"optipng-bin": "^7.0.0"
-			}
-		},
-		"imagemin-svgo": {
-			"version": "8.0.0",
-			"dev": true,
-			"requires": {
-				"is-svg": "^4.2.1",
-				"svgo": "^1.3.2"
-			}
-		},
 		"imagemin-webp": {
 			"version": "5.1.0",
 			"dev": true,
@@ -67952,10 +67649,6 @@
 				}
 			}
 		},
-		"is-png": {
-			"version": "2.0.0",
-			"dev": true
-		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"dev": true
@@ -67987,13 +67680,6 @@
 			"version": "1.0.7",
 			"requires": {
 				"has-tostringtag": "^1.0.0"
-			}
-		},
-		"is-svg": {
-			"version": "4.3.2",
-			"dev": true,
-			"requires": {
-				"fast-xml-parser": "^3.19.0"
 			}
 		},
 		"is-symbol": {
@@ -70664,10 +70350,6 @@
 			"version": "1.1.0",
 			"dev": true
 		},
-		"mdn-data": {
-			"version": "2.0.4",
-			"dev": true
-		},
 		"mdurl": {
 			"version": "1.0.1",
 			"dev": true
@@ -72047,14 +71729,6 @@
 				}
 			}
 		},
-		"optipng-bin": {
-			"version": "7.0.1",
-			"dev": true,
-			"requires": {
-				"bin-build": "^3.0.0",
-				"bin-wrapper": "^4.0.0"
-			}
-		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"dev": true
@@ -72994,10 +72668,6 @@
 			"requires": {
 				"bitcoin-ops": "^1.3.0"
 			}
-		},
-		"q": {
-			"version": "1.5.1",
-			"dev": true
 		},
 		"qr.js": {
 			"version": "0.0.0"
@@ -74282,10 +73952,6 @@
 					}
 				}
 			}
-		},
-		"sax": {
-			"version": "1.2.4",
-			"dev": true
 		},
 		"saxes": {
 			"version": "5.0.1",
@@ -75609,10 +75275,6 @@
 			"version": "1.0.1",
 			"dev": true
 		},
-		"strnum": {
-			"version": "1.0.5",
-			"dev": true
-		},
 		"sturdy-websocket": {
 			"version": "0.1.12",
 			"requires": {
@@ -75759,70 +75421,6 @@
 		"svg-parser": {
 			"version": "2.0.4",
 			"dev": true
-		},
-		"svgo": {
-			"version": "1.3.2",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.37",
-				"csso": "^4.0.2",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
-			},
-			"dependencies": {
-				"css-select": {
-					"version": "2.1.0",
-					"dev": true,
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^3.2.1",
-						"domutils": "^1.7.0",
-						"nth-check": "^1.0.2"
-					}
-				},
-				"css-what": {
-					"version": "3.4.2",
-					"dev": true
-				},
-				"dom-serializer": {
-					"version": "0.2.2",
-					"dev": true,
-					"requires": {
-						"domelementtype": "^2.0.1",
-						"entities": "^2.0.0"
-					}
-				},
-				"domutils": {
-					"version": "1.7.0",
-					"dev": true,
-					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
-					},
-					"dependencies": {
-						"domelementtype": {
-							"version": "1.3.1",
-							"dev": true
-						}
-					}
-				},
-				"nth-check": {
-					"version": "1.0.2",
-					"dev": true,
-					"requires": {
-						"boolbase": "~1.0.0"
-					}
-				}
-			}
 		},
 		"swap-case": {
 			"version": "1.1.2",
@@ -77001,10 +76599,6 @@
 		"unpipe": {
 			"version": "1.0.0"
 		},
-		"unquote": {
-			"version": "1.1.1",
-			"dev": true
-		},
 		"unset-value": {
 			"version": "1.0.0",
 			"requires": {
@@ -77180,16 +76774,6 @@
 		},
 		"util-deprecate": {
 			"version": "1.0.2"
-		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			}
 		},
 		"utila": {
 			"version": "0.4.0"

--- a/package.json
+++ b/package.json
@@ -128,8 +128,6 @@
 		"eslint-plugin-ui-testing": "^2.0.0",
 		"html-to-image": "^1.9.0",
 		"husky": "5.0.9",
-		"imagemin-optipng": "8.0.0",
-		"imagemin-svgo": "8.0.0",
 		"jest": "27.3.1",
 		"lint-staged": "^13.0.3",
 		"pinst": "3.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove obsolete/unused packages

## Related issue
- #875 

## Motivation and Context
Clean up codebase of redundant packages

## How Has This Been Tested?
Tested on localhost, checked that all images work just fine on landing page, dashboard, markets, exchange and leaderboard.

## Screenshots (if appropriate):
