### PR TITLE
Add icons to cross margin trades

### DIFF
--- a/components/Nav/FuturesIcon.tsx
+++ b/components/Nav/FuturesIcon.tsx
@@ -17,7 +17,11 @@ export default function FuturesIcon(props: IconProps) {
 	const CrossMarginIcon = currentTheme === 'dark' ? CrossMarginIconDark : CrossMarginIconLight;
 	const IsolatedMarginIcon =
 		currentTheme === 'dark' ? IsolatedMarginIconDark : IsolatedMarginIconLight;
-	return props.type === 'cross_margin' ? <CrossMarginIcon {...props} /> : <IsolatedMarginIcon />;
+	return props.type === 'cross_margin' ? (
+		<CrossMarginIcon {...props} />
+	) : (
+		<IsolatedMarginIcon {...props} />
+	);
 }
 
 export function CrossMarginIcon() {

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -191,6 +191,7 @@ export type FuturesTrade = {
 	pnl: Wei;
 	feesPaid: Wei;
 	orderType: FuturesOrderTypeMapped;
+	accountType: FuturesAccountType;
 };
 
 export type FuturesOrder = {

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -427,10 +427,12 @@ export const mapTrades = (futuresTrades: FuturesTradeResult[]): FuturesTrade[] =
 			pnl,
 			feesPaid,
 			orderType,
+			accountType,
 		}: FuturesTradeResult) => {
 			return {
+				asset,
+				accountType,
 				size: new Wei(size, 18, true),
-				asset: asset,
 				price: new Wei(price, 18, true),
 				txnHash: id.split('-')[0].toString(),
 				timestamp: timestamp,

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -9,6 +9,7 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import Currency from 'components/Currency';
+import FuturesIcon from 'components/Nav/FuturesIcon';
 import Table, { TableNoResults } from 'components/Table';
 import PositionType from 'components/Text/PositionType';
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
@@ -119,6 +120,7 @@ const FuturesHistoryTable: FC = () => {
 												/>
 											</IconContainer>
 											<StyledText>{cellProps.row.original.market}</StyledText>
+											<StyledFuturesIcon type={cellProps.row.original.accountType} />
 										</>
 									)}
 								</SynthContainer>
@@ -241,10 +243,6 @@ const StyledTable = styled(Table)`
 `;
 
 const StyledText = styled.div`
-	display: flex;
-	align-items: center;
-	grid-column: 2;
-	grid-row: 1;
 	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
 `;
 const SynthContainer = styled.div`
@@ -263,6 +261,10 @@ const PNL = styled.div<{ negative?: boolean; normal?: boolean }>`
 			: props.negative
 			? props.theme.colors.selectedTheme.red
 			: props.theme.colors.selectedTheme.green};
+`;
+
+const StyledFuturesIcon = styled(FuturesIcon)`
+	margin-left: 5px;
 `;
 
 export default FuturesHistoryTable;

--- a/sections/homepage/ShortList/ShortList.tsx
+++ b/sections/homepage/ShortList/ShortList.tsx
@@ -442,14 +442,4 @@ const SectionFeatureTitle = styled(FeatureTitle)`
 	`}
 `;
 
-const SectionFeatureCopy = styled(FeatureCopy)`
-	margin-top: 16px;
-	text-align: center;
-	width: 500px;
-	font-size: 18px;
-	${media.lessThan('sm')`
-		width: 100vw;
-	`}
-`;
-
 export default ShortList;

--- a/sections/leaderboard/TraderHistory/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory/TraderHistory.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import Currency from 'components/Currency';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import FuturesIcon from 'components/Nav/FuturesIcon';
 import Table from 'components/Table';
 import ROUTES from 'constants/routes';
 import { FuturesAccountTypes, PositionHistory } from 'queries/futures/types';
@@ -48,23 +49,17 @@ const TraderHistory: FC<TraderHistoryProps> = ({
 			.sort((a: PositionHistory, b: PositionHistory) => b.timestamp - a.timestamp)
 			.map((stat: PositionHistory, i: number) => {
 				return {
+					...stat,
 					rank: i + 1,
 					currencyIconKey: stat.asset ? (stat.asset[0] !== 's' ? 's' : '') + stat.asset : '',
 					marketShortName: getMarketName(stat.asset),
-					openTimestamp: stat.openTimestamp,
-					asset: stat.asset,
 					status: stat.isOpen ? 'Open' : stat.isLiquidated ? 'Liquidated' : 'Closed',
-					feesPaid: stat.feesPaid,
-					netFunding: stat.netFunding,
 					pnl: stat.pnlWithFeesPaid,
 					pnlPct: `(${stat.pnlWithFeesPaid
 						.div(stat.initialMargin.add(stat.totalDeposits))
 						.mul(100)
 						.toNumber()
 						.toFixed(2)}%)`,
-					totalVolume: stat.totalVolume,
-					trades: stat.trades,
-					side: stat.side,
 				};
 			})
 			.filter((i: { marketShortName: string; status: string }) =>
@@ -131,6 +126,7 @@ const TraderHistory: FC<TraderHistoryProps> = ({
 										<CurrencyInfo>
 											<StyledCurrencyIcon currencyKey={cellProps.row.original.currencyIconKey} />
 											<StyledSubtitle>{cellProps.row.original.marketShortName}</StyledSubtitle>
+											<StyledFuturesIcon type={cellProps.row.original.accountType} />
 										</CurrencyInfo>
 									),
 									width: compact ? 40 : 100,
@@ -243,9 +239,10 @@ const TraderHistory: FC<TraderHistoryProps> = ({
 										<CurrencyInfo>
 											<StyledCurrencyIcon currencyKey={cellProps.row.original.currencyIconKey} />
 											<StyledSubtitle>{cellProps.row.original.marketShortName}</StyledSubtitle>
+											<StyledFuturesIcon type={cellProps.row.original.accountType} />
 										</CurrencyInfo>
 									),
-									width: 40,
+									width: 50,
 								},
 								{
 									Header: <TableHeader>{t('leaderboard.trader-history.table.status')}</TableHeader>,
@@ -253,7 +250,7 @@ const TraderHistory: FC<TraderHistoryProps> = ({
 									Cell: (cellProps: CellProps<any>) => {
 										return <StyledCell>{cellProps.row.original.status}</StyledCell>;
 									},
-									width: 40,
+									width: 30,
 								},
 								{
 									Header: (
@@ -384,6 +381,10 @@ const StyledValue = styled.div`
 			: props.theme.colors.selectedTheme.button.text.primary};
 	margin: 0;
 	text-align: end;
+`;
+
+const StyledFuturesIcon = styled(FuturesIcon)`
+	margin-left: 5px;
 `;
 
 export default TraderHistory;


### PR DESCRIPTION
Add icons to differentiate isolated from cross margin trades in trade history (dashboard) and leaderboard.

## Description
* Add isolated and cross margin icons on two tables

## Related issue
- #1429 
