### PR TITLE
fix forex spot names on landing page

### DIFF
--- a/sections/homepage/Assets/Assets.tsx
+++ b/sections/homepage/Assets/Assets.tsx
@@ -241,7 +241,7 @@ const Assets = () => {
 			return {
 				key: synth.asset,
 				market: synth.name,
-				description: description.split(' ')[1],
+				description: description.slice(10),
 				price,
 				change: price !== 0 ? (price - (pastPrice?.price ?? 0)) / price || 0 : 0,
 				volume: !isNil(synthVolumes[synth.name]) ? Number(synthVolumes[synth.name]) ?? 0 : 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Forex **Spot** descriptions on landing page are cut off, both on L1 and L2. For example, the South Korean Won is just displayed as "South", and so forth.

![Screen Shot 2022-08-29 at 17 39 40](https://user-images.githubusercontent.com/548702/187294854-dbdba5fc-8e1a-4d92-b61e-07e8b30a23c7.png)


## Related issue
#1314 

## Motivation and Context
Order on the landing page

## How Has This Been Tested?
localhost

## Screenshots (if appropriate):
![Screen Shot 2022-08-29 at 17 42 14](https://user-images.githubusercontent.com/548702/187295093-22c0a5c4-1460-4a32-89c7-3f23586f9c9e.png)

