### PR TITLE
Fix the price rate of synth-token

### DIFF
--- a/hooks/useExchange.ts
+++ b/hooks/useExchange.ts
@@ -273,6 +273,7 @@ const useExchange = ({
 	const numEntries = numEntriesQuery.isSuccess ? numEntriesQuery.data ?? null : null;
 
 	const baseCurrency = baseCurrencyKey != null ? synthsMap[baseCurrencyKey]! : null;
+	const quoteCurrency = quoteCurrencyKey != null ? synthsMap[quoteCurrencyKey]! : null;
 
 	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
 
@@ -312,7 +313,7 @@ const useExchange = ({
 	// TODO: Fix coingecko prices (optimism issue maybe?)
 	const quotePriceRate = useMemo(
 		() =>
-			txProvider !== 'synthetix' && !isQuoteCurrencyETH
+			txProvider !== 'synthetix' && !isQuoteCurrencyETH && !quoteCurrency
 				? coinGeckoPrices != null &&
 				  quoteCurrencyTokenAddress != null &&
 				  selectPriceCurrencyRate != null &&
@@ -326,18 +327,20 @@ const useExchange = ({
 						selectedPriceCurrency.name
 				  ),
 		[
+			txProvider,
+			isQuoteCurrencyETH,
+			quoteCurrency,
+			coinGeckoPrices,
+			quoteCurrencyTokenAddress,
+			selectPriceCurrencyRate,
 			exchangeRates,
 			quoteCurrencyKey,
 			selectedPriceCurrency.name,
-			txProvider,
-			selectPriceCurrencyRate,
-			coinGeckoPrices,
-			quoteCurrencyTokenAddress,
-			isQuoteCurrencyETH,
 		]
 	);
+
 	const basePriceRate = useMemo(() => {
-		return txProvider !== 'synthetix' && !isBaseCurrencyETH
+		return txProvider !== 'synthetix' && !isBaseCurrencyETH && !baseCurrency
 			? coinGeckoPrices != null &&
 			  baseCurrencyTokenAddress != null &&
 			  selectPriceCurrencyRate != null &&
@@ -352,14 +355,15 @@ const useExchange = ({
 					selectedPriceCurrency.name
 			  );
 	}, [
+		txProvider,
+		isBaseCurrencyETH,
+		baseCurrency,
+		coinGeckoPrices,
+		baseCurrencyTokenAddress,
+		selectPriceCurrencyRate,
 		exchangeRates,
 		baseCurrencyKey,
 		selectedPriceCurrency.name,
-		txProvider,
-		selectPriceCurrencyRate,
-		baseCurrencyTokenAddress,
-		coinGeckoPrices,
-		isBaseCurrencyETH,
 	]);
 
 	const settlementWaitingPeriodQuery = useFeeReclaimPeriodQuery(baseCurrencyKey, walletAddress);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Try to fix the price rate of the synth token in 1inch swap

## Related issue
#1234 

## Motivation and Context
Improve UX

## How Has This Been Tested?
Verified the following scenarios:
1. sUSD <=> DAI (erc20)
2. sETH <=> DAI (erc20)
3. sMATIC <=> DAI (erc20)
4. sMATIC <=> sLink 
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/182963650-881be4c9-ae85-48d3-954b-6cd0d542cb03.png)
![image](https://user-images.githubusercontent.com/4819006/182963699-72cbfe5f-41bd-4a56-bb4d-4e4c60acdbf7.png)
