### PR TITLE
Fix issue where approval state is not properly set

### DIFF
--- a/hooks/useApproveExchange.ts
+++ b/hooks/useApproveExchange.ts
@@ -95,6 +95,8 @@ const useApproveExchange = () => {
 					)) as ethers.BigNumber;
 					if (wei(ethers.utils.formatEther(allowance)).gte(quoteCurrencyAmount)) {
 						setApproveStatus('approved');
+					} else {
+						setApproveStatus('none');
 					}
 				}
 			} catch (e) {


### PR DESCRIPTION
## Description
Users reporting an error when trying to swap via 1inch on exchange page. It shows a gas estimation error with reason `subtraction overflow`, which indicates allowance issue.

## How Has This Been Tested?
It's possible to get into a state where the allowance isn't reset after changing tokens so the exchange thinks you can make a swap when you don't actually have an allowance. To recreate the issues you can select a token with allowance, enter a value and then swap token sides. It will then allow the user to make a swap without an allowance.

Fixed by making sure to reset the allowance when a new token allowance is checked and insufficient.
