### PR TITLE
v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kwenta",
-	"version": "2.45.2",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kwenta",
-			"version": "2.45.2",
+			"version": "3.0.0",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@artsy/fresnel": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kwenta",
-	"version": "2.45.2",
+	"version": "3.0.0",
 	"scripts": {
 		"dev": "next",
 		"build": "next build",

--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -17,7 +17,7 @@ const Header: FC = () => {
 		<Container isL2={isL2}>
 			<MobileHiddenView>
 				<LogoNav>
-					<StyledLogo isL2={isL2} isFutures />
+					<Logo />
 					<Nav />
 				</LogoNav>
 				<WalletButtons />
@@ -43,7 +43,5 @@ const LogoNav = styled.div`
 	display: flex;
 	align-items: center;
 `;
-
-const StyledLogo = styled(Logo)``;
 
 export default Header;

--- a/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileMenuModal.tsx
+++ b/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileMenuModal.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useRecoilValue } from 'recoil';
 import styled, { css } from 'styled-components';
 
 import MobileMenuArrow from 'assets/svg/app/mobile-menu-arrow.svg';
@@ -10,7 +9,6 @@ import FullScreenModal from 'components/FullScreenModal';
 import ROUTES from 'constants/routes';
 import Links from 'sections/dashboard/Links';
 import Logo from 'sections/shared/Layout/Logo';
-import { isL2State } from 'store/wallet';
 
 import { HOMEPAGE_MENU_LINKS, MENU_LINKS } from '../constants';
 import { MenuButton, SUB_MENUS } from './common';
@@ -25,7 +23,6 @@ export const MobileMenuModal: FC<MobileMenuModalProps> = ({ onDismiss }) => {
 	const { asPath } = useRouter();
 	const menuLinks =
 		window.location.pathname === ROUTES.Home.Root ? HOMEPAGE_MENU_LINKS : MENU_LINKS;
-	const isL2 = useRecoilValue(isL2State);
 
 	const [expanded, setExpanded] = useState<string | undefined>();
 
@@ -37,7 +34,7 @@ export const MobileMenuModal: FC<MobileMenuModalProps> = ({ onDismiss }) => {
 		<StyledFullScreenModal isOpen>
 			<Container>
 				<LogoContainer>
-					<Logo isFutures isL2={isL2} />
+					<Logo />
 				</LogoContainer>
 				{menuLinks.map(({ i18nLabel, link }) => (
 					<div key={link}>

--- a/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileSettingsModal.tsx
+++ b/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileSettingsModal.tsx
@@ -55,7 +55,7 @@ export const MobileSettingsModal: FC<MobileSettingsModalProps> = ({ onDismiss })
 		<StyledFullScreenModal isOpen>
 			<Container>
 				<LogoContainer>
-					<Logo isFutures isL2={isL2} />
+					<Logo />
 				</LogoContainer>
 
 				{!(window.location.pathname === ROUTES.Home.Root) && (

--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -146,7 +146,6 @@ const MobileContainer = styled(FlexDivRow)`
 `;
 
 const LogoContainer = styled.div`
-	margin-top: -4px;
 	${media.lessThan('sm')`
 		margin-top: 4px;
 		padding-left:17px;

--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -92,7 +92,7 @@ const Header: FC = () => {
 			<MobileHiddenView>
 				<Container>
 					<LogoContainer>
-						<Logo isL2={isL2} />
+						<Logo />
 					</LogoContainer>
 					<Links>
 						{LINKS.map(({ id, label, icon, onClick }) => (

--- a/sections/shared/Layout/Logo/Logo.tsx
+++ b/sections/shared/Layout/Logo/Logo.tsx
@@ -11,7 +11,7 @@ import ROUTES from 'constants/routes';
 import { currentThemeState } from 'store/ui';
 
 type LogoProps = {
-	isL2: boolean;
+	isL2?: boolean;
 	isFutures?: boolean;
 };
 

--- a/sections/shared/SystemStatus/SystemStatus.tsx
+++ b/sections/shared/SystemStatus/SystemStatus.tsx
@@ -67,7 +67,7 @@ const SystemStatus: FC<SystemStatusProps> = ({ children }) => {
 			<FullScreenContainer>
 				<StyledPageContent>
 					<Header>
-						<Logo isL2 />
+						<Logo />
 					</Header>
 					<Container>
 						<StyledSystemDownIcon />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moving Kwenta Futures out of Beta, pushing the first v3.0.0 release. This PR in particular:

- Bumps Kwenta to 3.0.0
- Updates Futures Banner to remove "Beta"
- Removes `margin-top: -4px` to align landing page logo with Futures page logo when switching between both (by clicking on the logo)

## Related issue
#1168 

## Motivation and Context
Kwenta Futures is mature enough to remove the Beta label and begin a mature release cycle.

## How Has This Been Tested?
Localhost

## Screenshots (if appropriate):
![Screen Shot 2022-07-28 at 17 48 28](https://user-images.githubusercontent.com/548702/181634763-4498dc0c-6171-4821-8264-ac2b40801b94.png)
