### PR TITLE
Refetch trade query when switching between long and short

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -258,8 +258,9 @@ export const QUERY_KEYS = {
 			networkId: NetworkId,
 			market: string | null,
 			tradeSize: string,
-			walletAddress: string
-		) => ['futures', 'potentialTrade', tradeSize, networkId, market, walletAddress],
+			walletAddress: string,
+			leverageSide: string
+		) => ['futures', 'potentialTrade', tradeSize, networkId, market, walletAddress, leverageSide],
 		MarketLimit: (networkId: NetworkId, market: string | null) => [
 			'futures',
 			'marketLimit',

--- a/queries/futures/useGetFuturesPotentialTradeDetails.ts
+++ b/queries/futures/useGetFuturesPotentialTradeDetails.ts
@@ -56,7 +56,8 @@ const useGetFuturesPotentialTradeDetails = (
 			network.id,
 			marketAsset || null,
 			tradeSize,
-			walletAddress || ''
+			walletAddress || '',
+			leverageSide
 		),
 		async () => {
 			if (!marketAsset || !tradeSize || !isL2) {


### PR DESCRIPTION
## Description
Switching between long or short buttons does now change the trade details due to the query returning cached value

## Related issue
-

## How Has This Been Tested?
When switching between long and short you can now see the trade details correctly update
