### PR TITLE
Use ethcall for positionDetailsForMarketKey

### DIFF
--- a/lib/abis/FuturesMarket.json
+++ b/lib/abis/FuturesMarket.json
@@ -1,0 +1,1109 @@
+[
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "_resolver",
+				"type": "address"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "_baseAsset",
+				"type": "bytes32"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "_marketKey",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "name",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"internalType": "address",
+				"name": "destination",
+				"type": "address"
+			}
+		],
+		"name": "CacheUpdated",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "funding",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "index",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "timestamp",
+				"type": "uint256"
+			}
+		],
+		"name": "FundingRecomputed",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "baseAsset",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "marketKey",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "fee",
+				"type": "uint256"
+			}
+		],
+		"name": "FuturesTracking",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "marginDelta",
+				"type": "int256"
+			}
+		],
+		"name": "MarginTransferred",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "currentRoundId",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "targetRoundId",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "commitDeposit",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "keeperDeposit",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			}
+		],
+		"name": "NextPriceOrderRemoved",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "targetRoundId",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "commitDeposit",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "keeperDeposit",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			}
+		],
+		"name": "NextPriceOrderSubmitted",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "uint256",
+				"name": "id",
+				"type": "uint256"
+			},
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "liquidator",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "size",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "price",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "fee",
+				"type": "uint256"
+			}
+		],
+		"name": "PositionLiquidated",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "uint256",
+				"name": "id",
+				"type": "uint256"
+			},
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "margin",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "size",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "int256",
+				"name": "tradeSize",
+				"type": "int256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "lastPrice",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "fundingIndex",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "fee",
+				"type": "uint256"
+			}
+		],
+		"name": "PositionModified",
+		"type": "event"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "accessibleMargin",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "marginAccessible",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "accruedFunding",
+		"outputs": [
+			{
+				"internalType": "int256",
+				"name": "funding",
+				"type": "int256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "assetPrice",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "price",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "baseAsset",
+		"outputs": [
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "canLiquidate",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "cancelNextPriceOrder",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "closePosition",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			}
+		],
+		"name": "closePositionWithTracking",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "currentFundingRate",
+		"outputs": [
+			{
+				"internalType": "int256",
+				"name": "",
+				"type": "int256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "executeNextPriceOrder",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "fundingLastRecomputed",
+		"outputs": [
+			{
+				"internalType": "uint32",
+				"name": "",
+				"type": "uint32"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "fundingSequence",
+		"outputs": [
+			{
+				"internalType": "int128",
+				"name": "",
+				"type": "int128"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "fundingSequenceLength",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "isResolverCached",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "liquidatePosition",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "liquidationFee",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "liquidationPrice",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "price",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "marketDebt",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "debt",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "marketKey",
+		"outputs": [
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "marketSize",
+		"outputs": [
+			{
+				"internalType": "uint128",
+				"name": "",
+				"type": "uint128"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "marketSizes",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "long",
+				"type": "uint256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "short",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "marketSkew",
+		"outputs": [
+			{
+				"internalType": "int128",
+				"name": "",
+				"type": "int128"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			}
+		],
+		"name": "modifyPosition",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			}
+		],
+		"name": "modifyPositionWithTracking",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"name": "nextPriceOrders",
+		"outputs": [
+			{
+				"internalType": "int128",
+				"name": "sizeDelta",
+				"type": "int128"
+			},
+			{
+				"internalType": "uint128",
+				"name": "targetRoundId",
+				"type": "uint128"
+			},
+			{
+				"internalType": "uint128",
+				"name": "commitDeposit",
+				"type": "uint128"
+			},
+			{
+				"internalType": "uint128",
+				"name": "keeperDeposit",
+				"type": "uint128"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "notionalValue",
+		"outputs": [
+			{
+				"internalType": "int256",
+				"name": "value",
+				"type": "int256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			}
+		],
+		"name": "orderFee",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "fee",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"name": "positions",
+		"outputs": [
+			{
+				"internalType": "uint64",
+				"name": "id",
+				"type": "uint64"
+			},
+			{
+				"internalType": "uint64",
+				"name": "lastFundingIndex",
+				"type": "uint64"
+			},
+			{
+				"internalType": "uint128",
+				"name": "margin",
+				"type": "uint128"
+			},
+			{
+				"internalType": "uint128",
+				"name": "lastPrice",
+				"type": "uint128"
+			},
+			{
+				"internalType": "int128",
+				"name": "size",
+				"type": "int128"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			},
+			{
+				"internalType": "address",
+				"name": "sender",
+				"type": "address"
+			}
+		],
+		"name": "postTradeDetails",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "margin",
+				"type": "uint256"
+			},
+			{
+				"internalType": "int256",
+				"name": "size",
+				"type": "int256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "price",
+				"type": "uint256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "liqPrice",
+				"type": "uint256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "fee",
+				"type": "uint256"
+			},
+			{
+				"internalType": "enum IFuturesMarketBaseTypes.Status",
+				"name": "status",
+				"type": "uint8"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "profitLoss",
+		"outputs": [
+			{
+				"internalType": "int256",
+				"name": "pnl",
+				"type": "int256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "rebuildCache",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "recomputeFunding",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "lastIndex",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "remainingMargin",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "marginRemaining",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "resolver",
+		"outputs": [
+			{
+				"internalType": "contract AddressResolver",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "resolverAddressesRequired",
+		"outputs": [
+			{
+				"internalType": "bytes32[]",
+				"name": "addresses",
+				"type": "bytes32[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			}
+		],
+		"name": "submitNextPriceOrder",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "sizeDelta",
+				"type": "int256"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "trackingCode",
+				"type": "bytes32"
+			}
+		],
+		"name": "submitNextPriceOrderWithTracking",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "marginDelta",
+				"type": "int256"
+			}
+		],
+		"name": "transferMargin",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "unrecordedFunding",
+		"outputs": [
+			{
+				"internalType": "int256",
+				"name": "funding",
+				"type": "int256"
+			},
+			{
+				"internalType": "bool",
+				"name": "invalid",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "withdrawAllMargin",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}
+]

--- a/lib/abis/FuturesMarketData.json
+++ b/lib/abis/FuturesMarketData.json
@@ -1,0 +1,913 @@
+[
+	{
+		"inputs": [
+			{
+				"internalType": "contract IAddressResolver",
+				"name": "_resolverProxy",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "allMarketSummaries",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "market",
+						"type": "address"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "asset",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "key",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "uint256",
+						"name": "maxLeverage",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "price",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "marketSize",
+						"type": "uint256"
+					},
+					{
+						"internalType": "int256",
+						"name": "marketSkew",
+						"type": "int256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "marketDebt",
+						"type": "uint256"
+					},
+					{
+						"internalType": "int256",
+						"name": "currentFundingRate",
+						"type": "int256"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "takerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "takerFeeNextPrice",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFeeNextPrice",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FeeRates",
+						"name": "feeRates",
+						"type": "tuple"
+					}
+				],
+				"internalType": "struct FuturesMarketData.MarketSummary[]",
+				"name": "",
+				"type": "tuple[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "globals",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "uint256",
+						"name": "minInitialMargin",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "liquidationFeeRatio",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "liquidationBufferRatio",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "minKeeperFee",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct FuturesMarketData.FuturesGlobals",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "contract IFuturesMarket",
+				"name": "market",
+				"type": "address"
+			}
+		],
+		"name": "marketDetails",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "market",
+						"type": "address"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "baseAsset",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "marketKey",
+						"type": "bytes32"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "takerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "takerFeeNextPrice",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFeeNextPrice",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FeeRates",
+						"name": "feeRates",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "maxLeverage",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "maxMarketValueUSD",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.MarketLimits",
+						"name": "limits",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "maxFundingRate",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "skewScaleUSD",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FundingParameters",
+						"name": "fundingParameters",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "marketSize",
+								"type": "uint256"
+							},
+							{
+								"components": [
+									{
+										"internalType": "uint256",
+										"name": "long",
+										"type": "uint256"
+									},
+									{
+										"internalType": "uint256",
+										"name": "short",
+										"type": "uint256"
+									}
+								],
+								"internalType": "struct FuturesMarketData.Sides",
+								"name": "sides",
+								"type": "tuple"
+							},
+							{
+								"internalType": "uint256",
+								"name": "marketDebt",
+								"type": "uint256"
+							},
+							{
+								"internalType": "int256",
+								"name": "marketSkew",
+								"type": "int256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.MarketSizeDetails",
+						"name": "marketSizeDetails",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "price",
+								"type": "uint256"
+							},
+							{
+								"internalType": "bool",
+								"name": "invalid",
+								"type": "bool"
+							}
+						],
+						"internalType": "struct FuturesMarketData.PriceDetails",
+						"name": "priceDetails",
+						"type": "tuple"
+					}
+				],
+				"internalType": "struct FuturesMarketData.MarketData",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "marketKey",
+				"type": "bytes32"
+			}
+		],
+		"name": "marketDetailsForKey",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "market",
+						"type": "address"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "baseAsset",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "marketKey",
+						"type": "bytes32"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "takerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "takerFeeNextPrice",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFeeNextPrice",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FeeRates",
+						"name": "feeRates",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "maxLeverage",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "maxMarketValueUSD",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.MarketLimits",
+						"name": "limits",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "maxFundingRate",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "skewScaleUSD",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FundingParameters",
+						"name": "fundingParameters",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "marketSize",
+								"type": "uint256"
+							},
+							{
+								"components": [
+									{
+										"internalType": "uint256",
+										"name": "long",
+										"type": "uint256"
+									},
+									{
+										"internalType": "uint256",
+										"name": "short",
+										"type": "uint256"
+									}
+								],
+								"internalType": "struct FuturesMarketData.Sides",
+								"name": "sides",
+								"type": "tuple"
+							},
+							{
+								"internalType": "uint256",
+								"name": "marketDebt",
+								"type": "uint256"
+							},
+							{
+								"internalType": "int256",
+								"name": "marketSkew",
+								"type": "int256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.MarketSizeDetails",
+						"name": "marketSizeDetails",
+						"type": "tuple"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "price",
+								"type": "uint256"
+							},
+							{
+								"internalType": "bool",
+								"name": "invalid",
+								"type": "bool"
+							}
+						],
+						"internalType": "struct FuturesMarketData.PriceDetails",
+						"name": "priceDetails",
+						"type": "tuple"
+					}
+				],
+				"internalType": "struct FuturesMarketData.MarketData",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "address[]",
+				"name": "markets",
+				"type": "address[]"
+			}
+		],
+		"name": "marketSummaries",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "market",
+						"type": "address"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "asset",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "key",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "uint256",
+						"name": "maxLeverage",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "price",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "marketSize",
+						"type": "uint256"
+					},
+					{
+						"internalType": "int256",
+						"name": "marketSkew",
+						"type": "int256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "marketDebt",
+						"type": "uint256"
+					},
+					{
+						"internalType": "int256",
+						"name": "currentFundingRate",
+						"type": "int256"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "takerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "takerFeeNextPrice",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFeeNextPrice",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FeeRates",
+						"name": "feeRates",
+						"type": "tuple"
+					}
+				],
+				"internalType": "struct FuturesMarketData.MarketSummary[]",
+				"name": "",
+				"type": "tuple[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "bytes32[]",
+				"name": "marketKeys",
+				"type": "bytes32[]"
+			}
+		],
+		"name": "marketSummariesForKeys",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "market",
+						"type": "address"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "asset",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "bytes32",
+						"name": "key",
+						"type": "bytes32"
+					},
+					{
+						"internalType": "uint256",
+						"name": "maxLeverage",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "price",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "marketSize",
+						"type": "uint256"
+					},
+					{
+						"internalType": "int256",
+						"name": "marketSkew",
+						"type": "int256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "marketDebt",
+						"type": "uint256"
+					},
+					{
+						"internalType": "int256",
+						"name": "currentFundingRate",
+						"type": "int256"
+					},
+					{
+						"components": [
+							{
+								"internalType": "uint256",
+								"name": "takerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFee",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "takerFeeNextPrice",
+								"type": "uint256"
+							},
+							{
+								"internalType": "uint256",
+								"name": "makerFeeNextPrice",
+								"type": "uint256"
+							}
+						],
+						"internalType": "struct FuturesMarketData.FeeRates",
+						"name": "feeRates",
+						"type": "tuple"
+					}
+				],
+				"internalType": "struct FuturesMarketData.MarketSummary[]",
+				"name": "",
+				"type": "tuple[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "marketKey",
+				"type": "bytes32"
+			}
+		],
+		"name": "parameters",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "uint256",
+						"name": "takerFee",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "makerFee",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "takerFeeNextPrice",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "makerFeeNextPrice",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "nextPriceConfirmWindow",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "maxLeverage",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "maxMarketValueUSD",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "maxFundingRate",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "skewScaleUSD",
+						"type": "uint256"
+					}
+				],
+				"internalType": "struct IFuturesMarketSettings.Parameters",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "contract IFuturesMarket",
+				"name": "market",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "positionDetails",
+		"outputs": [
+			{
+				"components": [
+					{
+						"components": [
+							{
+								"internalType": "uint64",
+								"name": "id",
+								"type": "uint64"
+							},
+							{
+								"internalType": "uint64",
+								"name": "lastFundingIndex",
+								"type": "uint64"
+							},
+							{
+								"internalType": "uint128",
+								"name": "margin",
+								"type": "uint128"
+							},
+							{
+								"internalType": "uint128",
+								"name": "lastPrice",
+								"type": "uint128"
+							},
+							{
+								"internalType": "int128",
+								"name": "size",
+								"type": "int128"
+							}
+						],
+						"internalType": "struct IFuturesMarketBaseTypes.Position",
+						"name": "position",
+						"type": "tuple"
+					},
+					{
+						"internalType": "int256",
+						"name": "notionalValue",
+						"type": "int256"
+					},
+					{
+						"internalType": "int256",
+						"name": "profitLoss",
+						"type": "int256"
+					},
+					{
+						"internalType": "int256",
+						"name": "accruedFunding",
+						"type": "int256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "remainingMargin",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "accessibleMargin",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "liquidationPrice",
+						"type": "uint256"
+					},
+					{
+						"internalType": "bool",
+						"name": "canLiquidatePosition",
+						"type": "bool"
+					}
+				],
+				"internalType": "struct FuturesMarketData.PositionData",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "marketKey",
+				"type": "bytes32"
+			},
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			}
+		],
+		"name": "positionDetailsForMarketKey",
+		"outputs": [
+			{
+				"components": [
+					{
+						"components": [
+							{
+								"internalType": "uint64",
+								"name": "id",
+								"type": "uint64"
+							},
+							{
+								"internalType": "uint64",
+								"name": "lastFundingIndex",
+								"type": "uint64"
+							},
+							{
+								"internalType": "uint128",
+								"name": "margin",
+								"type": "uint128"
+							},
+							{
+								"internalType": "uint128",
+								"name": "lastPrice",
+								"type": "uint128"
+							},
+							{
+								"internalType": "int128",
+								"name": "size",
+								"type": "int128"
+							}
+						],
+						"internalType": "struct IFuturesMarketBaseTypes.Position",
+						"name": "position",
+						"type": "tuple"
+					},
+					{
+						"internalType": "int256",
+						"name": "notionalValue",
+						"type": "int256"
+					},
+					{
+						"internalType": "int256",
+						"name": "profitLoss",
+						"type": "int256"
+					},
+					{
+						"internalType": "int256",
+						"name": "accruedFunding",
+						"type": "int256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "remainingMargin",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "accessibleMargin",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint256",
+						"name": "liquidationPrice",
+						"type": "uint256"
+					},
+					{
+						"internalType": "bool",
+						"name": "canLiquidatePosition",
+						"type": "bool"
+					}
+				],
+				"internalType": "struct FuturesMarketData.PositionData",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "resolverProxy",
+		"outputs": [
+			{
+				"internalType": "contract IAddressResolver",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	}
+]

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -49,10 +49,10 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }: AppPropsWithLayout) =>
 					value={
 						provider && isSupportedNetworkId(network.id) && synthetixjs
 							? createQueryContext({
-									provider: provider,
+									provider,
 									signer: signer || undefined,
 									networkId: network.id,
-									synthetixjs: synthetixjs,
+									synthetixjs,
 							  })
 							: createQueryContext({ networkId: null, synthetixjs: null })
 					}

--- a/queries/futures/useGetFuturesPositionForMarkets.ts
+++ b/queries/futures/useGetFuturesPositionForMarkets.ts
@@ -1,21 +1,26 @@
+import { Provider, Contract } from 'ethcall';
 import { utils as ethersUtils } from 'ethers';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 
 import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
+import FuturesMarketABI from 'lib/abis/FuturesMarket.json';
+import FuturesMarketDataABI from 'lib/abis/FuturesMarketData.json';
 import { appReadyState } from 'store/app';
 import { futuresMarketsState, futuresAccountState, positionsState } from 'store/futures';
 import { isL2State } from 'store/wallet';
 import { MarketKeyByAsset } from 'utils/futures';
 
-import { FuturesPosition } from './types';
-import { mapFuturesPosition, getFuturesMarketContract } from './utils';
+import { FuturesPosition, PositionDetail } from './types';
+import { mapFuturesPosition } from './utils';
+
+const ethCallProvider = new Provider();
 
 const useGetFuturesPositionForMarkets = (options?: UseQueryOptions<FuturesPosition[]>) => {
 	const isAppReady = useRecoilValue(appReadyState);
 	const isL2 = useRecoilValue(isL2State);
-	const { synthetixjs, network } = Connector.useContainer();
+	const { synthetixjs, network, provider } = Connector.useContainer();
 	const setFuturesPositions = useSetRecoilState(positionsState);
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
 	const { selectedFuturesAddress } = useRecoilValue(futuresAccountState);
@@ -25,31 +30,41 @@ const useGetFuturesPositionForMarkets = (options?: UseQueryOptions<FuturesPositi
 	return useQuery<FuturesPosition[]>(
 		QUERY_KEYS.Futures.MarketsPositions(network.id, assets || [], selectedFuturesAddress || ''),
 		async () => {
-			if (!assets || (selectedFuturesAddress && !isL2)) {
-				return [];
-			}
+			if (!assets || !provider || (selectedFuturesAddress && !isL2)) return [];
+
+			await ethCallProvider.init(provider);
 
 			const {
 				contracts: { FuturesMarketData },
 			} = synthetixjs!;
 
-			const positionsForMarkets = await Promise.all(
-				assets.map((asset) => {
-					return Promise.all([
-						FuturesMarketData.positionDetailsForMarketKey(
-							ethersUtils.formatBytes32String(MarketKeyByAsset[asset]),
-							selectedFuturesAddress
-						),
-						getFuturesMarketContract(asset, synthetixjs!.contracts).canLiquidate(
-							selectedFuturesAddress
-						),
-					]);
-				})
-			);
+			const FMD = new Contract(FuturesMarketData.address, FuturesMarketDataABI);
 
-			const futuresPositions = positionsForMarkets.map(([position, canLiquidate], i) =>
-				mapFuturesPosition(position, canLiquidate, assets[i])
-			);
+			const positionCalls = [];
+			const liquidationCalls = [];
+
+			for (const { market, asset } of futuresMarkets) {
+				positionCalls.push(
+					FMD.positionDetailsForMarketKey(
+						ethersUtils.formatBytes32String(MarketKeyByAsset[asset]),
+						selectedFuturesAddress
+					)
+				);
+				const marketContract = new Contract(market, FuturesMarketABI);
+				liquidationCalls.push(marketContract.canLiquidate(selectedFuturesAddress));
+			}
+
+			const positions = (await ethCallProvider.all(positionCalls)) as PositionDetail[];
+			const canLiquidateState = (await ethCallProvider.all(liquidationCalls)) as boolean[];
+
+			const futuresPositions = [];
+
+			for (let i = 0; i < futuresMarkets.length; i++) {
+				const position = positions[i];
+				const canLiquidate = canLiquidateState[i];
+
+				futuresPositions.push(mapFuturesPosition(position, canLiquidate, assets[i]));
+			}
 
 			setFuturesPositions(futuresPositions);
 


### PR DESCRIPTION
## Description
This PR batches contract calls in the `useGetFuturesPositionForMarkets` hook using ethcall. It should improve performance on the app quite a bit, since the query was getting refetched quite a bit.

## Related issue
N/A

## Motivation and Context
Performance improvements

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
