### PR TITLE
Make cross margin unavailable in prod mode

### DIFF
--- a/queries/futures/useQueryCrossMarginAccount.ts
+++ b/queries/futures/useQueryCrossMarginAccount.ts
@@ -33,7 +33,8 @@ export default function useQueryCrossMarginAccount() {
 	return useQuery<any | null>(
 		QUERY_KEYS.Futures.CrossMarginAccount(network.id, walletAddress + 't' || ''),
 		async () => {
-			if (!supportedNetworks.includes(network.id)) {
+			//TODO: Remove dev check
+			if (!supportedNetworks.includes(network.id) || process?.env?.NODE_ENV !== 'development') {
 				const accountState = {
 					loading: false,
 					crossMarginAvailable: false,

--- a/sections/futures/Trade/Trade.tsx
+++ b/sections/futures/Trade/Trade.tsx
@@ -26,9 +26,7 @@ const Trade: React.FC = () => {
 		<div>
 			{
 				//TODO: Remove dev check
-				process?.env?.NODE_ENV === 'development' && futuresAccount.crossMarginAvailable && (
-					<AccountTypeToggle />
-				)
+				futuresAccount.crossMarginAvailable && <AccountTypeToggle />
 			}
 
 			<MarketsDropdown />


### PR DESCRIPTION
The previous method to only disable the toggle didn't cover all bases of disabling cross margin in prod.