### PR TITLE
Fix the missing futures markets on the landing page

### DIFF
--- a/sections/shared/Layout/HomeLayout/HomeLayout.tsx
+++ b/sections/shared/Layout/HomeLayout/HomeLayout.tsx
@@ -1,3 +1,4 @@
+import { RefetchProvider } from 'contexts/RefetchContext';
 import { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
@@ -14,7 +15,7 @@ const HomeLayout: FC<HomeLayoutProps> = ({ children }) => (
 	<FullScreenContainer>
 		<GlobalStyle />
 		<Header />
-		{children}
+		<RefetchProvider>{children}</RefetchProvider>
 		<Footer />
 	</FullScreenContainer>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user cannot see the future market cards on the landing page.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the landing page and the user can see the future market cards again.

## Screenshots (if appropriate):
