### PR TITLE
Stop Orders

### DIFF
--- a/queries/futures/subgraph.ts
+++ b/queries/futures/subgraph.ts
@@ -1834,6 +1834,14 @@ export type FuturesOrderFilter = {
 	targetPrice_lte?: WeiSource | null;
 	targetPrice_in?: WeiSource[];
 	targetPrice_not_in?: WeiSource[];
+	marginDelta?: WeiSource | null;
+	marginDelta_not?: WeiSource | null;
+	marginDelta_gt?: WeiSource | null;
+	marginDelta_lt?: WeiSource | null;
+	marginDelta_gte?: WeiSource | null;
+	marginDelta_lte?: WeiSource | null;
+	marginDelta_in?: WeiSource[];
+	marginDelta_not_in?: WeiSource[];
 	timestamp?: WeiSource | null;
 	timestamp_not?: WeiSource | null;
 	timestamp_gt?: WeiSource | null;
@@ -1856,7 +1864,6 @@ export type FuturesOrderFilter = {
 	keeper_not_in?: string[];
 	keeper_contains?: string | null;
 	keeper_not_contains?: string | null;
-	_change_block?: any | null;
 };
 export type FuturesOrderResult = {
 	id: string;
@@ -1868,6 +1875,7 @@ export type FuturesOrderResult = {
 	orderId: Wei;
 	targetRoundId: Wei;
 	targetPrice: Wei;
+	marginDelta: Wei;
 	timestamp: Wei;
 	orderType: Partial<FuturesOrderType>;
 	status: Partial<FuturesOrderStatus>;
@@ -1883,9 +1891,10 @@ export type FuturesOrderFields = {
 	orderId: true;
 	targetRoundId: true;
 	targetPrice: true;
+	marginDelta: true;
 	timestamp: true;
-	orderType: true;
-	status: true;
+	orderType: FuturesOrderType;
+	status: FuturesOrderStatus;
 	keeper: true;
 };
 export type FuturesOrderArgs<K extends keyof FuturesOrderResult> = {
@@ -1914,6 +1923,7 @@ export const getFuturesOrderById = async function <K extends keyof FuturesOrderR
 	if (obj['orderId']) formattedObj['orderId'] = wei(obj['orderId'], 0);
 	if (obj['targetRoundId']) formattedObj['targetRoundId'] = wei(obj['targetRoundId'], 0);
 	if (obj['targetPrice']) formattedObj['targetPrice'] = wei(obj['targetPrice'], 0);
+	if (obj['marginDelta']) formattedObj['marginDelta'] = wei(obj['marginDelta'], 0);
 	if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
 	if (obj['orderType']) formattedObj['orderType'] = obj['orderType'];
 	if (obj['status']) formattedObj['status'] = obj['status'];
@@ -1961,6 +1971,7 @@ export const getFuturesOrders = async function <K extends keyof FuturesOrderResu
 			if (obj['orderId']) formattedObj['orderId'] = wei(obj['orderId'], 0);
 			if (obj['targetRoundId']) formattedObj['targetRoundId'] = wei(obj['targetRoundId'], 0);
 			if (obj['targetPrice']) formattedObj['targetPrice'] = wei(obj['targetPrice'], 0);
+			if (obj['marginDelta']) formattedObj['marginDelta'] = wei(obj['marginDelta'], 0);
 			if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
 			if (obj['orderType']) formattedObj['orderType'] = obj['orderType'];
 			if (obj['status']) formattedObj['status'] = obj['status'];
@@ -4045,5 +4056,5 @@ export const getTotals = async function <K extends keyof TotalResult>(
 
 // additional types
 export type FuturesAccountType = 'isolated_margin' | 'cross_margin';
-export type FuturesOrderType = 'NextPrice' | 'Limit' | 'Market' | 'Liquidation';
-export type FuturesOrderStatus = 'Pending' | 'Filled' | 'Cancelled';
+export type FuturesOrderType = 'NextPrice' | 'Limit' | 'Market' | 'Stop' | 'StopMarket';
+export type FuturesOrderStatus = 'Pending' | 'Filled' | 'Cancelled' | 'Open';

--- a/queries/futures/subgraph.ts
+++ b/queries/futures/subgraph.ts
@@ -1893,8 +1893,8 @@ export type FuturesOrderFields = {
 	targetPrice: true;
 	marginDelta: true;
 	timestamp: true;
-	orderType: FuturesOrderType;
-	status: FuturesOrderStatus;
+	orderType: true;
+	status: true;
 	keeper: true;
 };
 export type FuturesOrderArgs<K extends keyof FuturesOrderResult> = {

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -176,7 +176,7 @@ export type FuturesTradeWithPrice = {
 };
 
 // This type exists to rename enum types from the subgraph to display-friendly types
-type FuturesOrderTypeMapped = 'Next-Price' | 'Limit' | 'Stop-Market' | 'Market';
+type FuturesOrderTypeMapped = 'Next-Price' | 'Limit' | 'Stop-Market' | 'Market' | 'Liquidation';
 
 export type FuturesTrade = {
 	size: Wei;

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -175,6 +175,9 @@ export type FuturesTradeWithPrice = {
 	price: string;
 };
 
+// This type exists to rename enum types from the subgraph to display-friendly types
+type FuturesOrderTypeMapped = 'Next-Price' | 'Limit' | 'Stop-Market' | 'Market';
+
 export type FuturesTrade = {
 	size: Wei;
 	asset: string;
@@ -187,7 +190,7 @@ export type FuturesTrade = {
 	side?: PositionSide | null;
 	pnl: Wei;
 	feesPaid: Wei;
-	orderType: 'NextPrice' | 'Limit' | 'Market' | 'Liquidation';
+	orderType: FuturesOrderTypeMapped;
 };
 
 export type FuturesOrder = {
@@ -198,9 +201,10 @@ export type FuturesOrder = {
 	marketKey: FuturesMarketKey;
 	size: Wei;
 	targetPrice: Wei | null;
+	marginDelta: Wei;
 	targetRoundId: Wei | null;
 	timestamp: Wei;
-	orderType: 'NextPrice' | 'Next-Price' | 'Limit' | 'Stop';
+	orderType: FuturesOrderTypeMapped;
 	sizeTxt?: string;
 	targetPriceTxt?: string;
 	side?: PositionSide;

--- a/queries/futures/useGetFuturesOpenOrders.ts
+++ b/queries/futures/useGetFuturesOpenOrders.ts
@@ -1,31 +1,22 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
-import Wei, { wei } from '@synthetixio/wei';
-import { utils as ethersUtils } from 'ethers';
 import request, { gql } from 'graphql-request';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 
 import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
-import { openOrdersState, marketInfoState, selectedFuturesAddressState } from 'store/futures';
-import { formatCurrency, formatDollars, weiFromWei } from 'utils/formatters/number';
-import {
-	FuturesMarketAsset,
-	getDisplayAsset,
-	getMarketName,
-	MarketKeyByAsset,
-} from 'utils/futures';
+import { openOrdersState, futuresMarketsState, selectedFuturesAddressState } from 'store/futures';
 import logError from 'utils/logError';
 
-import { PositionSide, FuturesOrder } from './types';
-import { getFuturesEndpoint } from './utils';
+import { FuturesOrder } from './types';
+import { getFuturesEndpoint, mapFuturesOrders } from './utils';
 
 const useGetFuturesOpenOrders = (options?: UseQueryOptions<any>) => {
 	const selectedFuturesAddress = useRecoilValue(selectedFuturesAddressState);
 	const { network } = Connector.useContainer();
 	const futuresEndpoint = getFuturesEndpoint(network?.id as NetworkId);
 
-	const marketInfo = useRecoilValue(marketInfoState);
+	const futuresMarkets = useRecoilValue(futuresMarketsState);
 	const setOpenOrders = useSetRecoilState(openOrdersState);
 
 	return useQuery<FuturesOrder[]>(
@@ -36,57 +27,31 @@ const useGetFuturesOpenOrders = (options?: UseQueryOptions<any>) => {
 				return [];
 			}
 			try {
-				const marketAsset = marketInfo?.assetHex;
 				const response = await request(
 					futuresEndpoint,
 					gql`
-						query OpenOrders($account: String!, $asset: String!) {
-							futuresOrders(where: { abstractAccount: $account, asset: $asset, status: Pending }) {
+						query OpenOrders($account: String!) {
+							futuresOrders(where: { abstractAccount: $account, status: Pending }) {
 								id
 								account
 								size
 								market
 								asset
 								targetRoundId
+								marginDelta
 								targetPrice
 								timestamp
 								orderType
 							}
 						}
 					`,
-					{ account: selectedFuturesAddress, asset: marketAsset }
+					{ account: selectedFuturesAddress }
 				);
 
 				const openOrders: FuturesOrder[] = response
-					? response.futuresOrders.map((o: FuturesOrder) => {
-							const asset: FuturesMarketAsset = ethersUtils.parseBytes32String(
-								o.asset
-							) as FuturesMarketAsset;
-							const size = weiFromWei(o.size);
-							const targetPrice = weiFromWei(o.targetPrice ?? 0);
-							const targetRoundId = new Wei(o.targetRoundId, 0);
-							const currentRoundId = wei(marketInfo?.currentRoundId ?? 0);
-							return {
-								...o,
-								asset: asset,
-								targetRoundId: targetRoundId,
-								targetPrice: targetPrice.gt(0) ? targetPrice : null,
-								size: size,
-								market: getMarketName(asset),
-								marketKey: MarketKeyByAsset[asset],
-								orderType: o.orderType === 'NextPrice' ? 'Next-Price' : o.orderType,
-								sizeTxt: formatCurrency(asset, size.abs(), {
-									currencyKey: getDisplayAsset(asset) ?? '',
-									minDecimals: size.abs().lt(0.01) ? 4 : 2,
-								}),
-								targetPriceTxt: formatDollars(targetPrice),
-								side: size.gt(0) ? PositionSide.LONG : PositionSide.SHORT,
-								isStale:
-									o.orderType === 'NextPrice' && currentRoundId.gte(wei(o.targetRoundId).add(2)),
-								isExecutable: targetRoundId
-									? currentRoundId.eq(targetRoundId) || currentRoundId.eq(targetRoundId.add(1))
-									: false,
-							};
+					? response.futuresOrders.map((o: any) => {
+							const marketInfo = futuresMarkets.find((m) => m.asset === o.asset);
+							return mapFuturesOrders(o, marketInfo);
 					  })
 					: [];
 				setOpenOrders(openOrders);
@@ -97,7 +62,7 @@ const useGetFuturesOpenOrders = (options?: UseQueryOptions<any>) => {
 			}
 		},
 		{
-			enabled: !!marketInfo?.market && !!selectedFuturesAddress,
+			enabled: futuresMarkets.length > 0 && !!selectedFuturesAddress,
 			refetchInterval: 5000,
 			...options,
 		}

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -56,7 +56,6 @@ const FuturesHistoryTable: FC = () => {
 					pnl: trade.pnl.div(ETH_UNIT),
 					feesPaid: trade.feesPaid.div(ETH_UNIT),
 					id: trade.txnHash,
-					orderType: trade.orderType === 'NextPrice' ? 'Next Price' : trade.orderType,
 					status: trade.positionClosed ? TradeStatus.CLOSED : TradeStatus.OPEN,
 				};
 			}),

--- a/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
@@ -42,7 +42,7 @@ const TradesTab: React.FC = () => {
 			feesPaid: trade?.feesPaid.div(ETH_UNIT),
 			id: trade?.txnHash,
 			asset: marketAsset,
-			type: trade?.orderType === 'NextPrice' ? 'Next Price' : trade?.orderType,
+			type: trade?.orderType,
 			status: trade?.positionClosed ? TradeStatus.CLOSED : TradeStatus.OPEN,
 			side: trade?.side,
 		}));

--- a/sections/futures/Trades/Trades.tsx
+++ b/sections/futures/Trades/Trades.tsx
@@ -45,7 +45,7 @@ const Trades: React.FC<TradesProps> = ({ history, isLoading, isLoaded, marketAss
 				feesPaid: trade?.feesPaid.div(ETH_UNIT),
 				id: trade?.txnHash,
 				asset: marketAsset,
-				type: trade?.orderType === 'NextPrice' ? 'Next Price' : trade?.orderType,
+				type: trade?.orderType,
 				status: trade?.positionClosed ? TradeStatus.CLOSED : TradeStatus.OPEN,
 			};
 		});

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -85,7 +85,7 @@ const OpenOrdersTable: React.FC = () => {
 		async (order: FuturesOrder | undefined) => {
 			if (!order) return;
 			setCancelling(order.id);
-			if (order.orderType === 'Limit' || order.orderType === 'Stop') {
+			if (order.orderType === 'Limit' || order.orderType === 'Stop-Market') {
 				try {
 					const id = order.id.split('-')[2];
 					const tx = await crossMarginAccountContract?.cancelOrder(id);


### PR DESCRIPTION
Updates order queries to add the `marginDelta` value and rename "Stop" orders to "Stop-Market" in the queries

## Description
- Update `subgraph.ts`
- Update types to include the new `marginDelta` field
- Improve data cleaning by isolating a mapping function

## Related issue
- #1469 
