### PR TITLE
Remove leading "s" from ETH/BTC/LINK assets display in `OrderSizing` component

### DIFF
--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -113,7 +113,7 @@ const OrderSizing: React.FC<OrderSizingProps> = ({ disabled }) => {
 
 			<CustomInput
 				disabled={isDisabled}
-				right={marketAsset || 'sUSD'}
+				right={marketAsset?.replace(/^s/, '') || 'sUSD'}
 				value={assetValue}
 				placeholder="0.0"
 				onChange={onChangeAssetValue}


### PR DESCRIPTION
Makes the ETH, BTC, and LINK asset names in the order size input consistent with the other Futures Market assets by removing the leading "s". 

## Description
This change is just a UI override of the underlying market asset name to remove the leading "s" for display. I initially wanted to update the `FuturesMarketAsset` representations in `utils/futures.ts` and the Recoil state to exclude the "s" so it would be consistent throughout the app, but decided against it since these markets are still called sETH/sBTC/sLINK in the underlying `FuturesMarketData` contract.

Happy to go another direction with it if anyone thinks the simple UI override isn't enough though!

## Related issue
https://github.com/Kwenta/kwenta/issues/1373

## Motivation and Context
Inconsistency between the futures markets

## How Has This Been Tested?
Test locally against Optimism Goerli

## Screenshots (if appropriate):
<img width="419" alt="kwenta-1373-screenshot" src="https://user-images.githubusercontent.com/109358247/189445800-68c3b891-d971-4535-aac6-69ab226ac8be.png">

