### PR TITLE
fix free margin

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -28,7 +28,6 @@ import {
 	FuturesTradeInputs,
 	FuturesAccountType,
 } from 'queries/futures/types';
-import useGetCrossMarginAccountOverview from 'queries/futures/useGetCrossMarginAccountOverview';
 import useGetFuturesPotentialTradeDetails from 'queries/futures/useGetFuturesPotentialTradeDetails';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import {
@@ -52,6 +51,7 @@ import {
 	orderFeeCapState,
 	isAdvancedOrderState,
 	aboveMaxLeverageState,
+	crossMarginAccountOverviewState,
 } from 'store/futures';
 import { zeroBN, floorNumber, weiToString } from 'utils/formatters/number';
 import { getDisplayAsset } from 'utils/futures';
@@ -84,7 +84,7 @@ const useFuturesData = () => {
 	const { useSynthetixTxn } = useSynthetixQueries();
 
 	const getPotentialTrade = useGetFuturesPotentialTradeDetails();
-	const crossMarginAccountOverview = useGetCrossMarginAccountOverview();
+	const crossMarginAccountOverview = useRecoilValue(crossMarginAccountOverviewState);
 	const { crossMarginAccountContract } = useCrossMarginAccountContracts();
 	const { monitorTransaction } = TransactionNotifier.useContainer();
 	const { handleRefetch, refetchUntilUpdate } = useRefetchContext();
@@ -125,10 +125,8 @@ const useFuturesData = () => {
 	]);
 
 	const crossMarginAccount = useMemo(() => {
-		return crossMarginAvailable
-			? { freeMargin: crossMarginAccountOverview.data?.freeMargin }
-			: null;
-	}, [crossMarginAccountOverview.data?.freeMargin, crossMarginAvailable]);
+		return crossMarginAvailable ? { freeMargin: crossMarginAccountOverview.freeMargin } : null;
+	}, [crossMarginAccountOverview.freeMargin, crossMarginAvailable]);
 
 	const selectedLeverage = useMemo(() => {
 		const effectiveLeverage = position?.position?.leverage.toString() || '';

--- a/queries/futures/useGetCrossMarginAccountOverview.ts
+++ b/queries/futures/useGetCrossMarginAccountOverview.ts
@@ -36,7 +36,7 @@ export default function useGetCrossMarginAccountOverview() {
 					freeMargin: zeroBN,
 					keeperEthBal: zeroBN,
 				});
-				return { freeMargin: zeroBN, keeperEthBal: zeroBN };
+				return;
 			}
 
 			try {
@@ -64,13 +64,10 @@ export default function useGetCrossMarginAccountOverview() {
 					keeperEthBal: wei(keeperEthBal),
 				});
 
-				return { freeMargin: wei(freeMargin), settings: crossMarginSettings, keeperEthBal };
+				return;
 			} catch (err) {
 				logError(err);
 			}
-		},
-		{
-			enabled: !!crossMarginAddress,
 		}
 	);
 }


### PR DESCRIPTION
Fixing a bug with the cross margin account overview on network switching. The query was not enabled when cross margin is not available, which means it was not cleared on networks without deployed contracts.

## Description
* Remove enabled parameters and make sure freeMargin is cleared on network switch
* Get the account data in useFuturesData from recoil instead of calling the query from 2 locations

## Related issue
- #1429 
