### PR TITLE
Market details enable tooltip refactoring

### DIFF
--- a/sections/futures/MarketDetails/MarketDetail.tsx
+++ b/sections/futures/MarketDetails/MarketDetail.tsx
@@ -1,0 +1,83 @@
+import { ReactElement, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+
+import StyledTooltip from 'components/Tooltip/StyledTooltip';
+import TimerTooltip from 'components/Tooltip/TimerTooltip';
+import useRateUpdateQuery from 'queries/rates/useRateUpdateQuery';
+import { currentMarketState, marketInfoState } from 'store/futures';
+
+import { isMarketDataKey, marketDataKeyMap } from './utils';
+
+type MarketDetailProp = {
+	mobile: boolean;
+	marketKey: string;
+	color?: string;
+	value: string | ReactElement;
+};
+
+const MarketDetail: React.FC<MarketDetailProp> = ({ mobile, marketKey, color, value }) => {
+	const { t } = useTranslation();
+	const marketInfo = useRecoilValue(marketInfoState);
+	const marketAsset = useRecoilValue(currentMarketState);
+
+	const pausedClass = marketInfo?.isSuspended ? 'paused' : '';
+	const lastOracleUpdateTimeQuery = useRateUpdateQuery({
+		baseCurrencyKey: marketAsset,
+	});
+
+	const lastOracleUpdateTime: Date = useMemo(() => lastOracleUpdateTimeQuery?.data ?? new Date(), [
+		lastOracleUpdateTimeQuery,
+	]);
+	const children = (
+		<WithCursor cursor="help" key={marketKey}>
+			<div key={marketKey}>
+				<p className="heading">{marketKey}</p>
+				<span className={`value ${color || ''} ${pausedClass}`}>{value}</span>
+			</div>
+		</WithCursor>
+	);
+
+	if (marketKey === marketInfo?.marketName) {
+		return (
+			<TimerTooltip
+				position={'fixed'}
+				key={marketKey}
+				startTimeDate={lastOracleUpdateTime}
+				width={'131px'}
+			>
+				{children}
+			</TimerTooltip>
+		);
+	}
+
+	if (isMarketDataKey(marketKey)) {
+		return (
+			<MarketDetailsTooltip
+				key={marketKey}
+				position={'fixed'}
+				height={'auto'}
+				mobile={mobile}
+				content={t(`exchange.market-details-card.tooltips.${marketDataKeyMap[marketKey]}`)}
+			>
+				{children}
+			</MarketDetailsTooltip>
+		);
+	}
+
+	return children;
+};
+
+export default MarketDetail;
+
+// Extend type of cursor to accept different style of cursor. Currently accept only 'help'
+const WithCursor = styled.div<{ cursor: 'help' }>`
+	cursor: ${(props) => props.cursor};
+`;
+
+const MarketDetailsTooltip = styled(StyledTooltip)<{ mobile?: boolean }>`
+	z-index: 2;
+	padding: 10px;
+	right: ${(props) => props.mobile && '1px'};
+`;

--- a/sections/futures/MarketDetails/MarketDetail.tsx
+++ b/sections/futures/MarketDetails/MarketDetail.tsx
@@ -10,14 +10,14 @@ import { currentMarketState, marketInfoState } from 'store/futures';
 
 import { isMarketDataKey, marketDataKeyMap } from './utils';
 
-type MarketDetailProp = {
+type MarketDetailProps = {
 	mobile: boolean;
 	marketKey: string;
 	color?: string;
 	value: string | ReactElement;
 };
 
-const MarketDetail: React.FC<MarketDetailProp> = ({ mobile, marketKey, color, value }) => {
+const MarketDetail: React.FC<MarketDetailProps> = ({ mobile, marketKey, color, value }) => {
 	const { t } = useTranslation();
 	const marketInfo = useRecoilValue(marketInfoState);
 	const marketAsset = useRecoilValue(currentMarketState);

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -1,12 +1,10 @@
-import React, { useMemo } from 'react';
-import { useRecoilValue } from 'recoil';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
-import { marketInfoState } from 'store/futures';
 import media from 'styles/media';
-import { formatDollars, formatPercent } from 'utils/formatters/number';
 
 import MarketDetail from './MarketDetail';
+import MobileMarketDetail from './MobileMarketDetail';
 import useGetMarketData from './useGetMarketData';
 
 type MarketDetailsProps = {
@@ -14,67 +12,18 @@ type MarketDetailsProps = {
 };
 
 const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
-	const marketInfo = useRecoilValue(marketInfoState);
-
-	const pausedClass = marketInfo?.isSuspended ? 'paused' : '';
-
 	const marketData = useGetMarketData(mobile);
-
-	// skew text
-	const longText = useMemo(() => {
-		return (
-			marketInfo?.openInterest &&
-			formatDollars(marketInfo.openInterest.longUSD, {
-				maxDecimals: 2,
-				...(marketInfo?.openInterest?.longUSD.gt(1e6)
-					? { truncation: { divisor: 1e6, unit: 'M' } }
-					: {}),
-			})
-		);
-	}, [marketInfo]);
-
-	const shortText = useMemo(() => {
-		return (
-			marketInfo?.openInterest &&
-			formatDollars(marketInfo.openInterest.shortUSD, {
-				maxDecimals: 2,
-				...(marketInfo?.openInterest?.shortUSD.gt(1e6)
-					? { truncation: { divisor: 1e6, unit: 'M' } }
-					: {}),
-			})
-		);
-	}, [marketInfo]);
 
 	return (
 		<MarketDetailsContainer mobile={mobile}>
-			{Object.entries(marketData).map(([key, data]) => (
-				<MarketDetail {...data} marketKey={key} mobile={Boolean(mobile)}></MarketDetail>
+			{Object.entries(marketData).map(([marketKey, data]) => (
+				<MarketDetail {...data} marketKey={marketKey} mobile={Boolean(mobile)}></MarketDetail>
 			))}
 
-			{mobile && (
-				<div key="Skew">
-					<p className="heading">Skew</p>
-					<SkewDataContainer>
-						<div className={`value green ${pausedClass}`}>
-							{marketInfo?.openInterest &&
-								formatPercent(marketInfo.openInterest.longPct ?? 0, { minDecimals: 0 })}{' '}
-							({longText})
-						</div>
-						<div className={`value red ${pausedClass}`}>
-							{marketInfo?.openInterest &&
-								formatPercent(marketInfo.openInterest.shortPct ?? 0, { minDecimals: 0 })}{' '}
-							({shortText})
-						</div>
-					</SkewDataContainer>
-				</div>
-			)}
+			{mobile && <MobileMarketDetail />}
 		</MarketDetailsContainer>
 	);
 };
-
-const SkewDataContainer = styled.div`
-	grid-row: 1;
-`;
 
 const MarketDetailsContainer = styled.div<{ mobile?: boolean }>`
 	width: 100%;

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -92,6 +92,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 							key={key}
 							position={'fixed'}
 							height={'auto'}
+							mobile={mobile}
 							content={t(`exchange.market-details-card.tooltips.${marketDataKeyMap[key]}`)}
 						>
 							{children}
@@ -132,9 +133,10 @@ const SkewDataContainer = styled.div`
 	grid-row: 1;
 `;
 
-const MarketDetailsTooltip = styled(StyledTooltip)`
+const MarketDetailsTooltip = styled(StyledTooltip)<{ mobile?: boolean }>`
 	z-index: 2;
 	padding: 10px;
+	right: ${(props) => props.mobile && '1px'};
 `;
 
 const MarketDetailsContainer = styled.div<{ mobile?: boolean }>`

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -11,6 +11,7 @@ import media from 'styles/media';
 import { formatDollars, formatPercent } from 'utils/formatters/number';
 
 import useGetMarketData from './useGetMarketData';
+import { isMarketDataKey, marketDataKeyMap } from './utils';
 
 type MarketDetailsProps = {
 	mobile?: boolean;
@@ -59,16 +60,6 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 		);
 	}, [marketInfo]);
 
-	const contentKeyMap: Record<string, string> = {
-		'External Price': 'external-price',
-		'24H Change': '24h-change',
-		'24H Volume': '24h-vol',
-		'24H Trades': '24H Trades',
-		'Open Interest': 'Open Interest',
-		'Inst. Funding Rate': '1h-funding-rate',
-		'1H Funding Rate': '1h-funding-rate',
-	};
-
 	return (
 		<MarketDetailsContainer mobile={mobile}>
 			{Object.entries(marketData).map(([key, { value, color }]) => {
@@ -95,13 +86,13 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 					);
 				}
 
-				if (Object.keys(contentKeyMap).includes(key)) {
+				if (isMarketDataKey(key)) {
 					return (
 						<MarketDetailsTooltip
 							key={key}
 							position={'fixed'}
 							height={'auto'}
-							content={t(`exchange.market-details-card.tooltips.${contentKeyMap[key]}`)}
+							content={t(`exchange.market-details-card.tooltips.${marketDataKeyMap[key]}`)}
 						>
 							{children}
 						</MarketDetailsTooltip>

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -1,12 +1,8 @@
 import React, { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 import styled, { css } from 'styled-components';
 
-import StyledTooltip from 'components/Tooltip/StyledTooltip';
-import TimerTooltip from 'components/Tooltip/TimerTooltip';
-import useRateUpdateQuery from 'queries/rates/useRateUpdateQuery';
-import { currentMarketState, marketInfoState } from 'store/futures';
+import { marketInfoState } from 'store/futures';
 import media from 'styles/media';
 import { formatDollars, formatPercent } from 'utils/formatters/number';
 

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -10,30 +10,19 @@ import { currentMarketState, marketInfoState } from 'store/futures';
 import media from 'styles/media';
 import { formatDollars, formatPercent } from 'utils/formatters/number';
 
+import MarketDetail from './MarketDetail';
 import useGetMarketData from './useGetMarketData';
-import { isMarketDataKey, marketDataKeyMap } from './utils';
 
 type MarketDetailsProps = {
 	mobile?: boolean;
 };
 
 const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
-	const { t } = useTranslation();
-
 	const marketInfo = useRecoilValue(marketInfoState);
-	const marketAsset = useRecoilValue(currentMarketState);
 
 	const pausedClass = marketInfo?.isSuspended ? 'paused' : '';
 
 	const marketData = useGetMarketData(mobile);
-
-	const lastOracleUpdateTimeQuery = useRateUpdateQuery({
-		baseCurrencyKey: marketAsset,
-	});
-
-	const lastOracleUpdateTime: Date = useMemo(() => lastOracleUpdateTimeQuery?.data ?? new Date(), [
-		lastOracleUpdateTimeQuery,
-	]);
 
 	// skew text
 	const longText = useMemo(() => {
@@ -62,46 +51,9 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 
 	return (
 		<MarketDetailsContainer mobile={mobile}>
-			{Object.entries(marketData).map(([key, { value, color }]) => {
-				const colorClass = color || '';
-				const children = (
-					<WithCursor cursor="help" key={key}>
-						<div key={key}>
-							<p className="heading">{key}</p>
-							<span className={`value ${colorClass} ${pausedClass}`}>{value}</span>
-						</div>
-					</WithCursor>
-				);
-
-				if (key === marketInfo?.marketName) {
-					return (
-						<TimerTooltip
-							position={'fixed'}
-							key={key}
-							startTimeDate={lastOracleUpdateTime}
-							width={'131px'}
-						>
-							{children}
-						</TimerTooltip>
-					);
-				}
-
-				if (isMarketDataKey(key)) {
-					return (
-						<MarketDetailsTooltip
-							key={key}
-							position={'fixed'}
-							height={'auto'}
-							mobile={mobile}
-							content={t(`exchange.market-details-card.tooltips.${marketDataKeyMap[key]}`)}
-						>
-							{children}
-						</MarketDetailsTooltip>
-					);
-				}
-
-				return children;
-			})}
+			{Object.entries(marketData).map(([key, data]) => (
+				<MarketDetail {...data} marketKey={key} mobile={Boolean(mobile)}></MarketDetail>
+			))}
 
 			{mobile && (
 				<div key="Skew">
@@ -124,19 +76,8 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 	);
 };
 
-// Extend type of cursor to accept different style of cursor. Currently accept only 'help'
-const WithCursor = styled.div<{ cursor: 'help' }>`
-	cursor: ${(props) => props.cursor};
-`;
-
 const SkewDataContainer = styled.div`
 	grid-row: 1;
-`;
-
-const MarketDetailsTooltip = styled(StyledTooltip)<{ mobile?: boolean }>`
-	z-index: 2;
-	padding: 10px;
-	right: ${(props) => props.mobile && '1px'};
 `;
 
 const MarketDetailsContainer = styled.div<{ mobile?: boolean }>`

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -24,7 +24,7 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 
 	const pausedClass = marketInfo?.isSuspended ? 'paused' : '';
 
-	const data = useGetMarketData(mobile);
+	const marketData = useGetMarketData(mobile);
 
 	const lastOracleUpdateTimeQuery = useRateUpdateQuery({
 		baseCurrencyKey: marketAsset,
@@ -59,98 +59,21 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 		);
 	}, [marketInfo]);
 
-	const enableTooltip = (key: string, children: React.ReactElement) => {
-		switch (key) {
-			case 'External Price':
-				return (
-					<MarketDetailsTooltip
-						position={'fixed'}
-						key={key}
-						height={'auto'}
-						content={t('exchange.market-details-card.tooltips.external-price')}
-					>
-						{children}
-					</MarketDetailsTooltip>
-				);
-			case '24H Change':
-				return (
-					<MarketDetailsTooltip
-						key={key}
-						position={'fixed'}
-						height={'auto'}
-						content={t('exchange.market-details-card.tooltips.24h-change')}
-					>
-						{children}
-					</MarketDetailsTooltip>
-				);
-			case '24H Volume':
-				return (
-					<MarketDetailsTooltip
-						key={key}
-						position={'fixed'}
-						height={'auto'}
-						content={t('exchange.market-details-card.tooltips.24h-vol')}
-					>
-						{children}
-					</MarketDetailsTooltip>
-				);
-			case '24H Trades':
-				return (
-					<MarketDetailsTooltip
-						key={key}
-						position={'fixed'}
-						height={'auto'}
-						content={t('exchange.market-details-card.tooltips.24h-trades')}
-					>
-						{children}
-					</MarketDetailsTooltip>
-				);
-			case 'Open Interest':
-				return (
-					<MarketDetailsTooltip
-						key={key}
-						position={'fixed'}
-						height={'auto'}
-						content={t('exchange.market-details-card.tooltips.open-interest')}
-					>
-						{children}
-					</MarketDetailsTooltip>
-				);
-			case marketInfo?.marketName:
-				return (
-					<TimerTooltip
-						position={'fixed'}
-						key={key}
-						startTimeDate={lastOracleUpdateTime}
-						width={'131px'}
-					>
-						{children}
-					</TimerTooltip>
-				);
-			case 'Inst. Funding Rate':
-			case '1H Funding Rate':
-				return (
-					<MarketDetailsTooltip
-						key={key}
-						position={'fixed'}
-						height={'auto'}
-						content={t('exchange.market-details-card.tooltips.1h-funding-rate')}
-					>
-						{children}
-					</MarketDetailsTooltip>
-				);
-			default:
-				return children;
-		}
+	const contentKeyMap: Record<string, string> = {
+		'External Price': 'external-price',
+		'24H Change': '24h-change',
+		'24H Volume': '24h-vol',
+		'24H Trades': '24H Trades',
+		'Open Interest': 'Open Interest',
+		'Inst. Funding Rate': '1h-funding-rate',
+		'1H Funding Rate': '1h-funding-rate',
 	};
 
 	return (
 		<MarketDetailsContainer mobile={mobile}>
-			{Object.entries(data).map(([key, { value, color }]) => {
+			{Object.entries(marketData).map(([key, { value, color }]) => {
 				const colorClass = color || '';
-
-				return enableTooltip(
-					key,
+				const children = (
 					<WithCursor cursor="help" key={key}>
 						<div key={key}>
 							<p className="heading">{key}</p>
@@ -158,6 +81,34 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 						</div>
 					</WithCursor>
 				);
+
+				if (key === marketInfo?.marketName) {
+					return (
+						<TimerTooltip
+							position={'fixed'}
+							key={key}
+							startTimeDate={lastOracleUpdateTime}
+							width={'131px'}
+						>
+							{children}
+						</TimerTooltip>
+					);
+				}
+
+				if (Object.keys(contentKeyMap).includes(key)) {
+					return (
+						<MarketDetailsTooltip
+							key={key}
+							position={'fixed'}
+							height={'auto'}
+							content={t(`exchange.market-details-card.tooltips.${contentKeyMap[key]}`)}
+						>
+							{children}
+						</MarketDetailsTooltip>
+					);
+				}
+
+				return children;
 			})}
 
 			{mobile && (

--- a/sections/futures/MarketDetails/MobileMarketDetail.tsx
+++ b/sections/futures/MarketDetails/MobileMarketDetail.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+
+import { marketInfoState } from 'store/futures';
+import { formatDollars, formatPercent } from 'utils/formatters/number';
+
+const MobileMarketDetail: React.FC = () => {
+	const marketInfo = useRecoilValue(marketInfoState);
+	const pausedClass = marketInfo?.isSuspended ? 'paused' : '';
+
+	const longSkewText = useMemo(() => {
+		return (
+			marketInfo?.openInterest &&
+			formatDollars(marketInfo.openInterest.longUSD, {
+				maxDecimals: 2,
+				...(marketInfo?.openInterest?.longUSD.gt(1e6)
+					? { truncation: { divisor: 1e6, unit: 'M' } }
+					: {}),
+			})
+		);
+	}, [marketInfo]);
+
+	const shortSkewText = useMemo(() => {
+		return (
+			marketInfo?.openInterest &&
+			formatDollars(marketInfo.openInterest.shortUSD, {
+				maxDecimals: 2,
+				...(marketInfo?.openInterest?.shortUSD.gt(1e6)
+					? { truncation: { divisor: 1e6, unit: 'M' } }
+					: {}),
+			})
+		);
+	}, [marketInfo]);
+
+	return (
+		<div key="Skew">
+			<p className="heading">Skew</p>
+			<SkewDataContainer>
+				<div className={`value green ${pausedClass}`}>
+					{marketInfo?.openInterest &&
+						formatPercent(marketInfo.openInterest.longPct ?? 0, { minDecimals: 0 })}{' '}
+					({longSkewText})
+				</div>
+				<div className={`value red ${pausedClass}`}>
+					{marketInfo?.openInterest &&
+						formatPercent(marketInfo.openInterest.shortPct ?? 0, { minDecimals: 0 })}{' '}
+					({shortSkewText})
+				</div>
+			</SkewDataContainer>
+		</div>
+	);
+};
+
+export default MobileMarketDetail;
+
+const SkewDataContainer = styled.div`
+	grid-row: 1;
+`;

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -19,6 +19,8 @@ import { isFiatCurrency } from 'utils/currencies';
 import { formatCurrency, formatPercent, zeroBN } from 'utils/formatters/number';
 import { isDecimalFour } from 'utils/futures';
 
+import { MarketDataKey } from './utils';
+
 type MarketData = Record<string, { value: string | JSX.Element; color?: string }>;
 
 const useGetMarketData = (mobile?: boolean) => {
@@ -74,10 +76,10 @@ const useGetMarketData = (mobile?: boolean) => {
 									minDecimals,
 							  }),
 				},
-				'24H Trades': {
+				[MarketDataKey.dailyTrades]: {
 					value: `${futuresTradeCount}`,
 				},
-				'Open Interest': {
+				[MarketDataKey.openInterest]: {
 					value: marketInfo?.marketSize?.mul(marketPrice)
 						? formatCurrency(
 								selectedPriceCurrency.name,
@@ -86,7 +88,7 @@ const useGetMarketData = (mobile?: boolean) => {
 						  )
 						: NO_VALUE,
 				},
-				'24H Volume': {
+				[MarketDataKey.dailyVolume]: {
 					value: formatCurrency(selectedPriceCurrency.name, futuresTradingVolume ?? zeroBN, {
 						sign: '$',
 					}),
@@ -97,7 +99,7 @@ const useGetMarketData = (mobile?: boolean) => {
 						: NO_VALUE,
 					color: fundingValue?.gt(zeroBN) ? 'green' : fundingValue?.lt(zeroBN) ? 'red' : undefined,
 				},
-				'24H Change': {
+				[MarketDataKey.dailyChange]: {
 					value:
 						marketPrice && marketPrice.gt(0) && pastPrice?.price
 							? `${formatCurrency(
@@ -124,7 +126,7 @@ const useGetMarketData = (mobile?: boolean) => {
 						minDecimals,
 					}),
 				},
-				'External Price': {
+				[MarketDataKey.externalPrice]: {
 					value:
 						externalPrice === 0
 							? NO_VALUE
@@ -133,7 +135,7 @@ const useGetMarketData = (mobile?: boolean) => {
 									minDecimals,
 							  }),
 				},
-				'24H Change': {
+				[MarketDataKey.dailyChange]: {
 					value:
 						marketPrice && marketPrice.gt(0) && pastPrice?.price
 							? `${formatCurrency(
@@ -151,15 +153,15 @@ const useGetMarketData = (mobile?: boolean) => {
 								: ''
 							: undefined,
 				},
-				'24H Volume': {
+				[MarketDataKey.dailyVolume]: {
 					value: formatCurrency(selectedPriceCurrency.name, futuresTradingVolume ?? zeroBN, {
 						sign: '$',
 					}),
 				},
-				'24H Trades': {
+				[MarketDataKey.dailyTrades]: {
 					value: `${futuresTradeCount}`,
 				},
-				'Open Interest': {
+				[MarketDataKey.openInterest]: {
 					value: marketInfo?.marketSize?.mul(marketPrice)
 						? formatCurrency(selectedPriceCurrency.name, marketInfo?.marketSize?.mul(marketPrice), {
 								sign: '$',

--- a/sections/futures/MarketDetails/utils.ts
+++ b/sections/futures/MarketDetails/utils.ts
@@ -46,8 +46,8 @@ export const marketDataKeyMap: Record<MarketDataKey, string> = {
 	[MarketDataKey.externalPrice]: 'external-price',
 	[MarketDataKey.dailyChange]: '24h-change',
 	[MarketDataKey.dailyVolume]: '24h-vol',
-	[MarketDataKey.dailyTrades]: '24H Trades',
-	[MarketDataKey.openInterest]: 'Open Interest',
+	[MarketDataKey.dailyTrades]: '24h-trades',
+	[MarketDataKey.openInterest]: 'open-interest',
 	[MarketDataKey.instFundingRate]: '1h-funding-rate',
 	[MarketDataKey.hourlyFundingRate]: '1h-funding-rate',
 };

--- a/sections/futures/MarketDetails/utils.ts
+++ b/sections/futures/MarketDetails/utils.ts
@@ -32,6 +32,30 @@ const map: Record<typeof markets[number], string> = {
 	sAPE: 'apecoin',
 };
 
+enum MarketDataKey {
+	externalPrice = 'External Price',
+	dailyChange = '24H Change',
+	dailyVolume = '24H Volume',
+	dailyTrades = '24H Trades',
+	openInterest = 'Open Interest',
+	instFundingRate = 'Inst. Funding Rate',
+	hourlyFundingRate = '1H Funding Rate',
+}
+
+export const marketDataKeyMap: Record<MarketDataKey, string> = {
+	[MarketDataKey.externalPrice]: 'external-price',
+	[MarketDataKey.dailyChange]: '24h-change',
+	[MarketDataKey.dailyVolume]: '24h-vol',
+	[MarketDataKey.dailyTrades]: '24H Trades',
+	[MarketDataKey.openInterest]: 'Open Interest',
+	[MarketDataKey.instFundingRate]: '1h-funding-rate',
+	[MarketDataKey.hourlyFundingRate]: '1h-funding-rate',
+};
+
+export const isMarketDataKey = (key: string): key is MarketDataKey => {
+	return Object.values<string>(MarketDataKey).includes(key);
+};
+
 export const synthToCoingeckoPriceId = (synth: any) => {
 	if (markets.includes(synth)) {
 		return map[synth as typeof markets[number]];

--- a/sections/futures/MarketDetails/utils.ts
+++ b/sections/futures/MarketDetails/utils.ts
@@ -32,7 +32,7 @@ const map: Record<typeof markets[number], string> = {
 	sAPE: 'apecoin',
 };
 
-enum MarketDataKey {
+export enum MarketDataKey {
 	externalPrice = 'External Price',
 	dailyChange = '24H Change',
 	dailyVolume = '24H Volume',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Get rid of `enableTooltip` function in `MarketDetails` 
- Create sub-components `MarketDetail` and `MobileMarketDetail` for sake of maintainability and performance
- Fix the bug that on mobile tooltip gets cut off on right column

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Kwenta/kwenta/issues/1190

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Tooltip resolving in `MarketDetails` was a bit messy
- Tooltip behaves incorrectly on mobile

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
### Before (on mobile) 
<img width="222" alt="Screenshot 2022-10-04 at 20 50 30" src="https://user-images.githubusercontent.com/3646680/193891376-fb6d90a7-a5fe-466b-a309-0984ef77b8a2.png">

### After
<img width="209" alt="Screenshot 2022-10-04 at 20 50 43" src="https://user-images.githubusercontent.com/3646680/193891530-96e179fe-217a-434e-9fb6-5bfac992ccf9.png">



