### PR TITLE
Fix funding display

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -215,12 +215,11 @@ export const QUERY_KEYS = {
 			networkId,
 			currencyKey,
 		],
-		FundingRates: (networkId: NetworkId, periodLength: number) => [
-			'futures',
-			'fundingRates',
-			networkId,
-			periodLength,
-		],
+		FundingRates: (
+			networkId: NetworkId,
+			periodLength: number,
+			marketAssets: FuturesMarketAsset[]
+		) => ['futures', 'fundingRates', networkId, periodLength, marketAssets],
 		TradingVolumeForAll: (networkId: NetworkId) => ['futures', 'tradingVolumeForAll', networkId],
 		AllPositionHistory: (networkId: NetworkId, walletAddress: string) => [
 			'futures',

--- a/contexts/RefetchContext.tsx
+++ b/contexts/RefetchContext.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-import { Period, PERIOD_IN_SECONDS } from 'constants/period';
+import { Period } from 'constants/period';
 import useGetAverageFundingRateForMarkets from 'queries/futures/useGetAverageFundingRateForMarkets';
 import useGetCrossMarginAccountOverview from 'queries/futures/useGetCrossMarginAccountOverview';
 import useGetFuturesMarkets from 'queries/futures/useGetFuturesMarkets';
@@ -43,7 +43,7 @@ export const RefetchProvider: React.FC = ({ children }) => {
 	const crossMarginAccountQuery = useQueryCrossMarginAccount();
 
 	useExchangeRatesQuery({ refetchInterval: 15000 });
-	useGetAverageFundingRateForMarkets(PERIOD_IN_SECONDS[Period.ONE_HOUR]);
+	useGetAverageFundingRateForMarkets(Period.ONE_HOUR);
 	useLaggedDailyPrice();
 
 	useEffect(() => {

--- a/queries/futures/useGetAverageFundingRateForMarkets.ts
+++ b/queries/futures/useGetAverageFundingRateForMarkets.ts
@@ -4,9 +4,10 @@ import request, { gql } from 'graphql-request';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
+import { Period, PERIOD_IN_SECONDS } from 'constants/period';
 import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
-import { fundingRatesState, futuresMarketsState } from 'store/futures';
+import { fundingRatesState, futuresMarketsState, marketAssetsState } from 'store/futures';
 import { FuturesMarketKey, MarketKeyByAsset } from 'utils/futures';
 import logError from 'utils/logError';
 
@@ -22,16 +23,18 @@ type FundingRateInput = {
 
 export type FundingRateResponse = {
 	asset: FuturesMarketKey;
+	fundingTitle: string;
 	fundingRate: Wei | null;
 };
 
 const useGetAverageFundingRateForMarkets = (
-	periodLength: number,
+	period: Period,
 	options?: UseQueryOptions<any | null>
 ) => {
 	const { network } = Connector.useContainer();
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
+	const marketAssets = useRecoilValue(marketAssetsState);
 	const futuresEndpoint = getFuturesEndpoint(network?.id as NetworkId);
 	const setFundingRates = useSetRecoilState(fundingRatesState);
 
@@ -46,8 +49,12 @@ const useGetAverageFundingRateForMarkets = (
 		}
 	);
 
+	const periodLength = PERIOD_IN_SECONDS[period];
+
+	const periodTitle = period === Period.ONE_HOUR ? '1H Funding Rate' : 'Funding Rate';
+
 	return useQuery<any>(
-		QUERY_KEYS.Futures.FundingRates(network?.id as NetworkId, periodLength),
+		QUERY_KEYS.Futures.FundingRates(network?.id as NetworkId, periodLength, marketAssets),
 		async () => {
 			const minTimestamp = Math.floor(Date.now() / 1000) - periodLength;
 
@@ -100,18 +107,24 @@ const useGetAverageFundingRateForMarkets = (
 								.map((entry: FundingRateUpdate[]): FundingRateUpdate => entry[0])
 								.sort((a: FundingRateUpdate, b: FundingRateUpdate) => a.timestamp - b.timestamp);
 
+							const fundingRate =
+								responseFilt && !!currentFundingRate
+									? calculateFundingRate(
+											minTimestamp,
+											periodLength,
+											responseFilt,
+											price,
+											currentFundingRate
+									  )
+									: currentFundingRate ?? null;
+
+							const fundingPeriod =
+								responseFilt && !!currentFundingRate ? periodTitle : 'Inst. Funding Rate';
+
 							const fundingRateResponse: FundingRateResponse = {
 								asset: marketKey,
-								fundingRate:
-									responseFilt && !!currentFundingRate
-										? calculateFundingRate(
-												minTimestamp,
-												periodLength,
-												responseFilt,
-												price,
-												currentFundingRate
-										  )
-										: null,
+								fundingTitle: fundingPeriod,
+								fundingRate: fundingRate,
 							};
 							return fundingRateResponse;
 						});
@@ -131,7 +144,7 @@ const useGetAverageFundingRateForMarkets = (
 			setFundingRates(fundingRates);
 		},
 		{
-			enabled: futuresMarkets.length > 0,
+			enabled: futuresMarkets.length > 0 && futuresMarkets.length === marketAssets.length,
 			...options,
 		}
 	);

--- a/queries/futures/useGetAverageFundingRateForMarkets.ts
+++ b/queries/futures/useGetAverageFundingRateForMarkets.ts
@@ -1,6 +1,7 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
 import Wei from '@synthetixio/wei';
 import request, { gql } from 'graphql-request';
+import { useTranslation } from 'react-i18next';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -31,6 +32,7 @@ const useGetAverageFundingRateForMarkets = (
 	period: Period,
 	options?: UseQueryOptions<any | null>
 ) => {
+	const { t } = useTranslation();
 	const { network } = Connector.useContainer();
 
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
@@ -51,7 +53,10 @@ const useGetAverageFundingRateForMarkets = (
 
 	const periodLength = PERIOD_IN_SECONDS[period];
 
-	const periodTitle = period === Period.ONE_HOUR ? '1H Funding Rate' : 'Funding Rate';
+	const periodTitle =
+		period === Period.ONE_HOUR
+			? t('futures.market.info.hourly-funding')
+			: t('futures.market.info.fallback-funding');
 
 	return useQuery<any>(
 		QUERY_KEYS.Futures.FundingRates(network?.id as NetworkId, periodLength, marketAssets),
@@ -119,7 +124,9 @@ const useGetAverageFundingRateForMarkets = (
 									: currentFundingRate ?? null;
 
 							const fundingPeriod =
-								responseFilt && !!currentFundingRate ? periodTitle : 'Inst. Funding Rate';
+								responseFilt && !!currentFundingRate
+									? periodTitle
+									: t('futures.markets.info.instant-funding');
 
 							const fundingRateResponse: FundingRateResponse = {
 								asset: marketKey,

--- a/queries/futures/useGetAverageFundingRateForMarkets.ts
+++ b/queries/futures/useGetAverageFundingRateForMarkets.ts
@@ -1,5 +1,5 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
-import Wei, { wei } from '@synthetixio/wei';
+import Wei from '@synthetixio/wei';
 import request, { gql } from 'graphql-request';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
@@ -111,7 +111,7 @@ const useGetAverageFundingRateForMarkets = (
 												price,
 												currentFundingRate
 										  )
-										: wei(0),
+										: null,
 							};
 							return fundingRateResponse;
 						});

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -1,5 +1,6 @@
 import { wei } from '@synthetixio/wei';
-import React from 'react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
@@ -22,6 +23,8 @@ import { isDecimalFour } from 'utils/futures';
 type MarketData = Record<string, { value: string | JSX.Element; color?: string }>;
 
 const useGetMarketData = (mobile?: boolean) => {
+	const { t } = useTranslation();
+
 	const marketAsset = useRecoilValue(currentMarketState);
 	const marketKey = useRecoilValue(marketKeyState);
 	const marketInfo = useRecoilValue(marketInfoState);
@@ -45,17 +48,19 @@ const useGetMarketData = (mobile?: boolean) => {
 
 	const pastPrice = pastRates.find((price) => price.synth === marketAsset);
 
-	const fundingTitle = React.useMemo(() => `${fundingRate?.fundingTitle ?? '1H Funding Rate'}`, [
-		fundingRate,
-	]);
+	const fundingTitle = useMemo(
+		() => `${fundingRate?.fundingTitle ?? t('futures.market.info.funding')}`,
+		[fundingRate, t]
+	);
 
-	const data: MarketData = React.useMemo(() => {
+	const data: MarketData = useMemo(() => {
 		const fundingValue =
 			!fundingRate?.fundingRate && !!fundingRate
 				? marketInfo?.currentFundingRate
 				: fundingRate?.fundingRate;
 
 		const marketPrice = wei(marketInfo?.price ?? 0);
+		const marketName = `${marketInfo?.marketName ?? t('futures.market.info.default-market')}`;
 
 		if (mobile) {
 			return {
@@ -114,7 +119,7 @@ const useGetMarketData = (mobile?: boolean) => {
 			};
 		} else {
 			return {
-				[marketInfo?.marketName ?? '']: {
+				[marketName]: {
 					value: formatCurrency(selectedPriceCurrency.name, marketPrice, {
 						sign: '$',
 						minDecimals,
@@ -185,6 +190,7 @@ const useGetMarketData = (mobile?: boolean) => {
 		fundingRate,
 		minDecimals,
 		fundingTitle,
+		t,
 	]);
 
 	return data;

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -49,7 +49,7 @@ const useGetMarketData = (mobile?: boolean) => {
 	const pastPrice = pastRates.find((price) => price.synth === marketAsset);
 
 	const fundingTitle = useMemo(
-		() => `${fundingRate?.fundingTitle ?? t('futures.market.info.funding')}`,
+		() => `${fundingRate?.fundingTitle ?? t('futures.market.info.hourly-funding')}`,
 		[fundingRate, t]
 	);
 

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -45,10 +45,9 @@ const useGetMarketData = (mobile?: boolean) => {
 
 	const pastPrice = pastRates.find((price) => price.synth === marketAsset);
 
-	const fundingTitle = React.useMemo(
-		() => `${!fundingRate?.fundingRate && !!fundingRate ? 'Inst.' : '1H'} Funding Rate`,
-		[fundingRate]
-	);
+	const fundingTitle = React.useMemo(() => `${fundingRate?.fundingTitle ?? '1H Funding Rate'}`, [
+		fundingRate,
+	]);
 
 	const data: MarketData = React.useMemo(() => {
 		const fundingValue =

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -46,13 +46,15 @@ const useGetMarketData = (mobile?: boolean) => {
 	const pastPrice = pastRates.find((price) => price.synth === marketAsset);
 
 	const fundingTitle = React.useMemo(
-		() => `${!fundingRate?.fundingRate && !!marketInfo ? 'Inst.' : '1H'} Funding Rate`,
-		[fundingRate, marketInfo]
+		() => `${!fundingRate?.fundingRate && !!fundingRate ? 'Inst.' : '1H'} Funding Rate`,
+		[fundingRate]
 	);
 
 	const data: MarketData = React.useMemo(() => {
 		const fundingValue =
-			!fundingRate && !!marketInfo ? marketInfo?.currentFundingRate : fundingRate?.fundingRate;
+			!fundingRate?.fundingRate && !!fundingRate
+				? marketInfo?.currentFundingRate
+				: fundingRate?.fundingRate;
 
 		const marketPrice = wei(marketInfo?.price ?? 0);
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -545,13 +545,9 @@
 				"daily-volume": "24H Vol"
 			},
 			"info": {
-				"asset": "asset",
-				"size": "market size",
-				"volume": "24H volume",
-				"skew": "market skew",
-				"debt": "market debt",
-				"rate": "24H funding rate"
-			},
+				"default-market": "ETH-PERP",
+				"funding": "1H Funding Rate"
+ 			},
 			"position-card": {
 				"position-side": "Side",
 				"position-size": "Size",

--- a/translations/en.json
+++ b/translations/en.json
@@ -546,7 +546,9 @@
 			},
 			"info": {
 				"default-market": "ETH-PERP",
-				"funding": "1H Funding Rate"
+				"hourly-funding": "1H Funding Rate",
+				"instant-funding": "Inst. Funding Rate",
+				"fallback-funding": "Funding Rate"
  			},
 			"position-card": {
 				"position-side": "Side",


### PR DESCRIPTION
Fixes a display issue with the hourly funding rate in `MarketDetails`.

Expected behavior is:
* Display 1H while the page loads
* If the 1H funding rate query fails, display the instant funding rate from the contract

## Description
The order that we retrieve data is causing a display bug in `MarketDetails` where it flashes the instant funding rate before displaying the hourly funding rate. The instant rate is used as a backup if the hourly query fails. This change checks if the funding query has a value of `null` before displaying the instant rate, which makes sure the query was attempted and failed.

## How Has This Been Tested?
* Forced null values for 1 market
* Forced null values for all markets

Both situations behaved as expected. 