### PR TITLE
Show L2 spot data only on landing page

### DIFF
--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -40,6 +40,12 @@ const useConnector = () => {
 		return [keyBy(defaultSynthetixjs.synths, 'name'), keyBy(defaultSynthetixjs.tokens, 'symbol')];
 	}, [defaultSynthetixjs]);
 
+	const l2SynthsMap = useMemo(() => {
+		if (l2Synthetixjs == null) return {};
+
+		return keyBy(l2Synthetixjs.synths, 'name');
+	}, [l2Synthetixjs]);
+
 	return {
 		isWalletConnected,
 		walletAddress,
@@ -52,6 +58,7 @@ const useConnector = () => {
 		staticMainnetProvider,
 		defaultSynthetixjs,
 		l2Synthetixjs,
+		l2SynthsMap,
 	};
 };
 

--- a/sections/homepage/Assets/Assets.tsx
+++ b/sections/homepage/Assets/Assets.tsx
@@ -144,7 +144,7 @@ export const PriceChart = ({ asset }: PriceChartProps) => {
 
 const Assets = () => {
 	const { t } = useTranslation();
-	const { synthsMap } = Connector.useContainer();
+	const { l2SynthsMap } = Connector.useContainer();
 	const [activeMarketsTab, setActiveMarketsTab] = useState<MarketsTab>(MarketsTab.FUTURES);
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
@@ -179,7 +179,7 @@ const Assets = () => {
 
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();
 
-	const synths = useMemo(() => values(synthsMap) || [], [synthsMap]);
+	const synths = useMemo(() => values(l2SynthsMap) || [], [l2SynthsMap]);
 	const queryCache = useQueryClient().getQueryCache();
 	// KM-NOTE: come back and delete
 	const frozenSynthsQuery = queryCache.find(['synths', 'frozenSynths', 10]);
@@ -199,7 +199,7 @@ const Assets = () => {
 
 		return (
 			futuresMarkets?.map((market, i) => {
-				const description = getSynthDescription(market.asset, synthsMap, t);
+				const description = getSynthDescription(market.asset, l2SynthsMap, t);
 				const volume = futuresVolume[market.assetHex];
 				const pastPrice = pastRates.find(
 					(price: Price) => price.synth === market.asset || price.synth === market.asset.slice(1)
@@ -220,7 +220,7 @@ const Assets = () => {
 			}) ?? []
 		);
 		// eslint-disable-next-line
-	}, [futuresMarkets, synthsMap, pastRates, futuresVolumeQuery?.data, t]);
+	}, [futuresMarkets, l2SynthsMap, pastRates, futuresVolumeQuery?.data, t]);
 
 	const SPOTS = useMemo(() => {
 		const synthVolumes = synthVolumesQuery?.data ?? {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The spot tab will show L1 spot data if the wallet is connected to Ethereum mainnet. However, the price feed is hardcoded to L2 so the L1 spot is missing most of the info. The PR will disable the query of L1 spot data so the landing page will only show L2 spot data.

## Related issue
#1331

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the landing page
2. Switch to `spot`  tab, see L2 spot data
3. Go to the market page and connect the wallet. Switch the network to Ethereum
4. Go to  the landing page and switch to `spot` tab, see L2 spot data.

## Screenshots (if appropriate):
