### PR TITLE
Fixed the broken link of the op goerli etherscan

### DIFF
--- a/constants/links.ts
+++ b/constants/links.ts
@@ -42,8 +42,8 @@ export const EXTERNAL_LINKS = {
 		Faq: 'https://docs.kwenta.io/resources/faq',
 	},
 	Explorer: {
-		Optimism: 'https://optimistic.etherscan.io/tx',
-		OptimismGoerli: 'https://goerli-optimism.etherscan.io/tx',
+		Optimism: 'https://optimistic.etherscan.io',
+		OptimismGoerli: 'https://goerli-optimism.etherscan.io',
 	},
 	Optimism: {
 		Home: 'https://optimism.io/',

--- a/containers/BlockExplorer/BlockExplorer.tsx
+++ b/containers/BlockExplorer/BlockExplorer.tsx
@@ -1,8 +1,10 @@
 import { NetworkId, NetworkIdByName, NetworkNameById } from '@synthetixio/contracts-interface';
-import { OPTIMISM_NETWORKS, MAINNET_OPTIMISM_EXPLORER } from '@synthetixio/optimism-networks';
+import { MAINNET_OPTIMISM_EXPLORER } from '@synthetixio/optimism-networks';
 import { useEffect, useState } from 'react';
 import { createContainer } from 'unstated-next';
-import { useNetwork } from 'wagmi';
+import { chain, useNetwork } from 'wagmi';
+
+import { EXTERNAL_LINKS } from 'constants/links';
 
 type BlockExplorerInstance = {
 	baseLink: string;
@@ -12,11 +14,14 @@ type BlockExplorerInstance = {
 	blockLink: (blockNumber: string) => string;
 };
 
+export const OPTIMISM_NETWORKS = {
+	[chain.optimism.id]: EXTERNAL_LINKS.Explorer.Optimism,
+	[chain.optimismGoerli.id]: EXTERNAL_LINKS.Explorer.OptimismGoerli,
+};
+
 const getBaseUrl = (networkId: NetworkId) => {
 	if (networkId === 10 || networkId === 420) {
-		return (
-			OPTIMISM_NETWORKS[networkId as NetworkId]?.blockExplorerUrls[0] ?? MAINNET_OPTIMISM_EXPLORER
-		);
+		return OPTIMISM_NETWORKS[networkId as NetworkId] ?? MAINNET_OPTIMISM_EXPLORER;
 	} else if ((networkId as NetworkId) === NetworkIdByName.mainnet) {
 		return 'https://etherscan.io';
 	}

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -112,8 +112,8 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 					onTableRowClick={(row) =>
 						row.original.id !== NO_VALUE
 							? isL2Mainnet
-								? window.open(`${EXTERNAL_LINKS.Explorer.Optimism}/${row.original.id}`)
-								: window.open(`${EXTERNAL_LINKS.Explorer.OptimismGoerli}/${row.original.id}`)
+								? window.open(`${EXTERNAL_LINKS.Explorer.Optimism}/tx/${row.original.id}`)
+								: window.open(`${EXTERNAL_LINKS.Explorer.OptimismGoerli}/tx/${row.original.id}`)
 							: undefined
 					}
 					highlightRowsOnHover

--- a/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
+++ b/sections/shared/Layout/AppLayout/Header/NetworksSwitcher.tsx
@@ -14,6 +14,7 @@ import Button from 'components/Button';
 import Select from 'components/Select';
 import { IndicatorSeparator } from 'components/Select/Select';
 import { EXTERNAL_LINKS } from 'constants/links';
+import BlockExplorer from 'containers/BlockExplorer';
 import Connector from 'containers/Connector';
 import useIsL2 from 'hooks/useIsL2';
 import { ExternalLink, FlexDivRowCentered } from 'styles/common';
@@ -35,6 +36,7 @@ const NetworksSwitcher: FC<NetworksSwitcherProps> = () => {
 	const isL2 = useIsL2();
 	const network = activeChain?.id === chain.optimismGoerli.id ? 'testnet' : 'mainnet';
 	const networkLabel = 'header.networks-switcher.optimism-' + network;
+	const { blockExplorerInstance } = BlockExplorer.useContainer();
 
 	const OPTIMISM_OPTIONS = [
 		{
@@ -50,7 +52,7 @@ const NetworksSwitcher: FC<NetworksSwitcherProps> = () => {
 		{
 			label: 'header.networks-switcher.optimistic-etherscan',
 			postfixIcon: 'Link',
-			link: activeChain?.blockExplorers?.etherscan?.url,
+			link: blockExplorerInstance?.baseLink,
 		},
 		{
 			label: 'header.networks-switcher.learn-more',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The link to OP Goerli etherscan is broken in `synthetix@optimism-network` package, so we created a map to fix the link.

## Related issue
#1166 

## Motivation and Context
Make the OP Goerli a fully functional testnet.

## How Has This Been Tested?
1. Connected to OP Goerli and click on the `Optimistic Etherscan`. 
2. From market page, switch to the trade tab and click on the historical trade.

## Screenshots (if appropriate):
