### PR TITLE
Removed the equities from metadata 

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
     "name": "Kwenta",
     "iconPath": "./images/favicon.svg",
-    "description": "Gain exposure to cryptocurrencies, forex, equities, indices, and commodities on Ethereum with zero slippage."
+    "description": "Gain exposure to cryptocurrencies, forex, indices, and commodities on Ethereum with zero slippage."
 }

--- a/sections/shared/modals/SelectCurrencyModal/SelectCurrencyModal.tsx
+++ b/sections/shared/modals/SelectCurrencyModal/SelectCurrencyModal.tsx
@@ -18,18 +18,14 @@ import useOneInchTokenList from 'queries/tokenLists/useOneInchTokenList';
 import useTokensBalancesQuery from 'queries/walletBalances/useTokensBalancesQuery';
 import { networkState, walletAddressState } from 'store/wallet';
 import { FlexDivCentered } from 'styles/common';
+import media from 'styles/media';
 
 import { RowsHeader, CenteredModal } from '../common';
 import CurrencyRow from './CurrencyRow';
 
 const PAGE_LENGTH = 50;
 
-export const CATEGORY_FILTERS = [
-	CATEGORY_MAP.crypto,
-	CATEGORY_MAP.forex,
-	CATEGORY_MAP.equities,
-	CATEGORY_MAP.commodity,
-];
+export const CATEGORY_FILTERS = [CATEGORY_MAP.crypto, CATEGORY_MAP.forex, CATEGORY_MAP.commodity];
 
 type SelectCurrencyModalProps = {
 	synthsOverride?: Array<CurrencyKey>;
@@ -323,7 +319,11 @@ const AssetSearchInput = styled(SearchInput)`
 const CategoryFilters = styled.div`
 	display: grid;
 	grid-auto-flow: column;
-	justify-content: space-between;
+	${media.lessThan('sm')`
+		justify-content: space-between;
+	`}
+	justify-content: flex-start;
+	column-gap: 10px;
 	padding: 0 16px;
 	margin-bottom: 18px;
 `;

--- a/translations/en.json
+++ b/translations/en.json
@@ -3,7 +3,7 @@
 		"en": "English"
 	},
 	"meta": {
-		"description": "Gain exposure to cryptocurrencies, forex, equities, indices, and commodities on Ethereum with zero slippage",
+		"description": "Gain exposure to cryptocurrencies, forex, indices, and commodities on Ethereum with zero slippage",
 		"og": {
 			"title": "Kwenta",
 			"site-name": "Kwenta"
@@ -974,8 +974,7 @@
 		"currency-category": {
 			"crypto": "crypto",
 			"forex": "forex",
-			"commodity": "commodities",
-			"equities": "equities"
+			"commodity": "commodities"
 		},
 		"contract": "contract",
 		"chart-periods": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Remove the `equities` from metadata
2. Remove the category `equities` in when the user select the currency category

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Compliance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/184421007-b4135a9e-8d44-4e57-a7c7-40349c06d563.png)
