### PR TITLE
Added two redirects to keep the previous path valid

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -80,5 +80,19 @@ module.exports = withPlugins([
 			styledComponents: true,
 		},
 		experimental: { images: { unoptimized: true } },
+		async redirects() {
+			return [
+				{
+					source: '/dashboard/overview',
+					destination: '/dashboard',
+					permanent: true,
+				},
+				{
+					source: '/market/sETH/',
+					destination: '/market/?asset=ETH',
+					permanent: true,
+				},
+			];
+		},
 	},
 ]);

--- a/next.config.js
+++ b/next.config.js
@@ -88,8 +88,13 @@ module.exports = withPlugins([
 					permanent: true,
 				},
 				{
-					source: '/market/sETH/',
-					destination: '/market/?asset=ETH',
+					source: '/market/:key',
+					destination: '/market/?asset=:key',
+					permanent: true,
+				},
+				{
+					source: '/exchange/:base-:quote',
+					destination: '/exchange/?quote=:quote&base=:base',
 					permanent: true,
 				},
 			];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redirect the following old paths to the valid url:
- `https://kwenta.io/market/sETH/` => `https://kwenta.io/market/?assets=sETH`
- `https://kwenta.io/dashboard/overview` => `https://kwenta.io/dashboard`
- `https://kwenta.io/exchange/sUSD-sETH` => `https://kwenta.io/exchange/?quote=sETH&base=sUSD`

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Help returning user access the dapp via saved tabs and bookmarks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
