### PR TITLE
adjusted PositionDetailsTooltips padding and preset location to fixed

### DIFF
--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -282,7 +282,7 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 					</InfoRow>
 					<InfoRow>
 						<PositionCardTooltip
-							preset="bottom"
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.position-side')}
 						>
@@ -294,7 +294,7 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 					</InfoRow>
 					<InfoRow>
 						<PositionCardTooltip
-							preset="bottom"
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.position-size')}
 						>
@@ -309,7 +309,7 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 				<DataCol>
 					<InfoRow>
 						<PositionCardTooltip
-							preset="bottom"
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.net-funding')}
 						>
@@ -331,7 +331,7 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 					</InfoRow>
 					<InfoRow>
 						<PositionCardTooltip
-							preset="bottom"
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.u-pnl')}
 						>
@@ -349,7 +349,7 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 					</InfoRow>
 					<InfoRow>
 						<PositionCardTooltip
-							preset="bottom"
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.r-pnl')}
 						>
@@ -373,20 +373,20 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 				<DataColDivider />
 				<DataCol>
 					<InfoRow>
-						<LeftMarginTooltip
-							preset="bottom"
+						<PositionCardTooltip
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.leverage')}
 						>
 							<StyledSubtitleWithCursor>
 								{t('futures.market.position-card.leverage')}
 							</StyledSubtitleWithCursor>
-						</LeftMarginTooltip>
+						</PositionCardTooltip>
 						<StyledValue data-testid="position-card-leverage-value">{data.leverage}</StyledValue>
 					</InfoRow>
 					<InfoRow>
 						<PositionCardTooltip
-							preset="bottom"
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.liquidation-price')}
 						>
@@ -397,15 +397,15 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 						<StyledValue>{data.liquidationPrice}</StyledValue>
 					</InfoRow>
 					<InfoRow>
-						<LeftMarginTooltip
-							preset="bottom-z-index-2-left-margin"
+						<PositionCardTooltip
+							preset="fixed"
 							height={'auto'}
 							content={t('futures.market.position-card.tooltips.avg-entry-price')}
 						>
 							<StyledSubtitleWithCursor>
 								{t('futures.market.position-card.avg-entry-price')}
 							</StyledSubtitleWithCursor>
-						</LeftMarginTooltip>
+						</PositionCardTooltip>
 						<StyledValue>{data.avgEntryPrice}</StyledValue>
 					</InfoRow>
 				</DataCol>
@@ -484,13 +484,7 @@ const StyledSubtitleWithCursor = styled.p`
 
 const PositionCardTooltip = styled(StyledTooltip)`
 	z-index: 2;
-`;
-
-const LeftMarginTooltip = styled(StyledTooltip)`
-	${media.greaterThan('sm')`
-		left: -60px;
-		z-index: 2;
-	`}
+	padding: 0px 10px 0px 10px;
 `;
 
 const StyledValue = styled.p`


### PR DESCRIPTION
I fixed the PositionDetails Tooltips' styling to remove the blank space above and below the tooltip text. 

I also changed the preset location for each tooltip to be fixed so that it expands right and does not ever get cut off by the left side of the window.

## Description
I fixed the PositionDetails Tooltips' styling by changing the top and bottom padding to 0px (left/right remain 10px). See the image at the bottom where padding is 0px 10px 0px 10px. This removes the blank space above and below the tooltip text.
 
I also changed the preset location prop for each PositionDetails Tooltip to be 'fixed' instead of 'bottom'. This included removing the a-typical LeftMarginTooltip styles to make all of the tooltips consistent using the 'fixed' preset. This removed the issue where tooltips would be cut off on the left side when the window was a medium width.


## Related issue
[Fix PositionDetails tooltip #1438](https://github.com/Kwenta/kwenta/issues/1438)

## Motivation and Context
This makes the PositionDetails tooltips consistent with the MarketDetails tooltips. Before the PositionDetails tooltips had blank space above and below the text.

Second, the fixed position correction was necessary to prevent the tooltips from being cut off by the left side of the window on a narrower screen (example shown below).
![Screen Shot 2022-10-03 at 7 44 08 PM](https://user-images.githubusercontent.com/83140889/193714383-a4ce97dc-c1d6-4e22-b89e-aee098c965ee.png)

## How Has This Been Tested?
I adjusted the styling and then tested in Brave browser as well as mobile. I also pulled it up on firefox for a quick glance.
I used metamask on the optimism network. I had to test with an open position in order to see the position details on mobile.
I kept my changes isolated to the PositionCard component.

## Screenshots (if appropriate):
![Screen Shot 2022-10-03 at 6 00 53 PM](https://user-images.githubusercontent.com/83140889/193714792-5e80c543-ad92-47b4-a8fa-f8f4a89b2f83.png)
![Screen Shot 2022-10-03 at 8 08 43 PM](https://user-images.githubusercontent.com/83140889/193714882-8947b257-d285-4f06-8693-59ce03d624f4.png)
