### PR TITLE
fix: Remove arrow indicator for funding #1223

### DIFF
--- a/components/ChangePercent/ChangePercent.tsx
+++ b/components/ChangePercent/ChangePercent.tsx
@@ -24,7 +24,7 @@ export const ChangePercent: FC<ChangePercentProps> = ({
 
 	return (
 		<CurrencyChange isPositive={isPositive} {...rest}>
-			{isPositive && showArrow ? <ChangePositiveIcon /> : <ChangeNegativeIcon />}
+			{showArrow ? isPositive ? <ChangePositiveIcon /> : <ChangeNegativeIcon /> : ''}
 			{formatPercent(wei(value ?? 0).abs(), { minDecimals: decimals })}
 		</CurrencyChange>
 	);

--- a/components/ChangePercent/ChangePercent.tsx
+++ b/components/ChangePercent/ChangePercent.tsx
@@ -11,14 +11,15 @@ type ChangePercentProps = {
 	value: WeiSource;
 	className?: string;
 	decimals?: number;
+	showArrow?: boolean;
 };
 
-export const ChangePercent: FC<ChangePercentProps> = ({ value, decimals = 2, ...rest }) => {
+export const ChangePercent: FC<ChangePercentProps> = ({ value, decimals = 2, showArrow = true, ...rest }) => {
 	const isPositive = wei(value ?? 0).gt(0);
 
 	return (
 		<CurrencyChange isPositive={isPositive} {...rest}>
-			{isPositive ? <ChangePositiveIcon /> : <ChangeNegativeIcon />}
+			{isPositive && showArrow ? <ChangePositiveIcon /> : <ChangeNegativeIcon />}
 			{formatPercent(wei(value ?? 0).abs(), { minDecimals: decimals })}
 		</CurrencyChange>
 	);
@@ -39,9 +40,9 @@ const CurrencyChange = styled.span<{ isPositive: boolean }>`
 		height: 10px;
 		path {
 			fill: ${(props) =>
-				props.isPositive
-					? props.theme.colors.selectedTheme.green
-					: props.theme.colors.selectedTheme.red};
+		props.isPositive
+			? props.theme.colors.selectedTheme.green
+			: props.theme.colors.selectedTheme.red};
 		}
 	}
 

--- a/components/ChangePercent/ChangePercent.tsx
+++ b/components/ChangePercent/ChangePercent.tsx
@@ -14,7 +14,12 @@ type ChangePercentProps = {
 	showArrow?: boolean;
 };
 
-export const ChangePercent: FC<ChangePercentProps> = ({ value, decimals = 2, showArrow = true, ...rest }) => {
+export const ChangePercent: FC<ChangePercentProps> = ({
+	value,
+	decimals = 2,
+	showArrow = true,
+	...rest
+}) => {
 	const isPositive = wei(value ?? 0).gt(0);
 
 	return (
@@ -40,9 +45,9 @@ const CurrencyChange = styled.span<{ isPositive: boolean }>`
 		height: 10px;
 		path {
 			fill: ${(props) =>
-		props.isPositive
-			? props.theme.colors.selectedTheme.green
-			: props.theme.colors.selectedTheme.red};
+				props.isPositive
+					? props.theme.colors.selectedTheme.green
+					: props.theme.colors.selectedTheme.red};
 		}
 	}
 

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -196,6 +196,7 @@ const FuturesMarketsTable: FC = () => {
 										<ChangePercent
 											value={cellProps.row.original.fundingRate}
 											decimals={6}
+											showArrow={false}
 											className="change-pct"
 										/>
 									);

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -190,6 +190,7 @@ const FuturesMarketsTable: FC = () => {
 										{t('dashboard.overview.futures-markets-table.funding-rate')}
 									</TableHeader>
 								),
+								sortable: false,
 								accessor: 'fundingRate',
 								Cell: (cellProps: CellProps<any>) => {
 									return (
@@ -201,7 +202,6 @@ const FuturesMarketsTable: FC = () => {
 									);
 								},
 								width: 125,
-								sortable: true,
 								sortType: useMemo(
 									() => (rowA: any, rowB: any) => {
 										const rowOne = rowA.original.fundingRate ?? wei(0);

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -190,7 +190,6 @@ const FuturesMarketsTable: FC = () => {
 										{t('dashboard.overview.futures-markets-table.funding-rate')}
 									</TableHeader>
 								),
-								sortable: false,
 								accessor: 'fundingRate',
 								Cell: (cellProps: CellProps<any>) => {
 									return (
@@ -341,6 +340,7 @@ const FuturesMarketsTable: FC = () => {
 										/>
 										<div>
 											<ChangePercent
+												showArrow={false}
 												value={cellProps.row.original.fundingRate}
 												decimals={6}
 												className="change-pct"

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -200,6 +200,7 @@ const FuturesMarketsTable: FC = () => {
 										/>
 									);
 								},
+								sortable: true,
 								width: 125,
 								sortType: useMemo(
 									() => (rowA: any, rowB: any) => {

--- a/sections/shared/Layout/HomeLayout/HomeLayout.tsx
+++ b/sections/shared/Layout/HomeLayout/HomeLayout.tsx
@@ -1,7 +1,7 @@
-import { RefetchProvider } from 'contexts/RefetchContext';
 import { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
+import { RefetchProvider } from 'contexts/RefetchContext';
 import { FullScreenContainer } from 'styles/common';
 
 import Footer from './Footer';


### PR DESCRIPTION
Removed arrow indicator from 1H funding in FuturesMarketTable

## Description
removed arrow from 1H funding by providing sortable as false

## Related issue
https://github.com/Kwenta/kwenta/issues/1223



## How Has This Been Tested?
Tested on local 

## Screenshots (if appropriate):
<img width="1434" alt="Screenshot 2022-08-09 at 12 14 02 AM" src="https://user-images.githubusercontent.com/26053388/183490871-3304fa80-def6-43bc-8b61-f147498e3d9c.png">
