### PR TITLE
Add Git commit hash to UI

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import CaretLeftXLIcon from 'assets/svg/app/caret-left-xl.svg';
 import CaretRightXLICon from 'assets/svg/app/caret-right-xl.svg';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 import { FlexDivRowCentered } from 'styles/common';
 import media from 'styles/media';
 
@@ -20,6 +21,7 @@ const NotFoundPage = () => {
 				<Content>
 					<Title>{t('not-found.title')}</Title>
 					<Subtitle>{t('not-found.subtitle')}</Subtitle>
+					<GitHashID />
 				</Content>
 				<CaretRightXLICon />
 			</Container>

--- a/pages/dashboard/history.tsx
+++ b/pages/dashboard/history.tsx
@@ -16,7 +16,6 @@ const HistoryPage: HistoryPageProps = () => {
 				<title>{t('dashboard-history.page-title')}</title>
 			</Head>
 			<History />
-			<br />
 			<GitHashID />
 		</>
 	);

--- a/pages/dashboard/history.tsx
+++ b/pages/dashboard/history.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import DashboardLayout from 'sections/dashboard/DashboardLayout';
 import History from 'sections/dashboard/History';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 
 type HistoryPageProps = React.FC & { getLayout: (page: HTMLElement) => JSX.Element };
 
@@ -15,6 +16,8 @@ const HistoryPage: HistoryPageProps = () => {
 				<title>{t('dashboard-history.page-title')}</title>
 			</Head>
 			<History />
+			<br />
+			<GitHashID />
 		</>
 	);
 };

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -16,7 +16,6 @@ const Dashboard: DashboardComponent = () => {
 				<title>{t('dashboard.page-title')}</title>
 			</Head>
 			<Overview />
-			<br />
 			<GitHashID />
 		</>
 	);

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import DashboardLayout from 'sections/dashboard/DashboardLayout';
 import Overview from 'sections/dashboard/Overview';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 
 type DashboardComponent = React.FC & { getLayout: (page: HTMLElement) => JSX.Element };
 
@@ -15,6 +16,8 @@ const Dashboard: DashboardComponent = () => {
 				<title>{t('dashboard.page-title')}</title>
 			</Head>
 			<Overview />
+			<br />
+			<GitHashID />
 		</>
 	);
 };

--- a/pages/dashboard/markets.tsx
+++ b/pages/dashboard/markets.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import DashboardLayout from 'sections/dashboard/DashboardLayout';
 import Markets from 'sections/dashboard/Markets';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 
 type MarketsProps = React.FC & { getLayout: (page: HTMLElement) => JSX.Element };
 
@@ -14,8 +15,9 @@ const MarketsPage: MarketsProps = () => {
 			<Head>
 				<title>{t('dashboard-markets.page-title')}</title>
 			</Head>
-
 			<Markets />
+			<br />
+			<GitHashID />
 		</>
 	);
 };

--- a/pages/dashboard/markets.tsx
+++ b/pages/dashboard/markets.tsx
@@ -16,7 +16,6 @@ const MarketsPage: MarketsProps = () => {
 				<title>{t('dashboard-markets.page-title')}</title>
 			</Head>
 			<Markets />
-			<br />
 			<GitHashID />
 		</>
 	);

--- a/pages/earn.tsx
+++ b/pages/earn.tsx
@@ -7,6 +7,7 @@ import Text from 'components/Text';
 import PoolGrid from 'sections/earn/Grids/PoolGrid';
 import StakeGrid from 'sections/earn/Grids/StakeGrid';
 import Rewards from 'sections/earn/Rewards/Rewards';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 import { PageContent, FullHeightContainer } from 'styles/common';
 
 const Earn: React.FC = () => {
@@ -28,6 +29,7 @@ const Earn: React.FC = () => {
 							<PoolGrid />
 						</GridsContainer>
 						<Rewards />
+						<GitHashID />
 					</MainContainer>
 				</FullHeightContainer>
 			</PageContent>

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -45,15 +45,12 @@ const Exchange: ExchangeComponent = () => {
 					<StyledFullHeightContainer>
 						<MainContent>
 							<BasicSwap />
-							<br />
 							<GitHashID />
 						</MainContent>
 					</StyledFullHeightContainer>
 				</DesktopOnlyView>
 				<MobileOrTabletView>
 					<MobileSwap />
-					<br />
-					<br />
 					<GitHashID />
 				</MobileOrTabletView>
 			</PageContent>

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -9,6 +9,7 @@ import useExchange from 'hooks/useExchange';
 import BasicSwap from 'sections/exchange/BasicSwap';
 import { MobileSwap } from 'sections/exchange/MobileSwap';
 import AppLayout from 'sections/shared/Layout/AppLayout';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 import { PageContent, FullHeightContainer, MainContent } from 'styles/common';
 import { formatCurrency } from 'utils/formatters/number';
 
@@ -44,11 +45,15 @@ const Exchange: ExchangeComponent = () => {
 					<StyledFullHeightContainer>
 						<MainContent>
 							<BasicSwap />
+							<br />
+							<GitHashID />
 						</MainContent>
 					</StyledFullHeightContainer>
 				</DesktopOnlyView>
 				<MobileOrTabletView>
 					<MobileSwap />
+					<br />
+					<GitHashID />
 				</MobileOrTabletView>
 			</PageContent>
 		</ExchangeContext.Provider>

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -53,6 +53,7 @@ const Exchange: ExchangeComponent = () => {
 				<MobileOrTabletView>
 					<MobileSwap />
 					<br />
+					<br />
 					<GitHashID />
 				</MobileOrTabletView>
 			</PageContent>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import Features from 'sections/homepage/Features';
 import Hero from 'sections/homepage/Hero';
 import ShortList from 'sections/homepage/ShortList';
 import TradeNow from 'sections/homepage/TradeNow';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 import HomeLayout from 'sections/shared/Layout/HomeLayout';
 import media from 'styles/media';
 
@@ -37,6 +38,7 @@ const HomePage: HomePageComponent = () => {
 					<Earning />
 					<Features />
 					<TradeNow />
+					<GitHashID />
 				</Container>
 			</HomeLayout>
 		</>

--- a/pages/leaderboard/index.tsx
+++ b/pages/leaderboard/index.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
 import Leaderboard from 'sections/leaderboard/Leaderboard';
 import AppLayout from 'sections/shared/Layout/AppLayout';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 import { PageContent, MainContent, FullHeightContainer } from 'styles/common';
 
 type LeaderComponent = FC & { getLayout: (page: HTMLElement) => JSX.Element };
@@ -23,12 +24,14 @@ const Leader: LeaderComponent = () => {
 					<FullHeightContainer>
 						<MainContent>
 							<Leaderboard />
+							<GitHashID />
 						</MainContent>
 					</FullHeightContainer>
 				</MobileHiddenView>
 				<MobileOnlyView>
 					<MobileMainContent>
 						<Leaderboard mobile />
+						<GitHashID />
 					</MobileMainContent>
 				</MobileOnlyView>
 			</PageContent>

--- a/pages/market.tsx
+++ b/pages/market.tsx
@@ -74,7 +74,7 @@ Market.getLayout = (page) => <AppLayout>{page}</AppLayout>;
 export default Market;
 
 const StyledMainContent = styled(MainContent)`
-	margin-bottom: 0px;
+	margin: unset;
 	max-width: unset;
 `;
 

--- a/pages/market.tsx
+++ b/pages/market.tsx
@@ -13,6 +13,7 @@ import MarketInfo from 'sections/futures/MarketInfo';
 import MobileTrade from 'sections/futures/MobileTrade/MobileTrade';
 import Trade from 'sections/futures/Trade';
 import AppLayout from 'sections/shared/Layout/AppLayout';
+import GitHashID from 'sections/shared/Layout/AppLayout/GitHashID';
 import { currentMarketState } from 'store/futures';
 import {
 	PageContent,
@@ -56,11 +57,13 @@ const Market: MarketComponent = () => {
 						<StyledRightSideContent>
 							<Trade />
 						</StyledRightSideContent>
+						<GitHashID />
 					</StyledFullHeightContainer>
 				</PageContent>
 			</DesktopOnlyView>
 			<MobileOrTabletView>
 				<MobileTrade />
+				<GitHashID />
 			</MobileOrTabletView>
 		</FuturesContext.Provider>
 	);

--- a/pages/market.tsx
+++ b/pages/market.tsx
@@ -57,8 +57,8 @@ const Market: MarketComponent = () => {
 						<StyledRightSideContent>
 							<Trade />
 						</StyledRightSideContent>
-						<GitHashID />
 					</StyledFullHeightContainer>
+					<GitHashID />
 				</PageContent>
 			</DesktopOnlyView>
 			<MobileOrTabletView>
@@ -74,7 +74,7 @@ Market.getLayout = (page) => <AppLayout>{page}</AppLayout>;
 export default Market;
 
 const StyledMainContent = styled(MainContent)`
-	margin: unset;
+	margin-bottom: 0px;
 	max-width: unset;
 `;
 

--- a/sections/futures/LeftSidebar/LeftSidebar.tsx
+++ b/sections/futures/LeftSidebar/LeftSidebar.tsx
@@ -15,6 +15,5 @@ const TradingHistory: React.FC = () => {
 export default TradingHistory;
 
 const Panel = styled.div`
-	height: 100%;
-	padding-bottom: 48px;
+	padding-bottom: 20px;
 `;

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -45,7 +45,7 @@ const MarketInfo: FC = () => {
 };
 
 const Container = styled.div`
-	padding-bottom: 48px;
+	padding-bottom: 20px;
 `;
 
 export default MarketInfo;

--- a/sections/shared/Layout/AppLayout/GitHashID/GitHashID.tsx
+++ b/sections/shared/Layout/AppLayout/GitHashID/GitHashID.tsx
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 
 const GitHashID: FC = () => {
 	const gitID = process.env.GIT_HASH_ID!.toString();
-	return <Container>{gitID}</Container>;
+	return (
+		<div>
+			<br />
+			<Container>{gitID}</Container>
+		</div>
+	);
 };
 
 const Container = styled.div`
@@ -12,9 +17,10 @@ const Container = styled.div`
 	color: #2b3035;
 
 	position: absolute;
-	bottom: 10px;
+	bottom: 0px;
 	left: 50%;
 	transform: translate(-50%, -50%);
+	z-index: 1000;
 `;
 
 export default GitHashID;

--- a/sections/shared/Layout/AppLayout/GitHashID/GitHashID.tsx
+++ b/sections/shared/Layout/AppLayout/GitHashID/GitHashID.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+import styled from 'styled-components';
+
+const GitHashID: FC = () => {
+	const gitID = process.env.GIT_HASH_ID!.toString();
+	return <Container>{gitID}</Container>;
+};
+
+const Container = styled.div`
+	font-family: ${(props) => props.theme.fonts.mono};
+	font-size: 10px;
+	color: #2b3035;
+
+	position: absolute;
+	bottom: 10px;
+	left: 50%;
+	transform: translate(-50%, -50%);
+`;
+
+export default GitHashID;

--- a/sections/shared/Layout/AppLayout/GitHashID/index.ts
+++ b/sections/shared/Layout/AppLayout/GitHashID/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GitHashID';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We should add build IDs to the bottom of the Kwenta page to help us as the community narrow down help-desk issues. This should be best tied to a Kwenta commit hash.

- [x] New GitHashID component
- [x] Add the GitHashID component to the bottom of all pages

## Related issue
#1311 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1467" alt="Screenshot 2022-08-20 at 09 19 59" src="https://user-images.githubusercontent.com/28714795/185735253-9e97e56d-52bd-4925-aafe-30561451f963.png">
<img width="1493" alt="Screenshot 2022-08-20 at 09 49 44" src="https://user-images.githubusercontent.com/28714795/185735256-6be3e8fe-217e-4783-9f1a-9a45ad376b08.png">
See the very subtle commit hash at the very bottom of the page (5411121f).
