### PR TITLE
Feat/order history

### DIFF
--- a/components/Checkbox/Checkbox.tsx
+++ b/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const Checkbox = ({
+	id,
+	label,
+	checked,
+	onChange,
+	...props
+}: {
+	id: string;
+	label: string;
+	checked: boolean;
+	onChange: () => void;
+}) => (
+	<CheckboxContainer>
+		<input type="checkbox" id={id} name={id} checked={checked} onChange={onChange} {...props} />
+		<label htmlFor={id}>{label}</label>
+	</CheckboxContainer>
+);
+
+const CheckboxContainer = styled.div`
+	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	display: flex;
+	align-items: center;
+`;

--- a/components/Checkbox/index.tsx
+++ b/components/Checkbox/index.tsx
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox';

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -292,6 +292,12 @@ export const QUERY_KEYS = {
 			networkId,
 			market,
 		],
+		Orders: (networkId: NetworkId, walletAddress: string | null) => [
+			'futures',
+			'openOrders',
+			networkId,
+			walletAddress,
+		],
 		OpenOrders: (networkId: NetworkId, walletAddress: string | null) => [
 			'futures',
 			'openOrders',

--- a/queries/futures/useGetFuturesOrders.ts
+++ b/queries/futures/useGetFuturesOrders.ts
@@ -30,7 +30,11 @@ const useGetFuturesOpenOrders = (options?: UseQueryOptions<any>) => {
 					futuresEndpoint,
 					gql`
 						query Orders($account: String!, $market: String!) {
-							futuresOrders(where: { account: $account, market: $market }) {
+							futuresOrders(
+								where: { account: $account, market: $market }
+								orderBy: timestamp
+								orderDirection: desc
+							) {
 								id
 								account
 								size

--- a/queries/futures/useGetFuturesOrders.ts
+++ b/queries/futures/useGetFuturesOrders.ts
@@ -1,0 +1,71 @@
+import Wei from '@synthetixio/wei';
+import { utils as ethersUtils } from 'ethers';
+import request, { gql } from 'graphql-request';
+import { useQuery, UseQueryOptions } from 'react-query';
+import { useRecoilValue } from 'recoil';
+
+import { ETH_UNIT } from 'constants/network';
+import QUERY_KEYS from 'constants/queryKeys';
+import { appReadyState } from 'store/app';
+import { futuresAccountState, marketInfoState } from 'store/futures';
+import { isL2State, networkState } from 'store/wallet';
+import logError from 'utils/logError';
+
+import { getFuturesEndpoint } from './utils';
+
+const useGetFuturesOpenOrders = (options?: UseQueryOptions<any>) => {
+	const { selectedFuturesAddress } = useRecoilValue(futuresAccountState);
+	const isAppReady = useRecoilValue(appReadyState);
+	const isL2 = useRecoilValue(isL2State);
+	const network = useRecoilValue(networkState);
+	const futuresEndpoint = getFuturesEndpoint(network);
+	const marketInfo = useRecoilValue(marketInfoState);
+
+	return useQuery<any>(
+		QUERY_KEYS.Futures.Orders(network.id, selectedFuturesAddress),
+		async () => {
+			try {
+				const marketAddress = marketInfo?.market;
+				const response = await request(
+					futuresEndpoint,
+					gql`
+						query Orders($account: String!, $market: String!) {
+							futuresOrders(where: { account: $account, market: $market }) {
+								id
+								account
+								size
+								market
+								asset
+								targetRoundId
+								timestamp
+								orderType
+								status
+							}
+						}
+					`,
+					{ account: selectedFuturesAddress, market: marketAddress }
+				);
+
+				const orders = response
+					? response.futuresOrders.map((o: any) => ({
+							...o,
+							asset: ethersUtils.parseBytes32String(o.asset),
+							targetRoundId: new Wei(o.targetRoundId, 0),
+							size: new Wei(o.size).div(ETH_UNIT),
+					  }))
+					: [];
+				return orders;
+			} catch (e) {
+				logError(e);
+				return [];
+			}
+		},
+		{
+			enabled: isAppReady && isL2 && !!marketInfo?.market && !!selectedFuturesAddress,
+			refetchInterval: 5000,
+			...options,
+		}
+	);
+};
+
+export default useGetFuturesOpenOrders;

--- a/sections/futures/Orders/Orders.tsx
+++ b/sections/futures/Orders/Orders.tsx
@@ -1,0 +1,236 @@
+import { wei } from '@synthetixio/wei';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CellProps } from 'react-table';
+import styled, { css } from 'styled-components';
+
+import LinkIcon from 'assets/svg/app/link-blue.svg';
+import Card from 'components/Card';
+import Table, { TableNoResults } from 'components/Table';
+import { Synths } from 'constants/currency';
+import { ETH_UNIT } from 'constants/network';
+import BlockExplorer from 'containers/BlockExplorer';
+import { FuturesTrade } from 'queries/futures/types';
+import { ExternalLink, GridDivCenteredRow } from 'styles/common';
+import { formatCryptoCurrency, formatCurrency } from 'utils/formatters/number';
+
+import { PositionSide, TradeStatus } from '../types';
+
+type TradesProps = {
+	history: FuturesTrade[] | [];
+	isLoading: boolean;
+	isLoaded: boolean;
+	marketAsset: string;
+};
+
+const Orders: React.FC<TradesProps> = ({ history, isLoading, isLoaded, marketAsset }) => {
+	const { t } = useTranslation();
+	const { blockExplorerInstance } = BlockExplorer.useContainer();
+
+	const historyData = React.useMemo(() => {
+		return history.map((trade: FuturesTrade) => {
+			return {
+				...trade,
+				value: Number(trade?.price?.div(ETH_UNIT)),
+				amount: Number(trade?.size.div(ETH_UNIT).abs()),
+				time: Number(trade?.timestamp.mul(1000)),
+				pnl: trade?.pnl.div(ETH_UNIT),
+				feesPaid: trade?.feesPaid.div(ETH_UNIT),
+				id: trade?.txnHash,
+				asset: marketAsset,
+				type: trade?.orderType === 'NextPrice' ? 'Next Price' : trade?.orderType,
+				status: trade?.positionClosed ? TradeStatus.CLOSED : TradeStatus.OPEN,
+			};
+		});
+	}, [history, marketAsset]);
+
+	const columnsDeps = useMemo(() => [historyData], [historyData]);
+
+	return (
+		<Card>
+			<StyledTable
+				palette="primary"
+				columns={[
+					{
+						Header: (
+							<StyledTableHeader>{t('futures.market.user.trades.table.date')}</StyledTableHeader>
+						),
+						accessor: 'time',
+						Cell: (cellProps: CellProps<FuturesTrade>) => (
+							<GridDivCenteredRow>
+								{/* <TimeDisplay cellPropsValue={cellProps.value} /> */}
+							</GridDivCenteredRow>
+						),
+						width: 90,
+						sortable: true,
+					},
+					{
+						Header: (
+							<StyledTableHeader>{t('futures.market.user.trades.table.side')}</StyledTableHeader>
+						),
+						accessor: 'side',
+						sortType: 'basic',
+						Cell: (cellProps: CellProps<FuturesTrade>) => (
+							<>
+								<StyledPositionSide side={cellProps.value}>{cellProps.value}</StyledPositionSide>
+							</>
+						),
+						width: 60,
+						sortable: true,
+					},
+					{
+						Header: (
+							<StyledTableHeader>{t('futures.market.user.trades.table.price')}</StyledTableHeader>
+						),
+						accessor: 'value',
+						sortType: 'basic',
+						Cell: (cellProps: CellProps<FuturesTrade>) => (
+							<>
+								{formatCurrency(Synths.sUSD, cellProps.value, {
+									sign: '$',
+								})}
+							</>
+						),
+						width: 80,
+						sortable: true,
+					},
+					{
+						Header: (
+							<StyledTableHeader>
+								{t('futures.market.user.trades.table.trade-size')}
+							</StyledTableHeader>
+						),
+						accessor: 'amount',
+						sortType: 'basic',
+						Cell: (cellProps: CellProps<FuturesTrade>) => (
+							<>{formatCryptoCurrency(cellProps.value)}</>
+						),
+						width: 80,
+						sortable: true,
+					},
+					{
+						Header: (
+							<StyledTableHeader>{t('futures.market.user.trades.table.pnl')}</StyledTableHeader>
+						),
+						accessor: 'pnl',
+						sortType: 'basic',
+						Cell: (cellProps: CellProps<FuturesTrade>) =>
+							cellProps.row.original.pnl.eq(wei(0)) ? (
+								<PNL normal>--</PNL>
+							) : (
+								<PNL negative={cellProps.value.lt(wei(0))}>
+									{formatCurrency(Synths.sUSD, cellProps.value, {
+										sign: '$',
+									})}
+								</PNL>
+							),
+						width: 80,
+						sortable: true,
+					},
+					{
+						Header: (
+							<StyledTableHeader>{t('futures.market.user.trades.table.fees')}</StyledTableHeader>
+						),
+						sortType: 'basic',
+						accessor: 'feesPaid',
+						Cell: (cellProps: CellProps<FuturesTrade>) => (
+							<>
+								{cellProps.value.eq(0)
+									? '--'
+									: formatCurrency(Synths.sUSD, cellProps.value, {
+											sign: '$',
+									  })}
+							</>
+						),
+						width: 80,
+						sortable: true,
+					},
+					{
+						Header: (
+							<StyledTableHeader>
+								{t('futures.market.user.trades.table.order-type')}
+							</StyledTableHeader>
+						),
+						accessor: 'type',
+						sortType: 'basic',
+						Cell: (cellProps: CellProps<FuturesTrade>) => <>{cellProps.value}</>,
+						width: 100,
+					},
+					{
+						accessor: 'txnHash',
+						Cell: (cellProps: CellProps<FuturesTrade>) => (
+							<StyledExternalLink href={blockExplorerInstance?.txLink(cellProps.value)}>
+								<StyledLinkIcon />
+							</StyledExternalLink>
+						),
+						width: 25,
+						sortable: false,
+					},
+				]}
+				columnsDeps={columnsDeps}
+				data={historyData}
+				isLoading={isLoading && isLoaded}
+				noResultsMessage={
+					isLoaded && historyData?.length === 0 ? (
+						<TableNoResults>{t('futures.market.user.trades.table.no-results')}</TableNoResults>
+					) : undefined
+				}
+				showPagination
+				pageSize={5}
+			/>
+		</Card>
+	);
+};
+export default Orders;
+
+const StyledTable = styled(Table)``;
+
+const StyledTableHeader = styled.div`
+	font-family: ${(props) => props.theme.fonts.regular};
+	text-transform: capitalize;
+`;
+
+const StyledPositionSide = styled.div<{ side: PositionSide }>`
+	text-transform: uppercase;
+	${(props) =>
+		props.side === PositionSide.LONG &&
+		css`
+			color: ${props.theme.colors.selectedTheme.green};
+		`}
+
+	${(props) =>
+		props.side === PositionSide.SHORT &&
+		css`
+			color: ${props.theme.colors.selectedTheme.red};
+		`}
+`;
+
+const PNL = styled.div<{ negative?: boolean; normal?: boolean }>`
+	color: ${(props) =>
+		props.normal
+			? props.theme.colors.selectedTheme.button.text
+			: props.negative
+			? props.theme.colors.selectedTheme.red
+			: props.theme.colors.selectedTheme.green};
+`;
+
+const StyledExternalLink = styled(ExternalLink)`
+	padding: 10px;
+	&:hover {
+		svg {
+			path {
+				fill: ${(props) => props.theme.colors.selectedTheme.button.text};
+			}
+		}
+	}
+`;
+
+const StyledLinkIcon = styled(LinkIcon)`
+	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	width: 14px;
+	height: 14px;
+
+	path {
+		fill: ${(props) => props.theme.colors.selectedTheme.gray};
+	}
+`;

--- a/sections/futures/Orders/index.ts
+++ b/sections/futures/Orders/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Orders';

--- a/sections/futures/UserInfo/OrderHistory.tsx
+++ b/sections/futures/UserInfo/OrderHistory.tsx
@@ -93,6 +93,8 @@ const OrderHistory: React.FC = () => {
 					wei(marketInfo?.currentRoundId ?? 0).gte(wei(order.targetRoundId).add(2)) &&
 					order.status === 'Pending'
 						? 'Expired'
+						: order.status === 'Pending'
+						? 'Open'
 						: order.status,
 				market: getMarketName(order.asset),
 				marketKey: MarketKeyByAsset[order.asset as FuturesMarketAsset],
@@ -102,12 +104,13 @@ const OrderHistory: React.FC = () => {
 				}),
 				side: wei(order.size).gt(0) ? PositionSide.LONG : PositionSide.SHORT,
 				isFilled: order.status === 'Filled',
+				isCancellable: order.status === 'Pending',
 				isExecutable:
 					order.status === 'Pending' &&
 					(wei(marketInfo?.currentRoundId ?? 0).eq(order.targetRoundId) ||
 						wei(marketInfo?.currentRoundId ?? 0).eq(order.targetRoundId.add(1))),
 			}))
-			.filter((order: any) => !openFilter || order.status === 'Pending');
+			.filter((order: any) => !openFilter || order.status === 'Open' || order.status === 'Expired');
 	}, [orders, marketInfo?.currentRoundId, synthsMap, openFilter]);
 
 	return (
@@ -207,7 +210,7 @@ const OrderHistory: React.FC = () => {
 							Cell: (cellProps: CellProps<any>) => {
 								return (
 									<div style={{ display: 'flex' }}>
-										{cellProps.row.original.isExecutable && (
+										{cellProps.row.original.isCancellable && (
 											<CancelButton
 												onClick={() => {
 													setAction('cancel');

--- a/sections/futures/UserInfo/OrderHistory.tsx
+++ b/sections/futures/UserInfo/OrderHistory.tsx
@@ -1,0 +1,341 @@
+import useSynthetixQueries from '@synthetixio/queries';
+import { wei } from '@synthetixio/wei';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CellProps } from 'react-table';
+import { useRecoilValue } from 'recoil';
+import styled, { css } from 'styled-components';
+
+import Currency from 'components/Currency';
+import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import Table, { TableNoResults } from 'components/Table';
+import PositionType from 'components/Text/PositionType';
+import Connector from 'containers/Connector';
+import TransactionNotifier from 'containers/TransactionNotifier';
+import { useRefetchContext } from 'contexts/RefetchContext';
+import useGetFuturesOrders from 'queries/futures/useGetFuturesOrders';
+import { currentMarketState, futuresAccountState, marketInfoState } from 'store/futures';
+import { gasSpeedState } from 'store/wallet';
+import { formatCurrency } from 'utils/formatters/number';
+import {
+	getDisplayAsset,
+	MarketKeyByAsset,
+	FuturesMarketAsset,
+	getMarketName,
+} from 'utils/futures';
+
+import OrderDrawer from '../MobileTrade/drawers/OrderDrawer';
+import { PositionSide } from '../types';
+
+const OrderHistory: React.FC = () => {
+	const { t } = useTranslation();
+	const { synthsMap } = Connector.useContainer();
+	const { monitorTransaction } = TransactionNotifier.useContainer();
+	const { useSynthetixTxn, useEthGasPriceQuery } = useSynthetixQueries();
+
+	const gasSpeed = useRecoilValue(gasSpeedState);
+	const currencyKey = useRecoilValue(currentMarketState);
+	const marketInfo = useRecoilValue(marketInfoState);
+	const { selectedFuturesAddress } = useRecoilValue(futuresAccountState);
+
+	const { handleRefetch } = useRefetchContext();
+
+	const [action, setAction] = React.useState<'' | 'cancel' | 'execute'>('');
+	const [selectedOrder, setSelectedOrder] = React.useState<any>();
+
+	const ethGasPriceQuery = useEthGasPriceQuery();
+	const orderQuery = useGetFuturesOrders();
+	const orders = useMemo(() => orderQuery?.data ?? [], [orderQuery?.data]);
+
+	const gasPrice = ethGasPriceQuery.data?.[gasSpeed];
+
+	const cancelOrExecuteOrderTxn = useSynthetixTxn(
+		`FuturesMarket${getDisplayAsset(currencyKey)}`,
+		`${action}NextPriceOrder`,
+		[selectedFuturesAddress],
+		gasPrice,
+		{
+			enabled: !!action,
+			onSettled: () => {
+				setAction('');
+			},
+		}
+	);
+
+	React.useEffect(() => {
+		if (!!action) {
+			cancelOrExecuteOrderTxn.mutate();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [action]);
+
+	React.useEffect(() => {
+		if (cancelOrExecuteOrderTxn.hash) {
+			monitorTransaction({
+				txHash: cancelOrExecuteOrderTxn.hash,
+				onTxConfirmed: () => {
+					handleRefetch('new-order');
+				},
+			});
+		}
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [cancelOrExecuteOrderTxn.hash]);
+
+	const data = React.useMemo(() => {
+		return orders.map((order: any) => ({
+			...order,
+			status:
+				wei(marketInfo?.currentRoundId ?? 0).gte(wei(order.targetRoundId).add(2)) &&
+				order.status === 'Pending'
+					? 'Expired'
+					: order.status,
+			market: getMarketName(order.asset),
+			marketKey: MarketKeyByAsset[order.asset as FuturesMarketAsset],
+			orderType: order.orderType === 'NextPrice' ? 'Next-Price' : order.orderType,
+			size: formatCurrency(order.asset, order.size.abs(), {
+				sign: order.asset ? synthsMap[order.asset]?.sign : '',
+			}),
+			side: wei(order.size).gt(0) ? PositionSide.LONG : PositionSide.SHORT,
+			isExecutable:
+				order.status === 'Pending' &&
+				(wei(marketInfo?.currentRoundId ?? 0).eq(order.targetRoundId) ||
+					wei(marketInfo?.currentRoundId ?? 0).eq(order.targetRoundId.add(1))),
+		}));
+	}, [orders, marketInfo?.currentRoundId, synthsMap]);
+
+	return (
+		<>
+			<DesktopOnlyView>
+				<StyledTable
+					data={data}
+					highlightRowsOnHover
+					showPagination
+					pageSize={5}
+					isLoading={orders.isLoading}
+					noResultsMessage={
+						<TableNoResults>{t('futures.market.user.open-orders.table.no-result')}</TableNoResults>
+					}
+					columns={[
+						{
+							Header: (
+								<StyledTableHeader>
+									{t('futures.market.user.open-orders.table.market-type')}
+								</StyledTableHeader>
+							),
+							accessor: 'market',
+							Cell: (cellProps: CellProps<any>) => {
+								return (
+									<MarketContainer>
+										<IconContainer>
+											<StyledCurrencyIcon currencyKey={cellProps.row.original.marketKey} />
+										</IconContainer>
+										<StyledText>{cellProps.row.original.market}</StyledText>
+										<StyledValue>{cellProps.row.original.orderType}</StyledValue>
+									</MarketContainer>
+								);
+							},
+							sortable: true,
+							width: 50,
+						},
+						{
+							Header: (
+								<StyledTableHeader>
+									{t('futures.market.user.open-orders.table.side')}
+								</StyledTableHeader>
+							),
+							accessor: 'side',
+							Cell: (cellProps: CellProps<any>) => {
+								return (
+									<div>
+										<PositionType side={cellProps.row.original.side} />
+									</div>
+								);
+							},
+							sortable: true,
+							width: 50,
+						},
+						{
+							Header: (
+								<StyledTableHeader>
+									{t('futures.market.user.open-orders.table.size')}
+								</StyledTableHeader>
+							),
+							accessor: 'size',
+							Cell: (cellProps: CellProps<any>) => {
+								return <div>{cellProps.row.original.size}</div>;
+							},
+							sortable: true,
+							width: 50,
+						},
+						{
+							Header: (
+								<StyledTableHeader>
+									{t('futures.market.user.open-orders.table.status')}
+								</StyledTableHeader>
+							),
+							accessor: 'status',
+							Cell: (cellProps: CellProps<any>) => {
+								return <div>{cellProps.row.original.status}</div>;
+							},
+							sortable: true,
+							width: 50,
+						},
+						{
+							Header: (
+								<StyledTableHeader>
+									{t('futures.market.user.open-orders.table.actions')}
+								</StyledTableHeader>
+							),
+							accessor: 'actions',
+							Cell: (cellProps: CellProps<any>) => {
+								return (
+									<div style={{ display: 'flex' }}>
+										<CancelButton
+											onClick={() => {
+												setAction('cancel');
+											}}
+										>
+											{t('futures.market.user.open-orders.actions.cancel')}
+										</CancelButton>
+										{cellProps.row.original.isExecutable && (
+											<EditButton
+												onClick={() => {
+													setAction('execute');
+												}}
+											>
+												{t('futures.market.user.open-orders.actions.execute')}
+											</EditButton>
+										)}
+									</div>
+								);
+							},
+							width: 50,
+						},
+					]}
+				/>
+			</DesktopOnlyView>
+			<MobileOrTabletView>
+				<StyledTable
+					data={data}
+					noResultsMessage={
+						<TableNoResults>{t('futures.market.user.open-orders.table.no-result')}</TableNoResults>
+					}
+					onTableRowClick={(row) => setSelectedOrder(row.original)}
+					columns={[
+						{
+							Header: <StyledTableHeader>Side/Type</StyledTableHeader>,
+							accessor: 'side/type',
+							Cell: (cellProps: CellProps<any>) => (
+								<div>
+									<MobilePositionSide $side={cellProps.row.original.side}>
+										{cellProps.row.original.side}
+									</MobilePositionSide>
+									<div>{cellProps.row.original.orderType}</div>
+								</div>
+							),
+							width: 100,
+						},
+						{
+							Header: <StyledTableHeader>Size</StyledTableHeader>,
+							accessor: 'size',
+							Cell: (cellProps: CellProps<any>) => <div>{cellProps.row.original.size}</div>,
+						},
+					]}
+				/>
+
+				<OrderDrawer
+					open={!!selectedOrder}
+					order={selectedOrder}
+					closeDrawer={() => setSelectedOrder(undefined)}
+					setAction={setAction}
+				/>
+			</MobileOrTabletView>
+		</>
+	);
+};
+
+const StyledTable = styled(Table)`
+	margin-bottom: 20px;
+`;
+
+const StyledTableHeader = styled.div`
+	font-family: ${(props) => props.theme.fonts.regular};
+	text-transform: capitalize;
+`;
+
+const StyledCurrencyIcon = styled(Currency.Icon)`
+	width: 30px;
+	height: 30px;
+	margin-right: 8px;
+`;
+
+const IconContainer = styled.div`
+	grid-column: 1;
+	grid-row: 1 / span 2;
+`;
+
+const StyledValue = styled.div`
+	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	font-family: ${(props) => props.theme.fonts.regular};
+	font-size: 12px;
+	grid-column: 2;
+	grid-row: 2;
+`;
+
+const StyledText = styled.div`
+	display: flex;
+	align-items: center;
+	grid-column: 2;
+	grid-row: 1;
+	margin-bottom: -4px;
+`;
+
+const MarketContainer = styled.div`
+	display: grid;
+	grid-template-rows: auto auto;
+	grid-template-columns: auto auto;
+	align-items: center;
+`;
+
+const EditButton = styled.button`
+	border: 1px solid ${(props) => props.theme.colors.selectedTheme.gray};
+	height: 28px;
+	box-sizing: border-box;
+	border-radius: 14px;
+	cursor: pointer;
+	background-color: transparent;
+	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 12px;
+	padding-left: 12px;
+	padding-right: 12px;
+`;
+
+const CancelButton = styled(EditButton)`
+	border: 1px solid ${(props) => props.theme.colors.selectedTheme.red};
+	color: ${(props) => props.theme.colors.selectedTheme.red};
+	margin-right: 8px;
+`;
+
+const MobilePositionSide = styled.div<{ $side: PositionSide }>`
+	text-transform: uppercase;
+	font-size: 13px;
+	font-family: ${(props) => props.theme.fonts.bold};
+	letter-spacing: 1.4px;
+	margin-bottom: 4px;
+
+	${(props) =>
+		props.$side === 'long' &&
+		css`
+			color: ${(props) => props.theme.colors.selectedTheme.green};
+		`};
+
+	${(props) =>
+		props.$side === 'short' &&
+		css`
+			color: ${(props) => props.theme.colors.selectedTheme.red};
+		`};
+`;
+
+export default OrderHistory;

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -30,7 +30,8 @@ import ProfitCalculator from '../ProfitCalculator';
 import ShareModal from '../ShareModal';
 import Trades from '../Trades';
 import Transfers from '../Transfers';
-import OpenOrdersTable from './OpenOrdersTable';
+import OrderHistory from './OrderHistory';
+// import OpenOrdersTable from './OpenOrdersTable';
 
 enum FuturesTab {
 	POSITION = 'position',
@@ -198,7 +199,7 @@ const UserInfo: React.FC = () => {
 				/>
 			</TabPanel>
 			<TabPanel name={FuturesTab.ORDERS} activeTab={activeTab}>
-				<OpenOrdersTable />
+				<OrderHistory />
 			</TabPanel>
 			<TabPanel name={FuturesTab.TRADES} activeTab={activeTab}>
 				<Trades

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -31,7 +31,6 @@ import ShareModal from '../ShareModal';
 import Trades from '../Trades';
 import Transfers from '../Transfers';
 import OrderHistory from './OrderHistory';
-// import OpenOrdersTable from './OpenOrdersTable';
 
 enum FuturesTab {
 	POSITION = 'position',

--- a/translations/en.json
+++ b/translations/en.json
@@ -724,6 +724,7 @@
 						"market-type": "Market/Type",
 						"side": "Side",
 						"size": "Size",
+						"status": "Status",
 						"parameters": "Parameters",
 						"actions": "Actions",
 						"no-result": "You have no open orders"

--- a/translations/en.json
+++ b/translations/en.json
@@ -727,7 +727,8 @@
 						"status": "Status",
 						"parameters": "Parameters",
 						"actions": "Actions",
-						"no-result": "You have no open orders"
+						"no-result": "You have no open orders",
+						"open-filter": "Only show open orders"
 					},
 					"actions": {
 						"cancel": "Cancel",


### PR DESCRIPTION
Changes the current "open orders" table into an "order history" table

## Description
- Updates the hook that requests orders to get all orders (not just pending)
- Adds a general checkbox component
- Implements an "open orders only" checkbox to filter the table

## Motivation and Context
This will give more information on the futures page without crowding it or adding anything new in the default state. It also sets up the frontend for the release of limit orders and stop losses when those order types are available.
