### PR TITLE
Fix queries being interrupted by Metamask error on network switch

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -318,11 +318,12 @@ export const QUERY_KEYS = {
 			currencyKey: string | null
 		) => ['futures', 'currentRoundId', networkId, walletAddress, currencyKey],
 		OverviewStats: (networkId: NetworkId) => ['futures', 'overview-stats', networkId],
-		CrossMarginAccountOverview: (networkId: NetworkId, wallet: string) => [
+		CrossMarginAccountOverview: (networkId: NetworkId, wallet: string, retryCount: number) => [
 			'futures',
 			'cross-margin-account-overview',
 			networkId,
 			wallet,
+			retryCount,
 		],
 		CrossMarginSettings: (networkId: NetworkId, settingsAddress: string) => [
 			'futures',

--- a/queries/futures/useGetCrossMarginAccountOverview.ts
+++ b/queries/futures/useGetCrossMarginAccountOverview.ts
@@ -24,11 +24,12 @@ export default function useGetCrossMarginAccountOverview() {
 		),
 		async () => {
 			if (!crossMarginAddress || !crossMarginAccountContract) {
-				setAccountOverview({
+				const overview = {
 					freeMargin: zeroBN,
 					keeperEthBal: zeroBN,
-				});
-				return;
+				};
+				setAccountOverview(overview);
+				return overview;
 			}
 
 			try {
@@ -36,13 +37,14 @@ export default function useGetCrossMarginAccountOverview() {
 					crossMarginAccountContract.freeMargin(),
 					provider.getBalance(crossMarginAddress),
 				]);
-
-				setAccountOverview({
+				const overview = {
 					freeMargin: wei(freeMargin),
 					keeperEthBal: wei(keeperEthBal),
-				});
+				};
 
-				return;
+				setAccountOverview(overview);
+
+				return overview;
 			} catch (err) {
 				logError(err);
 			}

--- a/queries/futures/useGetCrossMarginAccountOverview.ts
+++ b/queries/futures/useGetCrossMarginAccountOverview.ts
@@ -1,5 +1,6 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
 import { wei } from '@synthetixio/wei';
+import { useState } from 'react';
 import { useQuery } from 'react-query';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -16,11 +17,13 @@ export default function useGetCrossMarginAccountOverview() {
 	const setAccountOverview = useSetRecoilState(crossMarginAccountOverviewState);
 
 	const { crossMarginAccountContract } = useCrossMarginAccountContracts();
+	const [retryCount, setRetryCount] = useState(0);
 
 	return useQuery(
 		QUERY_KEYS.Futures.CrossMarginAccountOverview(
 			network.id as NetworkId,
-			crossMarginAddress || ''
+			crossMarginAddress || '',
+			retryCount
 		),
 		async () => {
 			if (!crossMarginAddress || !crossMarginAccountContract) {
@@ -37,15 +40,22 @@ export default function useGetCrossMarginAccountOverview() {
 					crossMarginAccountContract.freeMargin(),
 					provider.getBalance(crossMarginAddress),
 				]);
+
 				const overview = {
 					freeMargin: wei(freeMargin),
 					keeperEthBal: wei(keeperEthBal),
 				};
-
+				setRetryCount(0);
 				setAccountOverview(overview);
 
 				return overview;
 			} catch (err) {
+				// This a hacky workaround to deal with the delayed Metamask error
+				// which causes the logs query to fail on network switching
+				// https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1046125113
+				if (retryCount < 2) {
+					setRetryCount(retryCount + 1);
+				}
 				logError(err);
 			}
 		}

--- a/queries/futures/useQueryCrossMarginAccount.ts
+++ b/queries/futures/useQueryCrossMarginAccount.ts
@@ -1,9 +1,7 @@
-import { useCallback } from 'react';
-import { useQuery } from 'react-query';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { CROSS_MARGIN_ACCOUNT_FACTORY } from 'constants/address';
-import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
 import usePersistedRecoilState from 'hooks/usePersistedRecoilState';
 import { crossMarginAccountsState, futuresAccountState } from 'store/futures';
@@ -16,16 +14,17 @@ const SUPPORTED_NETWORKS = Object.keys(CROSS_MARGIN_ACCOUNT_FACTORY);
 
 export default function useQueryCrossMarginAccount() {
 	const { crossMarginContractFactory } = useCrossMarginAccountContracts();
-	const { network, walletAddress } = Connector.useContainer();
+	const { network, walletAddress, signer } = Connector.useContainer();
 
 	const [futuresAccount, setFuturesAccount] = useRecoilState(futuresAccountState);
 	const [storedCrossMarginAccounts, setStoredCrossMarginAccount] = usePersistedRecoilState(
 		crossMarginAccountsState
 	);
+	const [retryCount, setRetryCount] = useState(0);
 
-	const queryAccountFromLogs = useCallback(
-		async (address: string): Promise<string | null> => {
-			if (!crossMarginContractFactory) return null;
+	const handleAccountQuery = async () => {
+		const queryAccountFromLogs = async (address: string): Promise<string | null> => {
+			if (!signer || !crossMarginContractFactory) return null;
 			const accountFilter = crossMarginContractFactory.filters.NewAccount(address);
 			if (accountFilter) {
 				const logs = await crossMarginContractFactory.queryFilter(accountFilter);
@@ -34,89 +33,92 @@ export default function useQueryCrossMarginAccount() {
 				}
 			}
 			return null;
-		},
-		[crossMarginContractFactory]
-	);
+		};
 
-	return useQuery<string | null>(
-		QUERY_KEYS.Futures.CrossMarginAccount(
-			walletAddress || '',
-			crossMarginContractFactory?.address || ''
-		),
-		async () => {
-			// TODO: Improve Cross margin loading states
+		if (!SUPPORTED_NETWORKS.includes(String(network.id))) {
+			const accountState: FuturesAccountState = {
+				crossMarginAvailable: false,
+				crossMarginAddress: null,
+				walletAddress,
+				status: 'complete',
+			};
+			setFuturesAccount(accountState);
+			return null;
+		}
 
-			if (!SUPPORTED_NETWORKS.includes(String(network.id))) {
-				const accountState: FuturesAccountState = {
-					crossMarginAvailable: false,
-					crossMarginAddress: null,
-					walletAddress,
-					status: 'complete',
-				};
-				setFuturesAccount(accountState);
-				return null;
-			}
-
-			if (!crossMarginContractFactory?.address || !walletAddress) {
-				setFuturesAccount({
-					...futuresAccount,
-					status: 'idle',
-					crossMarginAddress: null,
-					crossMarginAvailable: true,
-					walletAddress,
-				});
-				return null;
-			}
-
-			const existing = crossMarginContractFactory?.address
-				? storedCrossMarginAccounts[crossMarginContractFactory?.address]?.[walletAddress]
-				: null;
-
-			if (existing) {
-				setFuturesAccount({
-					...futuresAccount,
-					status: 'complete',
-					crossMarginAddress: existing,
-					crossMarginAvailable: true,
-					walletAddress,
-				});
-				return existing;
-			}
-
+		if (!crossMarginContractFactory?.address || !walletAddress) {
 			setFuturesAccount({
 				...futuresAccount,
-				status: futuresAccount.status === 'initial-fetch' ? 'initial-fetch' : 'refetching',
+				status: 'idle',
 				crossMarginAddress: null,
 				crossMarginAvailable: true,
 				walletAddress,
 			});
+			return null;
+		}
 
-			try {
-				const crossMarginAccount = await queryAccountFromLogs(walletAddress);
+		const existing = crossMarginContractFactory?.address
+			? storedCrossMarginAccounts[crossMarginContractFactory?.address]?.[walletAddress]
+			: null;
 
-				const existingAccounts = crossMarginContractFactory
-					? storedCrossMarginAccounts[crossMarginContractFactory.address]
-					: {};
+		if (existing) {
+			setFuturesAccount({
+				...futuresAccount,
+				status: 'complete',
+				crossMarginAddress: existing,
+				crossMarginAvailable: true,
+				walletAddress,
+			});
+			return existing;
+		}
 
-				if (crossMarginAccount) {
-					setStoredCrossMarginAccount({
-						...storedCrossMarginAccounts,
-						[crossMarginContractFactory!.address]: {
-							...existingAccounts,
-							[walletAddress]: crossMarginAccount,
-						},
-					});
-				}
+		setFuturesAccount({
+			...futuresAccount,
+			status: futuresAccount.status === 'initial-fetch' ? 'initial-fetch' : 'refetching',
+			crossMarginAddress: null,
+			crossMarginAvailable: true,
+			walletAddress,
+		});
 
-				const accountState: FuturesAccountState = {
-					status: 'complete',
-					crossMarginAvailable: true,
-					crossMarginAddress: crossMarginAccount,
-					walletAddress,
-				};
-				setFuturesAccount(accountState);
-				return crossMarginAccount;
-			} catch (err) {
+		const crossMarginAccount = await queryAccountFromLogs(walletAddress);
+
+		const existingAccounts = crossMarginContractFactory
+			? storedCrossMarginAccounts[crossMarginContractFactory.address]
+			: {};
+
+		if (crossMarginAccount) {
+			setStoredCrossMarginAccount({
+				...storedCrossMarginAccounts,
+				[crossMarginContractFactory!.address]: {
+					...existingAccounts,
+					[walletAddress]: crossMarginAccount,
+				},
+			});
+		}
+
+		const accountState: FuturesAccountState = {
+			status: 'complete',
+			crossMarginAvailable: true,
+			crossMarginAddress: crossMarginAccount,
+			walletAddress,
+		};
+		setFuturesAccount(accountState);
+		return crossMarginAccount;
+	};
+
+	const queryAccount = async () => {
+		try {
+			return await handleAccountQuery();
+		} catch (err) {
+			// This a hacky workaround to deal with the delayed Metamask error
+			// which causes the logs query to fail on network switching
+			// https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1046125113
+			if (err.message.includes('underlying network changed') && retryCount < 5) {
+				setTimeout(() => {
+					setRetryCount(retryCount + 1);
+				}, 500);
+			} else {
+				setRetryCount(0);
 				logError(err);
 				setFuturesAccount({
 					...futuresAccount,
@@ -125,5 +127,19 @@ export default function useQueryCrossMarginAccount() {
 				return null;
 			}
 		}
-	);
+	};
+
+	useEffect(() => {
+		queryAccount();
+		// eslint-disable-next-line
+	}, [walletAddress, crossMarginContractFactory?.address]);
+
+	useEffect(() => {
+		if (retryCount) {
+			queryAccount();
+		}
+		// eslint-disable-next-line
+	}, [retryCount]);
+
+	return queryAccount;
 }


### PR DESCRIPTION
Because of a Metamask error that bubbles up during network switching, some contract queries get interrupted and error out causing state to fail to update. These workarounds ensure the queries will retry on failure to successfully complete the query on the next pass.