### PR TITLE
Enable sorting on futures/spot markets tables

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -105,6 +105,7 @@ export const Table: FC<TableProps> = ({
 				sortBy: sortBy,
 			},
 			autoResetPage: false,
+			autoResetSortBy: false,
 			...options,
 		},
 		useSortBy,

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -1,3 +1,4 @@
+import { wei } from '@synthetixio/wei';
 import { useRouter } from 'next/router';
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -146,6 +147,15 @@ const FuturesMarketsTable: FC = () => {
 									);
 								},
 								width: 130,
+								sortable: true,
+								sortType: useMemo(
+									() => (rowA: any, rowB: any) => {
+										const rowOne = rowA.original.price ?? wei(0);
+										const rowTwo = rowB.original.price ?? wei(0);
+										return rowOne.toSortable() > rowTwo.toSortable() ? 1 : -1;
+									},
+									[]
+								),
 							},
 							{
 								Header: (
@@ -164,6 +174,15 @@ const FuturesMarketsTable: FC = () => {
 									);
 								},
 								width: 105,
+								sortable: true,
+								sortType: useMemo(
+									() => (rowA: any, rowB: any) => {
+										const rowOne = rowA.original.priceChange ?? wei(0);
+										const rowTwo = rowB.original.priceChange ?? wei(0);
+										return rowOne.toSortable() > rowTwo.toSortable() ? 1 : -1;
+									},
+									[]
+								),
 							},
 							{
 								Header: (
@@ -182,6 +201,15 @@ const FuturesMarketsTable: FC = () => {
 									);
 								},
 								width: 125,
+								sortable: true,
+								sortType: useMemo(
+									() => (rowA: any, rowB: any) => {
+										const rowOne = rowA.original.fundingRate ?? wei(0);
+										const rowTwo = rowB.original.fundingRate ?? wei(0);
+										return rowOne.toSortable() > rowTwo.toSortable() ? 1 : -1;
+									},
+									[]
+								),
 							},
 							{
 								Header: (
@@ -207,6 +235,17 @@ const FuturesMarketsTable: FC = () => {
 									);
 								},
 								width: 125,
+								sortable: true,
+								sortType: useMemo(
+									() => (rowA: any, rowB: any) => {
+										const rowOne =
+											rowA.original.longInterest.add(rowA.original.shortInterest) ?? wei(0);
+										const rowTwo =
+											rowB.original.longInterest.add(rowB.original.shortInterest) ?? wei(0);
+										return rowOne.toSortable() > rowTwo.toSortable() ? 1 : -1;
+									},
+									[]
+								),
 							},
 							{
 								Header: (
@@ -226,6 +265,7 @@ const FuturesMarketsTable: FC = () => {
 									);
 								},
 								width: 125,
+								sortable: true,
 								sortType: useMemo(
 									() => (rowA: any, rowB: any) => {
 										const rowOne = rowA.original.volume;

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -179,7 +179,7 @@ const FuturesMarketsTable: FC = () => {
 									() => (rowA: any, rowB: any) => {
 										const rowOne = rowA.original.priceChange ?? wei(0);
 										const rowTwo = rowB.original.priceChange ?? wei(0);
-										return rowOne.toSortable() > rowTwo.toSortable() ? 1 : -1;
+										return rowOne.toNumber() > rowTwo.toNumber() ? -1 : 1;
 									},
 									[]
 								),
@@ -206,7 +206,7 @@ const FuturesMarketsTable: FC = () => {
 									() => (rowA: any, rowB: any) => {
 										const rowOne = rowA.original.fundingRate ?? wei(0);
 										const rowTwo = rowB.original.fundingRate ?? wei(0);
-										return rowOne.toSortable() > rowTwo.toSortable() ? 1 : -1;
+										return rowOne.toNumber() > rowTwo.toNumber() ? -1 : 1;
 									},
 									[]
 								),

--- a/sections/dashboard/SpotMarketsTable/SpotMarketsTable.tsx
+++ b/sections/dashboard/SpotMarketsTable/SpotMarketsTable.tsx
@@ -1,4 +1,5 @@
 import { Synth, Synths } from '@synthetixio/contracts-interface';
+import { wei } from '@synthetixio/wei';
 import * as _ from 'lodash/fp';
 import values from 'lodash/values';
 import { useRouter } from 'next/router';
@@ -140,6 +141,15 @@ const SpotMarketsTable: FC<SpotMarketsTableProps> = ({ exchangeRates }) => {
 							);
 						},
 						width: 130,
+						sortable: true,
+						sortType: useMemo(
+							() => (rowA: any, rowB: any) => {
+								const rowOne = rowA.original.price ?? 0;
+								const rowTwo = rowB.original.price ?? 0;
+								return rowOne > rowTwo ? 1 : -1;
+							},
+							[]
+						),
 					},
 					{
 						Header: (
@@ -158,6 +168,15 @@ const SpotMarketsTable: FC<SpotMarketsTableProps> = ({ exchangeRates }) => {
 							);
 						},
 						width: 105,
+						sortable: true,
+						sortType: useMemo(
+							() => (rowA: any, rowB: any) => {
+								const rowOne = rowA.original.change;
+								const rowTwo = rowB.original.change;
+								return rowOne > rowTwo ? 1 : -1;
+							},
+							[]
+						),
 					},
 					{
 						Header: <TableHeader>{t('dashboard.overview.spot-markets-table.24h-vol')}</TableHeader>,
@@ -173,6 +192,7 @@ const SpotMarketsTable: FC<SpotMarketsTableProps> = ({ exchangeRates }) => {
 							);
 						},
 						width: 125,
+						sortable: true,
 						sortType: useMemo(
 							() => (rowA: any, rowB: any) => {
 								const rowOne = rowA.original.volume;

--- a/sections/dashboard/SpotMarketsTable/SpotMarketsTable.tsx
+++ b/sections/dashboard/SpotMarketsTable/SpotMarketsTable.tsx
@@ -1,5 +1,4 @@
 import { Synth, Synths } from '@synthetixio/contracts-interface';
-import { wei } from '@synthetixio/wei';
 import * as _ from 'lodash/fp';
 import values from 'lodash/values';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add sorting function on the Spot markets tables 
## Related issue
https://github.com/Kwenta/kwenta/issues/1189

## Motivation and Context


## How Has This Been Tested?


## Screenshots (if appropriate):
