### PR TITLE
Add the default modal back

### DIFF
--- a/components/BaseModal/BaseModal.tsx
+++ b/components/BaseModal/BaseModal.tsx
@@ -31,7 +31,7 @@ export const BaseModal: FC<BaseModalProps> = ({
 }) => (
 	<StyledDialogOverlay onDismiss={onDismiss} isOpen={isOpen} {...rest}>
 		<StyledDialogContent aria-label="modal">
-			<Rnd {...rndProps}>
+			{rndProps.disableDragging ? (
 				<StyledCard className="card">
 					<StyledCardHeader lowercase={lowercase} noBorder className="card-header">
 						{title}
@@ -43,7 +43,21 @@ export const BaseModal: FC<BaseModalProps> = ({
 					</StyledCardHeader>
 					<StyledCardBody className="card-body">{children}</StyledCardBody>
 				</StyledCard>
-			</Rnd>
+			) : (
+				<Rnd {...rndProps}>
+					<StyledCard className="card">
+						<StyledCardHeader lowercase={lowercase} noBorder className="card-header">
+							{title}
+							{showCross && (
+								<DismissButton onClick={onDismiss}>
+									<CrossIcon />
+								</DismissButton>
+							)}
+						</StyledCardHeader>
+						<StyledCardBody className="card-body">{children}</StyledCardBody>
+					</StyledCard>
+				</Rnd>
+			)}
 		</StyledDialogContent>
 	</StyledDialogOverlay>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The style of `Select Currency Modal` has been affected by introducing `react-rnd` package.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Better UI

## How Has This Been Tested?
1. Open the exchange page and click on the currency icon
2. The `Select Currency Modal` is back to its style

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/184971924-24028e7a-3faf-4ed9-b3b2-74831f39a828.png)
