### PR TITLE
Improve Rates

### DIFF
--- a/hooks/useExchange.ts
+++ b/hooks/useExchange.ts
@@ -50,6 +50,7 @@ import {
 	sourceCurrencyKeyState,
 	txErrorState,
 } from 'store/exchange';
+import { ratesState } from 'store/futures';
 import { ordersState } from 'store/orders';
 import { hasOrdersNotificationState, slippageState } from 'store/ui';
 import { gasSpeedState } from 'store/wallet';
@@ -117,6 +118,7 @@ const useExchange = ({ showNoSynthsCard = false }: ExchangeCardProps) => {
 	const setHasOrdersNotification = useSetRecoilState(hasOrdersNotificationState);
 	const quoteCurrencyAmountBN = useRecoilValue(quoteCurrencyAmountBNState);
 	const baseCurrencyAmountBN = useRecoilValue(baseCurrencyAmountBNState);
+	useExchangeRatesQuery({ refetchInterval: 15000 });
 	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
 	const slippage = useRecoilValue(slippageState);
 	const getL1SecurityFee = useGetL1SecurityFee();
@@ -131,8 +133,6 @@ const useExchange = ({ showNoSynthsCard = false }: ExchangeCardProps) => {
 
 	const synthsWalletBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const synthsWalletBalance = synthsWalletBalancesQuery.data ?? null;
-
-	const exchangeRatesQuery = useExchangeRatesQuery();
 
 	const oneInchQuery = useOneInchTokenList();
 
@@ -240,7 +240,7 @@ const useExchange = ({ showNoSynthsCard = false }: ExchangeCardProps) => {
 	const baseCurrency = baseCurrencyKey != null ? synthsMap[baseCurrencyKey]! : null;
 	const quoteCurrency = quoteCurrencyKey != null ? synthsMap[quoteCurrencyKey]! : null;
 
-	const exchangeRates = exchangeRatesQuery.data ?? null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const [quoteRate, baseRate] = useMemo(
 		() => newGetExchangeRatesTupleForCurrencies(exchangeRates, quoteCurrencyKey, baseCurrencyKey),

--- a/hooks/useSelectedPriceCurrency.ts
+++ b/hooks/useSelectedPriceCurrency.ts
@@ -1,13 +1,12 @@
 import Wei from '@synthetixio/wei';
 import { useRecoilValue } from 'recoil';
 
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { priceCurrencyState } from 'store/app';
+import { ratesState } from 'store/futures';
 
 const useSelectedPriceCurrency = () => {
 	const selectedPriceCurrency = useRecoilValue(priceCurrencyState);
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 	const selectPriceCurrencyRate = exchangeRates && exchangeRates[selectedPriceCurrency.name];
 
 	const getPriceAtCurrentRate = (price: Wei) =>

--- a/queries/1inch/use1InchQuoteQuery.ts
+++ b/queries/1inch/use1InchQuoteQuery.ts
@@ -6,9 +6,10 @@ import { useQuery, UseQueryOptions } from 'react-query';
 import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
 import Convert from 'containers/Convert';
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { TxProvider } from 'sections/shared/modals/TxConfirmationModal/TxConfirmationModal';
 import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { useRecoilValue } from 'recoil';
+import { ratesState } from 'store/futures';
 
 type Currency = {
 	key: string;
@@ -25,10 +26,9 @@ const use1InchQuoteQuery = (
 ) => {
 	const { quote1Inch } = Convert.useContainer();
 
-	const exchangeRatesQuery = useExchangeRatesQuery();
 	const { tokensMap, network } = Connector.useContainer();
 
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const synthUsdRate = useMemo(() => {
 		if (!quoteCurrency || !baseCurrency) return null;

--- a/queries/1inch/use1InchQuoteQuery.ts
+++ b/queries/1inch/use1InchQuoteQuery.ts
@@ -2,14 +2,14 @@ import { NetworkId } from '@synthetixio/contracts-interface';
 import { wei } from '@synthetixio/wei';
 import { useMemo } from 'react';
 import { useQuery, UseQueryOptions } from 'react-query';
+import { useRecoilValue } from 'recoil';
 
 import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
 import Convert from 'containers/Convert';
 import { TxProvider } from 'sections/shared/modals/TxConfirmationModal/TxConfirmationModal';
-import { getExchangeRatesForCurrencies } from 'utils/currencies';
-import { useRecoilValue } from 'recoil';
 import { ratesState } from 'store/futures';
+import { getExchangeRatesForCurrencies } from 'utils/currencies';
 
 type Currency = {
 	key: string;

--- a/sections/dashboard/Markets/Markets.tsx
+++ b/sections/dashboard/Markets/Markets.tsx
@@ -1,10 +1,11 @@
 import { FC, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import TabButton from 'components/Button/TabButton';
 import { TabPanel } from 'components/Tab';
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
+import { ratesState } from 'store/futures';
 
 import FuturesMarketsTable from '../FuturesMarketsTable';
 import SpotMarketsTable from '../SpotMarketsTable';
@@ -17,8 +18,7 @@ export enum MarketsTab {
 const Markets: FC = () => {
 	const { t } = useTranslation();
 
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const [activeMarketsTab, setActiveMarketsTab] = useState<MarketsTab>(MarketsTab.FUTURES);
 

--- a/sections/dashboard/MobileDashboard/OpenPositions.tsx
+++ b/sections/dashboard/MobileDashboard/OpenPositions.tsx
@@ -2,7 +2,7 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SetterOrUpdater } from 'recoil';
+import { SetterOrUpdater, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import TabButton from 'components/Button/TabButton';
@@ -10,8 +10,8 @@ import { TabPanel } from 'components/Tab';
 import Connector from 'containers/Connector';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
+import { ratesState } from 'store/futures';
 import { formatDollars, zeroBN } from 'utils/formatters/number';
 
 import FuturesPositionsTable from '../FuturesPositionsTable';
@@ -37,8 +37,7 @@ const OpenPositions: React.FC<OpenPositionsProps> = ({
 	const futuresPositionQuery = useGetFuturesPositionForAccount();
 	const futuresPositionHistory = futuresPositionQuery?.data ?? [];
 
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);
 	const synthBalances =

--- a/sections/dashboard/MobileDashboard/SpotMarkets.tsx
+++ b/sections/dashboard/MobileDashboard/SpotMarkets.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
+import { ratesState } from 'store/futures';
 
 import SpotMarketsTable from '../SpotMarketsTable';
 import { HeaderContainer } from './common';
 
 const SpotMarkets: React.FC = () => {
 	const { t } = useTranslation();
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	return (
 		<>

--- a/sections/dashboard/MobileDashboard/SynthMarkets.tsx
+++ b/sections/dashboard/MobileDashboard/SynthMarkets.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
 import useGetFuturesDailyTradeStats from 'queries/futures/useGetFuturesDailyTradeStats';
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { SectionHeader, SectionTitle } from 'sections/futures/MobileTrade/common';
-import { futuresMarketsState } from 'store/futures';
+import { futuresMarketsState, ratesState } from 'store/futures';
 import { formatDollars, formatNumber, zeroBN } from 'utils/formatters/number';
 
 import SpotMarketsTable from '../SpotMarketsTable';
@@ -14,9 +13,7 @@ import { HeaderContainer, MarketStatsContainer, MarketStat } from './common';
 const SynthMarkets: React.FC = () => {
 	const { t } = useTranslation();
 	const futuresMarkets = useRecoilValue(futuresMarketsState);
-
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.data ?? null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const dailyTradeStats = useGetFuturesDailyTradeStats();
 

--- a/sections/dashboard/Overview/Overview.tsx
+++ b/sections/dashboard/Overview/Overview.tsx
@@ -2,7 +2,7 @@ import useSynthetixQueries from '@synthetixio/queries';
 import { wei } from '@synthetixio/wei';
 import { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import TabButton from 'components/Button/TabButton';
@@ -11,8 +11,8 @@ import { TabPanel } from 'components/Tab';
 import Connector from 'containers/Connector';
 import useGetCurrentPortfolioValue from 'queries/futures/useGetCurrentPortfolioValue';
 import useGetFuturesPositionForAccount from 'queries/futures/useGetFuturesPositionForAccount';
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import { CompetitionBanner } from 'sections/shared/components/CompetitionBanner';
+import { ratesState } from 'store/futures';
 import { activePositionsTabState } from 'store/ui';
 import { formatDollars, zeroBN } from 'utils/formatters/number';
 
@@ -35,8 +35,7 @@ const Overview: FC = () => {
 	const futuresPositionQuery = useGetFuturesPositionForAccount();
 	const futuresPositionHistory = futuresPositionQuery?.data ?? [];
 
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const { walletAddress } = Connector.useContainer();
 	const synthsBalancesQuery = useSynthsBalancesQuery(walletAddress);

--- a/sections/homepage/Assets/Assets.tsx
+++ b/sections/homepage/Assets/Assets.tsx
@@ -19,9 +19,8 @@ import Connector from 'containers/Connector';
 import useGetFuturesTradingVolumeForAllMarkets from 'queries/futures/useGetFuturesTradingVolumeForAllMarkets';
 import { Price } from 'queries/rates/types';
 import { requestCandlesticks } from 'queries/rates/useCandlesticksQuery';
-import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import useGetSynthsTradingVolumeForAllMarkets from 'queries/synths/useGetSynthsTradingVolumeForAllMarkets';
-import { futuresMarketsState, pastRatesState } from 'store/futures';
+import { futuresMarketsState, pastRatesState, ratesState } from 'store/futures';
 import {
 	FlexDiv,
 	FlexDivColCentered,
@@ -174,8 +173,7 @@ const Assets = () => {
 		[activeMarketsTab, t]
 	);
 
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useRecoilValue(ratesState);
 
 	const futuresVolumeQuery = useGetFuturesTradingVolumeForAllMarkets();
 


### PR DESCRIPTION
Get exchange rates from the `ratesState` variable everywhere it is needed. The query will be called from both the `ExchangeContext` and the `RefetchContext`.

## Description
* Update all instances of `useExchangeRatesQuery` to use the state variable

## Related issue
* #1220 

