### PR TITLE
add gitpoap badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Kwenta CI](https://github.com/kwenta/kwenta/workflows/Kwenta%20CI/badge.svg?branch=main) [![Discord](https://img.shields.io/discord/413890591840272394.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/413890591840272394/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/kwenta_io.svg?label=kwenta_io&style=social)](https://twitter.com/kwenta_io)
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/Kwenta/kwenta/badge)](https://www.gitpoap.io/gh/Kwenta/kwenta)
 
 # Kwenta
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A simple PR to add the GitPOAP counter badge to the readme

## Related issue
[See GitPOAP docs](https://docs.gitpoap.io/api#get-v1repoownernamebadge)

## Motivation and Context
Make repository visitors aware of the availability of GitPOAP badges

## How Has This Been Tested?
local preview

## Screenshots (if appropriate):
![Screen Shot 2022-09-27 at 14 01 28](https://user-images.githubusercontent.com/548702/192590064-d2fb1db6-903c-411a-ba11-6098e67104fd.png)

