### PR TITLE
Bump various synthetix packages to 2.74.*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@synthetixio/contracts-interface": "2.74.1",
 				"@synthetixio/optimism-networks": "2.73.1",
 				"@synthetixio/providers": "2.74.1",
-				"@synthetixio/queries": "2.73.1",
+				"@synthetixio/queries": "2.74.3",
 				"@synthetixio/transaction-notifier": "2.73.1",
 				"@synthetixio/wei": "2.73.1",
 				"@tippyjs/react": "4.1.0",
@@ -13339,6 +13339,47 @@
 			"version": "2.0.13",
 			"license": "MIT"
 		},
+		"node_modules/@synthetixio/codegen-graph-ts": {
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/codegen-graph-ts/-/codegen-graph-ts-2.74.1.tgz",
+			"integrity": "sha512-aohd8gpFTY2UOhhjM+tqDVwo51VIS1iub1nErEM4tPpfMZzvtD47IVwO8LK5xhg1B1qNo91/eMV1jiLlvE9/bg==",
+			"dependencies": {
+				"@synthetixio/wei": "2.74.1",
+				"axios": "^0.21.4",
+				"commander": "^8.1.0",
+				"graphql": "^15.5.0",
+				"graphql-request": "^3.4.0",
+				"lodash": "^4.17.21"
+			},
+			"bin": {
+				"codegen-graph-ts": "build/src/gen/index.js"
+			}
+		},
+		"node_modules/@synthetixio/codegen-graph-ts/node_modules/@synthetixio/wei": {
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+			"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
+			"dependencies": {
+				"big.js": "^6.1.1",
+				"ethers": "^5.5.3"
+			}
+		},
+		"node_modules/@synthetixio/codegen-graph-ts/node_modules/axios": {
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"dependencies": {
+				"follow-redirects": "^1.14.0"
+			}
+		},
+		"node_modules/@synthetixio/codegen-graph-ts/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/@synthetixio/contracts-interface": {
 			"version": "2.74.1",
 			"license": "MIT",
@@ -13711,21 +13752,21 @@
 			}
 		},
 		"node_modules/@synthetixio/queries": {
-			"version": "2.73.1",
-			"license": "MIT",
+			"version": "2.74.3",
+			"resolved": "https://registry.npmjs.org/@synthetixio/queries/-/queries-2.74.3.tgz",
+			"integrity": "sha512-3RPWrD1B6Lthb6WihzPtGcZhgtM8GqSVblFmDzB4dcbWzeRypAOKLt5nimrGZTav+wE8A5VZcCaNZ5MsWPv00Q==",
 			"dependencies": {
 				"@snapshot-labs/snapshot.js": "^0.3.22",
-				"@synthetixio/contracts-interface": "2.73.1",
-				"@synthetixio/optimism-networks": "2.73.1",
-				"@synthetixio/providers": "2.73.1",
-				"@synthetixio/wei": "2.73.1",
+				"@synthetixio/codegen-graph-ts": "2.74.1",
+				"@synthetixio/contracts-interface": "2.74.1",
+				"@synthetixio/optimism-networks": "2.74.1",
+				"@synthetixio/wei": "2.74.1",
 				"axios": "^0.21.4",
 				"date-fns": "^2.19.0",
 				"ethers": "^5.5.3",
 				"graphql": "^15.5.0",
 				"graphql-request": "^3.4.0",
-				"lodash": "^4.17.21",
-				"maxibon-codegen-graph-ts": "^0.2.0"
+				"lodash": "^4.17.21"
 			},
 			"peerDependencies": {
 				"react": "17.x",
@@ -13733,21 +13774,22 @@
 				"react-query": "3.16.x"
 			}
 		},
-		"node_modules/@synthetixio/queries/node_modules/@synthetixio/contracts-interface": {
-			"version": "2.73.1",
-			"license": "MIT",
+		"node_modules/@synthetixio/queries/node_modules/@synthetixio/optimism-networks": {
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/optimism-networks/-/optimism-networks-2.74.1.tgz",
+			"integrity": "sha512-OZ3BeZLE56oK9nvYHwqeNYudxnwjLPC90Hx2KpLtLZ4sn2xsxJARL74pXTuoD45P7zMo8ulVYAo4yCldv7WWFQ==",
 			"dependencies": {
-				"ethers": "^5.5.3",
-				"synthetix": "v2.73.1"
+				"@eth-optimism/watcher": "^0.0.1-alpha.9",
+				"@metamask/providers": "^8.1.1",
+				"ethers": "^5.5.3"
 			}
 		},
-		"node_modules/@synthetixio/queries/node_modules/@synthetixio/providers": {
-			"version": "2.73.1",
-			"license": "MIT",
+		"node_modules/@synthetixio/queries/node_modules/@synthetixio/wei": {
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+			"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
 			"dependencies": {
-				"@eth-optimism/provider": "^0.0.1-alpha.14",
-				"@synthetixio/contracts-interface": "2.73.1",
-				"@synthetixio/optimism-networks": "2.73.1",
+				"big.js": "^6.1.1",
 				"ethers": "^5.5.3"
 			}
 		},
@@ -34889,59 +34931,6 @@
 				"css-mediaquery": "^0.1.2"
 			}
 		},
-		"node_modules/maxibon-codegen-graph-ts": {
-			"version": "0.2.1",
-			"license": "GPL-3.0",
-			"dependencies": {
-				"@synthetixio/wei": "^2.47.0-ovm.5",
-				"axios": "^0.24.0",
-				"commander": "^8.1.0",
-				"graphql": "^15.5.1",
-				"graphql-request": "^3.5.0",
-				"lodash": "^4.17.21"
-			},
-			"bin": {
-				"maxibon-codegen-graph-ts": "build/src/gen/index.js"
-			}
-		},
-		"node_modules/maxibon-codegen-graph-ts/node_modules/axios": {
-			"version": "0.24.0",
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.14.4"
-			}
-		},
-		"node_modules/maxibon-codegen-graph-ts/node_modules/commander": {
-			"version": "8.3.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/maxibon-codegen-graph-ts/node_modules/form-data": {
-			"version": "3.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/maxibon-codegen-graph-ts/node_modules/graphql-request": {
-			"version": "3.7.0",
-			"license": "MIT",
-			"dependencies": {
-				"cross-fetch": "^3.0.6",
-				"extract-files": "^9.0.0",
-				"form-data": "^3.0.0"
-			},
-			"peerDependencies": {
-				"graphql": "14 - 16"
-			}
-		},
 		"node_modules/md5.js": {
 			"version": "1.3.5",
 			"license": "MIT",
@@ -55412,6 +55401,43 @@
 		"@synthetixio/assets": {
 			"version": "2.0.13"
 		},
+		"@synthetixio/codegen-graph-ts": {
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/codegen-graph-ts/-/codegen-graph-ts-2.74.1.tgz",
+			"integrity": "sha512-aohd8gpFTY2UOhhjM+tqDVwo51VIS1iub1nErEM4tPpfMZzvtD47IVwO8LK5xhg1B1qNo91/eMV1jiLlvE9/bg==",
+			"requires": {
+				"@synthetixio/wei": "2.74.1",
+				"axios": "^0.21.4",
+				"commander": "^8.1.0",
+				"graphql": "^15.5.0",
+				"graphql-request": "^3.4.0",
+				"lodash": "^4.17.21"
+			},
+			"dependencies": {
+				"@synthetixio/wei": {
+					"version": "2.74.1",
+					"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+					"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
+					"requires": {
+						"big.js": "^6.1.1",
+						"ethers": "^5.5.3"
+					}
+				},
+				"axios": {
+					"version": "0.21.4",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+					"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+					"requires": {
+						"follow-redirects": "^1.14.0"
+					}
+				},
+				"commander": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+					"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+				}
+			}
+		},
 		"@synthetixio/contracts-interface": {
 			"version": "2.74.1",
 			"requires": {
@@ -55728,35 +55754,39 @@
 			}
 		},
 		"@synthetixio/queries": {
-			"version": "2.73.1",
+			"version": "2.74.3",
+			"resolved": "https://registry.npmjs.org/@synthetixio/queries/-/queries-2.74.3.tgz",
+			"integrity": "sha512-3RPWrD1B6Lthb6WihzPtGcZhgtM8GqSVblFmDzB4dcbWzeRypAOKLt5nimrGZTav+wE8A5VZcCaNZ5MsWPv00Q==",
 			"requires": {
 				"@snapshot-labs/snapshot.js": "^0.3.22",
-				"@synthetixio/contracts-interface": "2.73.1",
-				"@synthetixio/optimism-networks": "2.73.1",
-				"@synthetixio/providers": "2.73.1",
-				"@synthetixio/wei": "2.73.1",
+				"@synthetixio/codegen-graph-ts": "2.74.1",
+				"@synthetixio/contracts-interface": "2.74.1",
+				"@synthetixio/optimism-networks": "2.74.1",
+				"@synthetixio/wei": "2.74.1",
 				"axios": "^0.21.4",
 				"date-fns": "^2.19.0",
 				"ethers": "^5.5.3",
 				"graphql": "^15.5.0",
 				"graphql-request": "^3.4.0",
-				"lodash": "^4.17.21",
-				"maxibon-codegen-graph-ts": "^0.2.0"
+				"lodash": "^4.17.21"
 			},
 			"dependencies": {
-				"@synthetixio/contracts-interface": {
-					"version": "2.73.1",
+				"@synthetixio/optimism-networks": {
+					"version": "2.74.1",
+					"resolved": "https://registry.npmjs.org/@synthetixio/optimism-networks/-/optimism-networks-2.74.1.tgz",
+					"integrity": "sha512-OZ3BeZLE56oK9nvYHwqeNYudxnwjLPC90Hx2KpLtLZ4sn2xsxJARL74pXTuoD45P7zMo8ulVYAo4yCldv7WWFQ==",
 					"requires": {
-						"ethers": "^5.5.3",
-						"synthetix": "v2.73.1"
+						"@eth-optimism/watcher": "^0.0.1-alpha.9",
+						"@metamask/providers": "^8.1.1",
+						"ethers": "^5.5.3"
 					}
 				},
-				"@synthetixio/providers": {
-					"version": "2.73.1",
+				"@synthetixio/wei": {
+					"version": "2.74.1",
+					"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+					"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
 					"requires": {
-						"@eth-optimism/provider": "^0.0.1-alpha.14",
-						"@synthetixio/contracts-interface": "2.73.1",
-						"@synthetixio/optimism-networks": "2.73.1",
+						"big.js": "^6.1.1",
 						"ethers": "^5.5.3"
 					}
 				},
@@ -70267,44 +70297,6 @@
 			"version": "0.3.1",
 			"requires": {
 				"css-mediaquery": "^0.1.2"
-			}
-		},
-		"maxibon-codegen-graph-ts": {
-			"version": "0.2.1",
-			"requires": {
-				"@synthetixio/wei": "^2.47.0-ovm.5",
-				"axios": "^0.24.0",
-				"commander": "^8.1.0",
-				"graphql": "^15.5.1",
-				"graphql-request": "^3.5.0",
-				"lodash": "^4.17.21"
-			},
-			"dependencies": {
-				"axios": {
-					"version": "0.24.0",
-					"requires": {
-						"follow-redirects": "^1.14.4"
-					}
-				},
-				"commander": {
-					"version": "8.3.0"
-				},
-				"form-data": {
-					"version": "3.0.1",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.8",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"graphql-request": {
-					"version": "3.7.0",
-					"requires": {
-						"cross-fetch": "^3.0.6",
-						"extract-files": "^9.0.0",
-						"form-data": "^3.0.0"
-					}
-				}
 			}
 		},
 		"md5.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"@synthetixio/optimism-networks": "2.73.1",
 				"@synthetixio/providers": "2.74.1",
 				"@synthetixio/queries": "2.74.3",
-				"@synthetixio/transaction-notifier": "2.73.1",
+				"@synthetixio/transaction-notifier": "2.74.1",
 				"@synthetixio/wei": "2.74.1",
 				"@tippyjs/react": "4.1.0",
 				"axios": "0.27.2",
@@ -14366,8 +14366,9 @@
 			}
 		},
 		"node_modules/@synthetixio/transaction-notifier": {
-			"version": "2.73.1",
-			"license": "MIT",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/transaction-notifier/-/transaction-notifier-2.74.1.tgz",
+			"integrity": "sha512-vVcmV8S0sNQswE2Nzi5FTS1JAMRpBQ6FjMyrpAzs3XpAMqemTEZEetvLshQ1sasxZ8lMCZzGmkmf5FcOhZIBJQ==",
 			"dependencies": {
 				"ethers": "^5.5.3"
 			}
@@ -56077,7 +56078,9 @@
 			}
 		},
 		"@synthetixio/transaction-notifier": {
-			"version": "2.73.1",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/transaction-notifier/-/transaction-notifier-2.74.1.tgz",
+			"integrity": "sha512-vVcmV8S0sNQswE2Nzi5FTS1JAMRpBQ6FjMyrpAzs3XpAMqemTEZEetvLshQ1sasxZ8lMCZzGmkmf5FcOhZIBJQ==",
 			"requires": {
 				"ethers": "^5.5.3"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
 				"slick-carousel": "1.8.1",
 				"styled-components": "5.1.1",
 				"styled-media-query": "2.1.2",
-				"synthetix": "2.73.1",
+				"synthetix": "2.74.1",
 				"unstated-next": "1.1.0"
 			},
 			"devDependencies": {
@@ -13377,69 +13377,6 @@
 			"dependencies": {
 				"ethers": "^5.5.3",
 				"synthetix": "2.74.1"
-			}
-		},
-		"node_modules/@synthetixio/contracts-interface/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@synthetixio/contracts-interface/node_modules/commander": {
-			"version": "8.3.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/@synthetixio/contracts-interface/node_modules/pretty-error": {
-			"version": "2.1.2",
-			"license": "MIT",
-			"dependencies": {
-				"lodash": "^4.17.20",
-				"renderkid": "^2.0.4"
-			}
-		},
-		"node_modules/@synthetixio/contracts-interface/node_modules/renderkid": {
-			"version": "2.0.7",
-			"license": "MIT",
-			"dependencies": {
-				"css-select": "^4.1.3",
-				"dom-converter": "^0.2.0",
-				"htmlparser2": "^6.1.0",
-				"lodash": "^4.17.21",
-				"strip-ansi": "^3.0.1"
-			}
-		},
-		"node_modules/@synthetixio/contracts-interface/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@synthetixio/contracts-interface/node_modules/synthetix": {
-			"version": "2.74.1",
-			"license": "MIT",
-			"dependencies": {
-				"abi-decoder": "^2.3.0",
-				"commander": "^8.1.0",
-				"inquirer": "^6.5.2",
-				"inquirer-list-search-prompt": "^1.0.2",
-				"js-levenshtein": "^1.1.6",
-				"pretty-error": "^2.1.1",
-				"solidity-parser-antlr": "^0.4.11",
-				"web3-utils": "^1.2.2"
-			},
-			"bin": {
-				"snx": "bin.js"
-			},
-			"engines": {
-				"node": ">=8.10.0"
 			}
 		},
 		"node_modules/@synthetixio/js": {
@@ -42695,8 +42632,9 @@
 			}
 		},
 		"node_modules/synthetix": {
-			"version": "2.73.1",
-			"license": "MIT",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.74.1.tgz",
+			"integrity": "sha512-ArZUnbMvbH96TN7M63s2lAiRZrqPYYUo3yHUJBSlzYK0Blx6AJEKgLH6RpmRTCwA48R/V5+3TmdAlWsAra6qPg==",
 			"dependencies": {
 				"abi-decoder": "^2.3.0",
 				"commander": "^8.1.0",
@@ -55400,50 +55338,6 @@
 			"requires": {
 				"ethers": "^5.5.3",
 				"synthetix": "2.74.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1"
-				},
-				"commander": {
-					"version": "8.3.0"
-				},
-				"pretty-error": {
-					"version": "2.1.2",
-					"requires": {
-						"lodash": "^4.17.20",
-						"renderkid": "^2.0.4"
-					}
-				},
-				"renderkid": {
-					"version": "2.0.7",
-					"requires": {
-						"css-select": "^4.1.3",
-						"dom-converter": "^0.2.0",
-						"htmlparser2": "^6.1.0",
-						"lodash": "^4.17.21",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"synthetix": {
-					"version": "2.74.1",
-					"requires": {
-						"abi-decoder": "^2.3.0",
-						"commander": "^8.1.0",
-						"inquirer": "^6.5.2",
-						"inquirer-list-search-prompt": "^1.0.2",
-						"js-levenshtein": "^1.1.6",
-						"pretty-error": "^2.1.1",
-						"solidity-parser-antlr": "^0.4.11",
-						"web3-utils": "^1.2.2"
-					}
-				}
 			}
 		},
 		"@synthetixio/js": {
@@ -75425,7 +75319,9 @@
 			}
 		},
 		"synthetix": {
-			"version": "2.73.1",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.74.1.tgz",
+			"integrity": "sha512-ArZUnbMvbH96TN7M63s2lAiRZrqPYYUo3yHUJBSlzYK0Blx6AJEKgLH6RpmRTCwA48R/V5+3TmdAlWsAra6qPg==",
 			"requires": {
 				"abi-decoder": "^2.3.0",
 				"commander": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@reach/tabs": "0.15.0",
 				"@synthetixio/assets": "2.0.13",
 				"@synthetixio/contracts-interface": "2.74.1",
-				"@synthetixio/optimism-networks": "2.73.1",
+				"@synthetixio/optimism-networks": "2.74.1",
 				"@synthetixio/providers": "2.74.1",
 				"@synthetixio/queries": "2.74.3",
 				"@synthetixio/transaction-notifier": "2.74.1",
@@ -13715,8 +13715,9 @@
 			}
 		},
 		"node_modules/@synthetixio/optimism-networks": {
-			"version": "2.73.1",
-			"license": "MIT",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/optimism-networks/-/optimism-networks-2.74.1.tgz",
+			"integrity": "sha512-OZ3BeZLE56oK9nvYHwqeNYudxnwjLPC90Hx2KpLtLZ4sn2xsxJARL74pXTuoD45P7zMo8ulVYAo4yCldv7WWFQ==",
 			"dependencies": {
 				"@eth-optimism/watcher": "^0.0.1-alpha.9",
 				"@metamask/providers": "^8.1.1",
@@ -13730,15 +13731,6 @@
 				"@eth-optimism/provider": "^0.0.1-alpha.14",
 				"@synthetixio/contracts-interface": "2.74.1",
 				"@synthetixio/optimism-networks": "2.74.1",
-				"ethers": "^5.5.3"
-			}
-		},
-		"node_modules/@synthetixio/providers/node_modules/@synthetixio/optimism-networks": {
-			"version": "2.74.1",
-			"license": "MIT",
-			"dependencies": {
-				"@eth-optimism/watcher": "^0.0.1-alpha.9",
-				"@metamask/providers": "^8.1.1",
 				"ethers": "^5.5.3"
 			}
 		},
@@ -13763,16 +13755,6 @@
 				"react": "17.x",
 				"react-dom": "17.x",
 				"react-query": "3.16.x"
-			}
-		},
-		"node_modules/@synthetixio/queries/node_modules/@synthetixio/optimism-networks": {
-			"version": "2.74.1",
-			"resolved": "https://registry.npmjs.org/@synthetixio/optimism-networks/-/optimism-networks-2.74.1.tgz",
-			"integrity": "sha512-OZ3BeZLE56oK9nvYHwqeNYudxnwjLPC90Hx2KpLtLZ4sn2xsxJARL74pXTuoD45P7zMo8ulVYAo4yCldv7WWFQ==",
-			"dependencies": {
-				"@eth-optimism/watcher": "^0.0.1-alpha.9",
-				"@metamask/providers": "^8.1.1",
-				"ethers": "^5.5.3"
 			}
 		},
 		"node_modules/@synthetixio/queries/node_modules/axios": {
@@ -55702,7 +55684,9 @@
 			}
 		},
 		"@synthetixio/optimism-networks": {
-			"version": "2.73.1",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/optimism-networks/-/optimism-networks-2.74.1.tgz",
+			"integrity": "sha512-OZ3BeZLE56oK9nvYHwqeNYudxnwjLPC90Hx2KpLtLZ4sn2xsxJARL74pXTuoD45P7zMo8ulVYAo4yCldv7WWFQ==",
 			"requires": {
 				"@eth-optimism/watcher": "^0.0.1-alpha.9",
 				"@metamask/providers": "^8.1.1",
@@ -55716,16 +55700,6 @@
 				"@synthetixio/contracts-interface": "2.74.1",
 				"@synthetixio/optimism-networks": "2.74.1",
 				"ethers": "^5.5.3"
-			},
-			"dependencies": {
-				"@synthetixio/optimism-networks": {
-					"version": "2.74.1",
-					"requires": {
-						"@eth-optimism/watcher": "^0.0.1-alpha.9",
-						"@metamask/providers": "^8.1.1",
-						"ethers": "^5.5.3"
-					}
-				}
 			}
 		},
 		"@synthetixio/queries": {
@@ -55746,16 +55720,6 @@
 				"lodash": "^4.17.21"
 			},
 			"dependencies": {
-				"@synthetixio/optimism-networks": {
-					"version": "2.74.1",
-					"resolved": "https://registry.npmjs.org/@synthetixio/optimism-networks/-/optimism-networks-2.74.1.tgz",
-					"integrity": "sha512-OZ3BeZLE56oK9nvYHwqeNYudxnwjLPC90Hx2KpLtLZ4sn2xsxJARL74pXTuoD45P7zMo8ulVYAo4yCldv7WWFQ==",
-					"requires": {
-						"@eth-optimism/watcher": "^0.0.1-alpha.9",
-						"@metamask/providers": "^8.1.1",
-						"ethers": "^5.5.3"
-					}
-				},
 				"axios": {
 					"version": "0.21.4",
 					"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@synthetixio/providers": "2.74.1",
 				"@synthetixio/queries": "2.74.3",
 				"@synthetixio/transaction-notifier": "2.73.1",
-				"@synthetixio/wei": "2.73.1",
+				"@synthetixio/wei": "2.74.1",
 				"@tippyjs/react": "4.1.0",
 				"axios": "0.27.2",
 				"bignumber.js": "9.0.0",
@@ -13355,15 +13355,6 @@
 				"codegen-graph-ts": "build/src/gen/index.js"
 			}
 		},
-		"node_modules/@synthetixio/codegen-graph-ts/node_modules/@synthetixio/wei": {
-			"version": "2.74.1",
-			"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
-			"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
-			"dependencies": {
-				"big.js": "^6.1.1",
-				"ethers": "^5.5.3"
-			}
-		},
 		"node_modules/@synthetixio/codegen-graph-ts/node_modules/axios": {
 			"version": "0.21.4",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -13781,15 +13772,6 @@
 			"dependencies": {
 				"@eth-optimism/watcher": "^0.0.1-alpha.9",
 				"@metamask/providers": "^8.1.1",
-				"ethers": "^5.5.3"
-			}
-		},
-		"node_modules/@synthetixio/queries/node_modules/@synthetixio/wei": {
-			"version": "2.74.1",
-			"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
-			"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
-			"dependencies": {
-				"big.js": "^6.1.1",
 				"ethers": "^5.5.3"
 			}
 		},
@@ -14391,8 +14373,9 @@
 			}
 		},
 		"node_modules/@synthetixio/wei": {
-			"version": "2.73.1",
-			"license": "MIT",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+			"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
 			"dependencies": {
 				"big.js": "^6.1.1",
 				"ethers": "^5.5.3"
@@ -55414,15 +55397,6 @@
 				"lodash": "^4.17.21"
 			},
 			"dependencies": {
-				"@synthetixio/wei": {
-					"version": "2.74.1",
-					"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
-					"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
-					"requires": {
-						"big.js": "^6.1.1",
-						"ethers": "^5.5.3"
-					}
-				},
 				"axios": {
 					"version": "0.21.4",
 					"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -55781,15 +55755,6 @@
 						"ethers": "^5.5.3"
 					}
 				},
-				"@synthetixio/wei": {
-					"version": "2.74.1",
-					"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
-					"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
-					"requires": {
-						"big.js": "^6.1.1",
-						"ethers": "^5.5.3"
-					}
-				},
 				"axios": {
 					"version": "0.21.4",
 					"requires": {
@@ -56118,7 +56083,9 @@
 			}
 		},
 		"@synthetixio/wei": {
-			"version": "2.73.1",
+			"version": "2.74.1",
+			"resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+			"integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
 			"requires": {
 				"big.js": "^6.1.1",
 				"ethers": "^5.5.3"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@reach/tabs": "0.15.0",
 		"@synthetixio/assets": "2.0.13",
 		"@synthetixio/contracts-interface": "2.74.1",
-		"@synthetixio/optimism-networks": "2.73.1",
+		"@synthetixio/optimism-networks": "2.74.1",
 		"@synthetixio/providers": "2.74.1",
 		"@synthetixio/queries": "2.74.3",
 		"@synthetixio/transaction-notifier": "2.74.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"slick-carousel": "1.8.1",
 		"styled-components": "5.1.1",
 		"styled-media-query": "2.1.2",
-		"synthetix": "2.73.1",
+		"synthetix": "2.74.1",
 		"unstated-next": "1.1.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@synthetixio/contracts-interface": "2.74.1",
 		"@synthetixio/optimism-networks": "2.73.1",
 		"@synthetixio/providers": "2.74.1",
-		"@synthetixio/queries": "2.73.1",
+		"@synthetixio/queries": "2.74.3",
 		"@synthetixio/transaction-notifier": "2.73.1",
 		"@synthetixio/wei": "2.73.1",
 		"@tippyjs/react": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@synthetixio/providers": "2.74.1",
 		"@synthetixio/queries": "2.74.3",
 		"@synthetixio/transaction-notifier": "2.73.1",
-		"@synthetixio/wei": "2.73.1",
+		"@synthetixio/wei": "2.74.1",
 		"@tippyjs/react": "4.1.0",
 		"axios": "0.27.2",
 		"bignumber.js": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"@synthetixio/optimism-networks": "2.73.1",
 		"@synthetixio/providers": "2.74.1",
 		"@synthetixio/queries": "2.74.3",
-		"@synthetixio/transaction-notifier": "2.73.1",
+		"@synthetixio/transaction-notifier": "2.74.1",
 		"@synthetixio/wei": "2.74.1",
 		"@tippyjs/react": "4.1.0",
 		"axios": "0.27.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR bumps the following packages:
- synthetix
- synthetixio/queries
- synthetixio/wei
- synthetixio/transaction-notifier
- synthetixio/optimism-networks

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Keeping Kwenta up-to-date

## How Has This Been Tested?
Functionality of Futures markets and Spot market has been tested on localhost

## Screenshots (if appropriate):
