### PR TITLE
Update order sorting

### DIFF
--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -196,7 +196,7 @@ export type FuturesTrade = {
 export type FuturesOrder = {
 	id: string;
 	account: string;
-	asset: string;
+	asset: FuturesMarketAsset;
 	market: string;
 	marketKey: FuturesMarketKey;
 	size: Wei;
@@ -210,6 +210,7 @@ export type FuturesOrder = {
 	side?: PositionSide;
 	isStale?: boolean;
 	isExecutable?: boolean;
+	isCancelling?: boolean;
 };
 
 export type FuturesVolumes = {

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -37,6 +37,7 @@ import {
 	FuturesTrade,
 	MarginTransfer,
 	FuturesMarket,
+	FuturesOrder,
 } from './types';
 
 export const getFuturesEndpoint = (networkId: NetworkId): string => {
@@ -120,7 +121,10 @@ const mapOrderType = (orderType: Partial<FuturesOrderType>) => {
 		: orderType;
 };
 
-export const mapFuturesOrders = (o: FuturesOrderResult, marketInfo: FuturesMarket | undefined) => {
+export const mapFuturesOrders = (
+	o: FuturesOrderResult,
+	marketInfo: FuturesMarket | undefined
+): FuturesOrder => {
 	const asset: FuturesMarketAsset = parseBytes32String(o.asset) as FuturesMarketAsset;
 	const size = weiFromWei(o.size);
 	const targetPrice = weiFromWei(o.targetPrice ?? 0);

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -112,12 +112,19 @@ const OpenOrdersTable: React.FC = () => {
 	}, [cancelNextPriceOrder.hash, executeNextPriceOrder.hash]);
 
 	const rowsData = useMemo(() => {
-		if (!cancelling) return openOrders;
 		const copyOrders = [...openOrders];
+		copyOrders.sort((a, b) => {
+			return b.asset === currencyKey && a.asset !== currencyKey
+				? 1
+				: b.asset === currencyKey && a.asset === currencyKey
+				? 0
+				: -1;
+		});
+		if (!cancelling) return copyOrders;
 		const cancellingIndex = copyOrders.findIndex((o) => o.id === cancelling);
 		copyOrders[cancellingIndex] = { ...copyOrders[cancellingIndex], isCancelling: true };
 		return copyOrders;
-	}, [openOrders, cancelling]);
+	}, [openOrders, currencyKey, cancelling]);
 
 	return (
 		<>

--- a/store/futures/index.ts
+++ b/store/futures/index.ts
@@ -18,6 +18,7 @@ import {
 	FuturesPositionsState,
 	PositionHistoryState,
 	FuturesAccountTypes,
+	FuturesOrder,
 } from 'queries/futures/types';
 import { FundingRateResponse } from 'queries/futures/useGetAverageFundingRateForMarkets';
 import { Price, Rates } from 'queries/rates/types';
@@ -266,7 +267,7 @@ export const leverageValueCommittedState = atom({
 	default: true,
 });
 
-export const openOrdersState = atom<any[]>({
+export const openOrdersState = atom<FuturesOrder[]>({
 	key: getFuturesKey('openOrders'),
 	default: [],
 });


### PR DESCRIPTION
Update the sorting of the orders table. This update will put orders for the selected market first, then list any other open orders.

## Description
* Update orders sorting
* Update orders type in recoil from `any` to `FuturesOrder[]`

## Related issue
- #1429 
