### PR TITLE
Always format USD value of spot trades with a sign instead of a currencyKey

### DIFF
--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -174,17 +174,10 @@ const SpotHistoryTable: FC = () => {
 									price={cellProps.row.original.toAmountInUSD}
 									sign={selectedPriceCurrency.sign}
 									conversionRate={selectPriceCurrencyRate}
-									formatOptions={
-										isFiatCurrency(currencyKey)
-											? {
-													currencyKey: undefined,
-													sign: selectedPriceCurrency.sign,
-											  }
-											: {
-													currencyKey: selectedPriceCurrency.sign,
-													sign: undefined,
-											  }
-									}
+									formatOptions={{
+										currencyKey: undefined,
+										sign: selectedPriceCurrency.sign,
+									}}
 								/>
 							);
 						},

--- a/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
+++ b/sections/dashboard/SpotHistoryTable/SpotHistoryTable.tsx
@@ -20,7 +20,6 @@ import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import useGetWalletTrades from 'queries/synths/useGetWalletTrades';
 import { walletAddressState } from 'store/wallet';
 import { ExternalLink } from 'styles/common';
-import { isFiatCurrency } from 'utils/currencies';
 
 import TimeDisplay from '../../futures/Trades/TimeDisplay';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the Spot History table to always format the USD Value column with a `sign` (on the left) instead of a `currencyKey` (on the right). Previously the value was being formatted on the left for trades involving fiat synths and on the right for non-fiat synths, but that doesn't make a whole lot of sense since USD Value will always be in fiat terms.

## Related issue
https://github.com/Kwenta/kwenta/issues/1295

## Motivation and Context
Inconsistent currency symbol display is confusing and doesn't look great

## How Has This Been Tested?
Tested locally against a mainnet fork

## Screenshot
<img width="944" alt="Kwenta-1295-screenshot" src="https://user-images.githubusercontent.com/109358247/186968661-469129ee-fb91-4adb-bbb2-fad057714f49.png">
