### PR TITLE
hotfix: disabled theme switch if expected theme is already set.

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileSubMenu.tsx
+++ b/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileSubMenu.tsx
@@ -75,7 +75,7 @@ const MobileSubMenu: React.FC<MobileSubMenuProps> = ({
 										<SubMenuFlex>
 											<SubMenuItem
 												currentTheme={currentTheme}
-												onClick={onClick}
+												onClick={selected ? undefined : onClick}
 												selected={selected}
 											>
 												{label}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the bug introduced in #1333 

If the current theme is already `light`, then clicked the button should do nothing **instead of** change the theme to `dark`, which is unexpected, and the same to the `dark` button.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
