### PR TITLE
Paginate Transfers table with 5 rows per page

### DIFF
--- a/sections/futures/Trades/Trades.tsx
+++ b/sections/futures/Trades/Trades.tsx
@@ -56,6 +56,7 @@ const Trades: React.FC<TradesProps> = ({ history, isLoading, isLoaded, marketAss
 	return (
 		<Card>
 			<StyledTable
+				highlightRowsOnHover
 				columns={[
 					{
 						Header: (

--- a/sections/futures/Transfers/Transfers.tsx
+++ b/sections/futures/Transfers/Transfers.tsx
@@ -96,6 +96,7 @@ const Transfers: FC<TransferProps> = ({ marginTransfers, isLoading, isLoaded }: 
 				)
 			}
 			showPagination
+			pageSize={5}
 		/>
 	);
 };


### PR DESCRIPTION
Adds pagination to the Transfers table to match the behavior of the other tables, with 5 rows per page.

Also added the `highlightRowsOnHover` prop to the Trades table since the other 3 tabs already had it and it sounded like the goal here was consistency between tabs.

## Related issue
https://github.com/Kwenta/kwenta/issues/1339

## How Has This Been Tested?
Tested locally against Optimism Goerli. 

## Screenshots (if appropriate):
<img width="889" alt="Kwenta-1339" src="https://user-images.githubusercontent.com/109358247/193392794-8724ff58-0dd4-4ed0-8906-da8901f041cc.png">
