### PR TITLE
Hotfix: Market filter

### DIFF
--- a/queries/futures/useGetFuturesMarkets.ts
+++ b/queries/futures/useGetFuturesMarkets.ts
@@ -45,7 +45,12 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 				FuturesMarketData.globals(),
 			]);
 
-			const assetKeys = markets.map((m: any) => {
+			const enabledMarkets = markets.filter((m: any) => {
+				const asset = utils.parseBytes32String(m.asset) as FuturesMarketAsset;
+				return !!MarketKeyByAsset[asset];
+			});
+
+			const assetKeys = enabledMarkets.map((m: any) => {
 				const asset = utils.parseBytes32String(m.asset) as FuturesMarketAsset;
 				return utils.formatBytes32String(MarketKeyByAsset[asset]);
 			});
@@ -66,7 +71,7 @@ const useGetFuturesMarkets = (options?: UseQueryOptions<FuturesMarket[]>) => {
 				systemStatusPromise,
 			]);
 
-			const futuresMarkets = markets.map(
+			const futuresMarkets = enabledMarkets.map(
 				(
 					{
 						market,


### PR DESCRIPTION
Fix the `useGetFuturesMarkets` hook to filter markets not present in the config