### PR TITLE
Bug/exchange rates

### DIFF
--- a/constants/currency.ts
+++ b/constants/currency.ts
@@ -77,7 +77,7 @@ export const COMMODITY_SYNTHS = new Set<CurrencyKey | 'XAU' | 'XAG' | 'WTI'>(['X
 export const sUSD_EXCHANGE_RATE = new Wei(1);
 export const SYNTH_DECIMALS = 18;
 
-export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+export const ETH_ADDRESS = '0x4200000000000000000000000000000000000006';
 
 export const ATOMIC_EXCHANGES_L1 = [
 	'sBTC',

--- a/hooks/useExchange.ts
+++ b/hooks/useExchange.ts
@@ -309,7 +309,7 @@ const useExchange = ({
 	// TODO: Fix coingecko prices (optimism issue maybe?)
 	const quotePriceRate = useMemo(
 		() =>
-			txProvider !== 'synthetix' && !isQuoteCurrencyETH && !quoteCurrency
+			txProvider !== 'synthetix' && !quoteCurrency
 				? coinGeckoPrices != null &&
 				  quoteCurrencyTokenAddress != null &&
 				  selectPriceCurrencyRate != null &&
@@ -324,7 +324,6 @@ const useExchange = ({
 				  ),
 		[
 			txProvider,
-			isQuoteCurrencyETH,
 			quoteCurrency,
 			coinGeckoPrices,
 			quoteCurrencyTokenAddress,
@@ -336,7 +335,7 @@ const useExchange = ({
 	);
 
 	const basePriceRate = useMemo(() => {
-		return txProvider !== 'synthetix' && !isBaseCurrencyETH && !baseCurrency
+		return txProvider !== 'synthetix' && !baseCurrency
 			? coinGeckoPrices != null &&
 			  baseCurrencyTokenAddress != null &&
 			  selectPriceCurrencyRate != null &&
@@ -352,7 +351,6 @@ const useExchange = ({
 			  );
 	}, [
 		txProvider,
-		isBaseCurrencyETH,
 		baseCurrency,
 		coinGeckoPrices,
 		baseCurrencyTokenAddress,

--- a/hooks/useExchange.ts
+++ b/hooks/useExchange.ts
@@ -1112,7 +1112,7 @@ const useExchange = ({
 	const onQuoteBalanceClick = useCallback(async () => {
 		if (quoteCurrencyBalance != null) {
 			if ((quoteCurrencyKey as string) === 'ETH') {
-				const ETH_TX_BUFFER = 0.1;
+				const ETH_TX_BUFFER = 0.006;
 				const balanceWithBuffer = quoteCurrencyBalance.sub(wei(ETH_TX_BUFFER));
 				setQuoteCurrencyAmount(
 					balanceWithBuffer.lt(0)

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -28,7 +28,7 @@ const Exchange: ExchangeComponent = () => {
 		<ExchangeContext.Provider value={exchangeData}>
 			<Head>
 				<title>
-					{baseCurrencyKey != null && quoteCurrencyKey != null
+					{!!baseCurrencyKey && !!quoteCurrencyKey && inverseRate.gt(0)
 						? t('exchange.page-title-currency-pair', {
 								baseCurrencyKey,
 								quoteCurrencyKey,

--- a/queries/rates/useExchangeRatesQuery.ts
+++ b/queries/rates/useExchangeRatesQuery.ts
@@ -47,7 +47,12 @@ const useExchangeRatesQuery = (options?: UseQueryOptions<Rates>) => {
 				const marketAsset = MarketAssetByKey[currencyKey as FuturesMarketKey];
 
 				const rate = Number(ethers.utils.formatEther(rates[idx]));
-				exchangeRates[marketAsset ?? currencyKey] = wei(rate);
+
+				// add rates for each synth
+				exchangeRates[currencyKey] = wei(rate);
+
+				// if a futures market exists, add the market asset rate
+				if (marketAsset) exchangeRates[marketAsset] = wei(rate);
 			});
 
 			setRates(exchangeRates);

--- a/translations/en.json
+++ b/translations/en.json
@@ -286,7 +286,7 @@
 			"from": "from",
 			"into": "into"
 		},
-		"synth-exchange": "Synth Exchange",
+		"synth-exchange": "Spot Exchange",
 		"currency-card": {
 			"synth-name": "-",
 			"amount-placeholder": "0.0000",


### PR DESCRIPTION
Fix exchange rates on swap for synths that have futures markets (sEUR)

## Description
- change the `rates` object in state to include synth and asset names (`sEUR` and `EUR`)
- Update the ETH address for swap pricing to the WETH contract on Optimism
