### PR TITLE
Fix the snx swap issue

### DIFF
--- a/hooks/useExchange.ts
+++ b/hooks/useExchange.ts
@@ -285,7 +285,7 @@ const useExchange = ({
 			if (currencyKey != null) {
 				if (isETH) {
 					return ETHBalance;
-				} else if (synthTokensMap[currencyKey]) {
+				} else if (synthsMap[currencyKey]) {
 					return synthsWalletBalance != null
 						? (get(synthsWalletBalance, ['balancesMap', currencyKey, 'balance'], zeroBN) as Wei)
 						: null;
@@ -295,7 +295,7 @@ const useExchange = ({
 			}
 			return null;
 		},
-		[ETHBalance, synthsWalletBalance, tokenBalances, synthTokensMap]
+		[synthsMap, ETHBalance, synthsWalletBalance, tokenBalances]
 	);
 
 	const quoteCurrencyBalance = useMemo(() => {

--- a/hooks/useExchange.ts
+++ b/hooks/useExchange.ts
@@ -151,10 +151,10 @@ const useExchange = ({
 
 	const txProvider: TxProvider | null = useMemo(() => {
 		if (!baseCurrencyKey || !quoteCurrencyKey) return null;
-		if (synthTokensMap[baseCurrencyKey] && synthTokensMap[quoteCurrencyKey]) return 'synthetix';
+		if (synthsMap[baseCurrencyKey] && synthsMap[quoteCurrencyKey]) return 'synthetix';
 		if (oneInchTokensMap?.[baseCurrencyKey] && oneInchTokensMap?.[quoteCurrencyKey]) return '1inch';
 		return 'synthswap';
-	}, [baseCurrencyKey, quoteCurrencyKey, synthTokensMap, oneInchTokensMap]);
+	}, [synthsMap, baseCurrencyKey, quoteCurrencyKey, oneInchTokensMap]);
 
 	// TODO: these queries break when `txProvider` is not `synthetix` and should not be called.
 	// however, condition would break rule of hooks here

--- a/sections/exchange/MobileSwap/SwapButton.tsx
+++ b/sections/exchange/MobileSwap/SwapButton.tsx
@@ -31,7 +31,7 @@ const SwapButton: React.FC = () => {
 		>
 			{!!submissionDisabledReason
 				? submissionDisabledReason
-				: !isApproved
+				: needsApproval && !isApproved
 				? t('exchange.summary-info.button.approve')
 				: t('exchange.summary-info.button.submit-order')}
 		</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Remove the SNX token in synthetix exchange (use `1inch` instead)
2. Fix the button text on mobile swap
3. Fix the snx balance 

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
User can't execute the swap with SNX token because of the wrong provider (error: `gas required exceeds allowance (15000000)`).

## How Has This Been Tested?
1. Open exchange page on mobile and execute the swap between sETH and SNX
2. Open exchange page on desktop and execute the swap between sETH and SNX

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/185648531-23424217-d16c-4493-8156-c3bf0158a811.png)
