### PR TITLE
Replace currencykey with market key

### DIFF
--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -51,7 +51,8 @@ const FuturesMarketsTable: FC = () => {
 			const volume = futuresVolume[market.assetHex];
 			const pastPrice = dailyPriceChanges.find((price) => price.synth === market.asset);
 			const fundingRateResponse = fundingRates.find(
-				({ data: fundingData }) => (fundingData as FundingRateResponse)?.asset === market.asset
+				({ data: fundingData }) =>
+					(fundingData as FundingRateResponse)?.asset === MarketKeyByAsset[market.asset]
 			);
 
 			return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1H Funding rates are not working for most assets in `FutureMarketTable` because of change #1191 

## Related issue
#1191

## Motivation and Context
Fix the display of funding rates

## How Has This Been Tested?
1. Open the `FutureMarketsTable` and check the funding rate

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/182251127-9caf0c7b-536c-46d1-9e51-e9c729d641f8.png)

