### PR TITLE
Bug: Portfolio Value

### DIFF
--- a/sections/dashboard/MobileDashboard/OpenPositions.tsx
+++ b/sections/dashboard/MobileDashboard/OpenPositions.tsx
@@ -11,10 +11,8 @@ import { Synths } from 'constants/currency';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
-import { futuresMarketsState } from 'store/futures';
 import { walletAddressState } from 'store/wallet';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
-import { MarketKeyByAsset } from 'utils/futures';
 
 import FuturesPositionsTable from '../FuturesPositionsTable';
 import SynthBalancesTable from '../SynthBalancesTable';
@@ -29,10 +27,7 @@ const OpenPositions: React.FC = () => {
 
 	const { useExchangeRatesQuery, useSynthsBalancesQuery } = useSynthetixQueries();
 
-	const futuresMarkets = useRecoilValue(futuresMarketsState);
-
-	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
-	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
+	const portfolioValueQuery = useGetCurrentPortfolioValue();
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 
 	const futuresPositionQuery = useGetFuturesPositionForAccount();

--- a/sections/dashboard/Overview/Overview.tsx
+++ b/sections/dashboard/Overview/Overview.tsx
@@ -11,10 +11,8 @@ import { TabPanel } from 'components/Tab';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
 import useQueryCrossMarginAccount from 'queries/futures/useQueryCrossMarginAccount';
-import { futuresMarketsState } from 'store/futures';
 import { walletAddressState } from 'store/wallet';
 import { formatCurrency, zeroBN } from 'utils/formatters/number';
-import { MarketKeyByAsset } from 'utils/futures';
 
 import FuturesMarketsTable from '../FuturesMarketsTable';
 import FuturesPositionsTable from '../FuturesPositionsTable';
@@ -38,12 +36,9 @@ const Overview: FC = () => {
 
 	const { useExchangeRatesQuery, useSynthsBalancesQuery } = useSynthetixQueries();
 
-	const futuresMarkets = useRecoilValue(futuresMarketsState);
-
 	useQueryCrossMarginAccount();
 
-	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
-	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
+	const portfolioValueQuery = useGetCurrentPortfolioValue();
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 
 	const futuresPositionQuery = useGetFuturesPositionForAccount();

--- a/sections/dashboard/PortfolioChart/PortfolioChart.tsx
+++ b/sections/dashboard/PortfolioChart/PortfolioChart.tsx
@@ -7,16 +7,11 @@ import Currency from 'components/Currency';
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
 import { Synths } from 'constants/currency';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
-import { futuresMarketsState } from 'store/futures';
 import { walletAddressState } from 'store/wallet';
 import { zeroBN } from 'utils/formatters/number';
-import { MarketKeyByAsset } from 'utils/futures';
 
 const PortfolioChart: FC = () => {
-	const futuresMarkets = useRecoilValue(futuresMarketsState);
-
-	const markets = futuresMarkets.map(({ asset }) => MarketKeyByAsset[asset]);
-	const portfolioValueQuery = useGetCurrentPortfolioValue(markets);
+	const portfolioValueQuery = useGetCurrentPortfolioValue();
 	const portfolioValue = portfolioValueQuery?.data ?? null;
 
 	const walletAddress = useRecoilValue(walletAddressState);

--- a/sections/shared/Layout/HomeLayout/HomeLayout.tsx
+++ b/sections/shared/Layout/HomeLayout/HomeLayout.tsx
@@ -1,7 +1,7 @@
-import { RefetchProvider } from 'contexts/RefetchContext';
 import { FC } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
+import { RefetchProvider } from 'contexts/RefetchContext';
 import { FullScreenContainer } from 'styles/common';
 
 import Footer from './Footer';


### PR DESCRIPTION
A bug was introduced in the cross-margin PR which is returning 0 for all account portfolio values. This PR fixes the hook to pull the market keys from recoil, and removed a dependency on cross-margin.

## Description
* Get market keys from recoil for portfolio hook
* Remove cross margin account from `enabled` values, preventing the hook to run
