### PR TITLE
Bug: Margin info and buying power

### DIFF
--- a/sections/futures/MarketInfoBox/MarketInfoBox.tsx
+++ b/sections/futures/MarketInfoBox/MarketInfoBox.tsx
@@ -33,8 +33,8 @@ const MarketInfoBox: React.FC = () => {
 	const availableMargin = position?.accessibleMargin ?? zeroBN;
 
 	const buyingPower =
-		position && position?.accessibleMargin.gt(zeroBN)
-			? position?.accessibleMargin?.mul(maxLeverage ?? zeroBN)
+		position && position?.remainingMargin.gt(zeroBN)
+			? maxLeverage.mul(position?.remainingMargin ?? zeroBN)
 			: zeroBN;
 
 	const marginUsage =
@@ -85,11 +85,14 @@ const MarketInfoBox: React.FC = () => {
 	};
 
 	const previewAvailableMargin = React.useMemo(() => {
-		const potentialAvailableMargin = getPotentialAvailableMargin(previewTrade, maxLeverage);
+		const potentialAvailableMargin = getPotentialAvailableMargin(
+			previewTrade,
+			marketInfo?.maxLeverage
+		);
 		return isNextPriceOrder
 			? potentialAvailableMargin?.sub(totalDeposit) ?? zeroBN
 			: potentialAvailableMargin;
-	}, [previewTrade, maxLeverage, isNextPriceOrder, totalDeposit]);
+	}, [previewTrade, marketInfo?.maxLeverage, isNextPriceOrder, totalDeposit]);
 
 	const previewTradeData = React.useMemo(() => {
 		const size = wei(tradeSize || zeroBN);


### PR DESCRIPTION
Fixing a bug with buying power and available margin. It is using the `maxLeverage` value which depends on the open position. Instead, we should be using `marketInfo.maxLeverage` which is a static value for each market.

## Description
* Replicate logic from max order size button for buying power
* Use marketInfo max leverage value to calculate changes in available margin after a trade
