### PR TITLE
Hide cross margin in prod

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -41,6 +41,10 @@ export const DEFAULT_NP_LEVERAGE_ADJUSTMENT: number = 0.9975;
 // for mobile leaderboard
 export const DEFAULT_LEADERBOARD_ROWS = 20;
 
-export const DEFAULT_FUTURES_MARGIN_TYPE = 'cross_margin';
+export const CROSS_MARGIN_ENABLED = process.env.NODE_ENV === 'development';
+
+export const DEFAULT_FUTURES_MARGIN_TYPE = CROSS_MARGIN_ENABLED
+	? 'cross_margin'
+	: 'isolated_margin';
 
 export const DEFAULT_LEVERAGE = '10';

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -8,7 +8,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
-import { DEFAULT_LEVERAGE } from 'constants/defaults';
+import { CROSS_MARGIN_ENABLED, DEFAULT_LEVERAGE } from 'constants/defaults';
 import Connector from 'containers/Connector';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRefetchContext } from 'contexts/RefetchContext';
@@ -479,9 +479,18 @@ const useFuturesData = () => {
 	]);
 
 	useEffect(() => {
+		// TODO: Can remove once cross margin is fully integrated
+		if (!CROSS_MARGIN_ENABLED && selectedAccountType === 'cross_margin') {
+			setSelectedAccountType('isolated_margin');
+		}
+	}, [selectedAccountType, setSelectedAccountType]);
+
+	useEffect(() => {
 		const validType = ['cross_margin', 'isolated_margin'].includes(routerAccountType);
 		if (validType) {
-			setSelectedAccountType(routerAccountType as FuturesAccountType);
+			setSelectedAccountType(
+				CROSS_MARGIN_ENABLED ? (routerAccountType as FuturesAccountType) : 'isolated_margin'
+			);
 			if (routerAccountType === 'cross_margin' && orderType === 1) {
 				setOrderType(0);
 			}

--- a/sections/shared/Layout/AppLayout/Header/constants.ts
+++ b/sections/shared/Layout/AppLayout/Header/constants.ts
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { CrossMarginIcon, IsolatedMarginIcon } from 'components/Nav/FuturesIcon';
-import { DEFAULT_FUTURES_MARGIN_TYPE } from 'constants/defaults';
+import { CROSS_MARGIN_ENABLED, DEFAULT_FUTURES_MARGIN_TYPE } from 'constants/defaults';
 import { EXTERNAL_LINKS } from 'constants/links';
 import ROUTES from 'constants/routes';
 
@@ -58,18 +58,20 @@ export const getMenuLinks = (isMobile: boolean): MenuLinks => [
 	{
 		i18nLabel: 'header.nav.markets',
 		link: ROUTES.Markets.Home(DEFAULT_FUTURES_MARGIN_TYPE),
-		links: [
-			{
-				link: ROUTES.Markets.Home('isolated_margin'),
-				i18nLabel: 'header.nav.isolated-margin',
-				Icon: IsolatedMarginIcon,
-			},
-			{
-				link: ROUTES.Markets.Home('cross_margin'),
-				i18nLabel: 'header.nav.cross-margin',
-				Icon: CrossMarginIcon,
-			},
-		],
+		links: CROSS_MARGIN_ENABLED
+			? [
+					{
+						link: ROUTES.Markets.Home('isolated_margin'),
+						i18nLabel: 'header.nav.isolated-margin',
+						Icon: IsolatedMarginIcon,
+					},
+					{
+						link: ROUTES.Markets.Home('cross_margin'),
+						i18nLabel: 'header.nav.cross-margin',
+						Icon: CrossMarginIcon,
+					},
+			  ]
+			: null,
 	},
 	{
 		i18nLabel: 'header.nav.exchange',


### PR DESCRIPTION
Only enable cross margin in development mode for now.

When it prod it:
- Removes drop down in nav futures tab
- Sets default margin account to isolated margin for generating links etc
- Switches to isolated margin when routed to cross margin futures