### PR TITLE
fix skew bar border on light theme

### DIFF
--- a/sections/futures/TradingHistory/OpenInterestBar.tsx
+++ b/sections/futures/TradingHistory/OpenInterestBar.tsx
@@ -26,7 +26,7 @@ const OpenInterestChart: React.FC<OpenInterestProps> = ({ skew }) => {
 export default OpenInterestChart;
 
 const OIContainer = styled.div`
-	border: 1px solid #2b2a2a;
+	border: ${(props) => props.theme.colors.selectedTheme.openInterestBar.border};
 	border-radius: 1px;
 	width: 100%;
 `;

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -93,7 +93,7 @@ const darkTheme = {
 		hover: '#ECE8E3',
 	},
 	openInterestBar: {
-		border: '1px solid #2b2a2a'
+		border: '1px solid #2b2a2a',
 	},
 };
 

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -92,6 +92,9 @@ const darkTheme = {
 		fill: '#787878',
 		hover: '#ECE8E3',
 	},
+	openInterestBar: {
+		border: '1px solid #2b2a2a'
+	},
 };
 
 export default darkTheme;

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -94,7 +94,7 @@ const lightTheme = {
 		hover: '#171002',
 	},
 	openInterestBar: {
-		border: '1px solid #F2F2F2'
+		border: '1px solid #F2F2F2',
 	},
 };
 

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -93,6 +93,9 @@ const lightTheme = {
 		fill: '#515151',
 		hover: '#171002',
 	},
+	openInterestBar: {
+		border: '1px solid #F2F2F2'
+	},
 };
 
 export default lightTheme;


### PR DESCRIPTION
## Description
This PR fixes skew bar border color on light theme.

## Related issue
N/A

## Motivation and Context
This border does not switch to a white border to match the light theme, but instead stays black. This is inconsistent with the theme and should be fixed.

## How Has This Been Tested?
On light theme, the Skew bar border color switches to white.

## Screenshots (if appropriate):
Before
![skew-bar-before](https://user-images.githubusercontent.com/15921121/181083187-f719e8bc-0d12-405f-bbd5-3c9828166f23.PNG)

After
![skew-bar-after](https://user-images.githubusercontent.com/15921121/181083222-e7e1dbfc-c8d7-43d9-a4bd-15e780e579b0.PNG)

