### PR TITLE
Rename `stop` to `stop-market` 

### DIFF
--- a/components/SegmentedControl/SegmentedControl.tsx
+++ b/components/SegmentedControl/SegmentedControl.tsx
@@ -43,7 +43,7 @@ const SegmentedControlContainer = styled.div<{ $length: number; styleType: Style
 	display: grid;
 	grid-template-columns: repeat(${(props) => props.$length}, 1fr);
 	box-sizing: border-box;
-	grid-gap: 14px;
+	grid-gap: 8px;
 	width: 100%;
 	height: ${(props) => (props.styleType === 'tab' ? '38px' : '24px')};
 	padding: ${(props) => (props.styleType === 'tab' ? '4px' : '0')};

--- a/constants/futures.ts
+++ b/constants/futures.ts
@@ -1,7 +1,9 @@
 import { wei } from '@synthetixio/wei';
 
-export const ISOLATED_MARGIN_ORDER_TYPES = ['market', 'next-price'];
-export const CROSS_MARGIN_ORDER_TYPES = ['market', 'limit', 'stop'];
+import { FuturesOrderType } from 'queries/futures/types';
+
+export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'next price'];
+export const CROSS_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'limit', 'stop market'];
 export const ORDER_KEEPER_ETH_DEPOSIT = wei(0.01);
 export const DEFAULT_MAX_LEVERAGE = wei(10);
 export const MAX_POSITION_BUFFER = 0.01;

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -224,7 +224,9 @@ const useFuturesData = () => {
 			]);
 
 			const currentDeposit =
-				orderType === 'limit' || orderType === 'stop' ? await getCrossMarginEthBal() : zeroBN;
+				orderType === 'limit' || orderType === 'stop market'
+					? await getCrossMarginEthBal()
+					: zeroBN;
 			const requiredDeposit = currentDeposit.lt(ORDER_KEEPER_ETH_DEPOSIT)
 				? ORDER_KEEPER_ETH_DEPOSIT.sub(currentDeposit)
 				: zeroBN;

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -204,7 +204,7 @@ const useFuturesData = () => {
 
 	const calculateCrossMarginFee = useCallback(
 		(susdSizeDelta: Wei) => {
-			if (orderType !== 'limit' && orderType !== 'stop-market') return zeroBN;
+			if (orderType !== 'limit' && orderType !== 'stop market') return zeroBN;
 			const advancedOrderFeeRate = orderType === 'limit' ? limitOrderFee : stopOrderFee;
 			return susdSizeDelta.abs().mul(advancedOrderFeeRate);
 		},
@@ -440,7 +440,7 @@ const useFuturesData = () => {
 
 	const orderTxn = useSynthetixTxn(
 		`FuturesMarket${getDisplayAsset(marketAsset)}`,
-		orderType === 'next-price' ? 'submitNextPriceOrderWithTracking' : 'modifyPositionWithTracking',
+		orderType === 'next price' ? 'submitNextPriceOrderWithTracking' : 'modifyPositionWithTracking',
 		[tradeInputs.nativeSizeDelta.toBN(), KWENTA_TRACKING_CODE],
 		{},
 		{

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -204,7 +204,7 @@ const useFuturesData = () => {
 
 	const calculateCrossMarginFee = useCallback(
 		(susdSizeDelta: Wei) => {
-			if (orderType !== 'limit' && orderType !== 'stop') return zeroBN;
+			if (orderType !== 'limit' && orderType !== 'stop-market') return zeroBN;
 			const advancedOrderFeeRate = orderType === 'limit' ? limitOrderFee : stopOrderFee;
 			return susdSizeDelta.abs().mul(advancedOrderFeeRate);
 		},

--- a/queries/futures/subgraph.ts
+++ b/queries/futures/subgraph.ts
@@ -4056,5 +4056,5 @@ export const getTotals = async function <K extends keyof TotalResult>(
 
 // additional types
 export type FuturesAccountType = 'isolated_margin' | 'cross_margin';
-export type FuturesOrderType = 'NextPrice' | 'Limit' | 'Market' | 'Stop' | 'StopMarket';
+export type FuturesOrderType = 'NextPrice' | 'Limit' | 'Market' | 'StopMarket';
 export type FuturesOrderStatus = 'Pending' | 'Filled' | 'Cancelled' | 'Open';

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -176,7 +176,12 @@ export type FuturesTradeWithPrice = {
 };
 
 // This type exists to rename enum types from the subgraph to display-friendly types
-type FuturesOrderTypeDisplay = 'Next-Price' | 'Limit' | 'Stop-Market' | 'Market' | 'Liquidation';
+export type FuturesOrderTypeDisplay =
+	| 'Next Price'
+	| 'Limit'
+	| 'Stop Market'
+	| 'Market'
+	| 'Liquidation';
 
 export type FuturesTrade = {
 	size: Wei;
@@ -328,4 +333,4 @@ export type FuturesTradeInputs = {
 	orderPrice?: Wei | undefined;
 };
 
-export type FuturesOrderType = 'market' | 'next-price' | 'stop-market' | 'limit';
+export type FuturesOrderType = 'market' | 'next price' | 'stop market' | 'limit';

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -176,7 +176,7 @@ export type FuturesTradeWithPrice = {
 };
 
 // This type exists to rename enum types from the subgraph to display-friendly types
-type FuturesOrderTypeMapped = 'Next-Price' | 'Limit' | 'Stop-Market' | 'Market' | 'Liquidation';
+type FuturesOrderTypeDisplay = 'Next-Price' | 'Limit' | 'Stop-Market' | 'Market' | 'Liquidation';
 
 export type FuturesTrade = {
 	size: Wei;
@@ -190,7 +190,7 @@ export type FuturesTrade = {
 	side?: PositionSide | null;
 	pnl: Wei;
 	feesPaid: Wei;
-	orderType: FuturesOrderTypeMapped;
+	orderType: FuturesOrderTypeDisplay;
 	accountType: FuturesAccountType;
 };
 
@@ -205,7 +205,7 @@ export type FuturesOrder = {
 	marginDelta: Wei;
 	targetRoundId: Wei | null;
 	timestamp: Wei;
-	orderType: FuturesOrderTypeMapped;
+	orderType: FuturesOrderTypeDisplay;
 	sizeTxt?: string;
 	targetPriceTxt?: string;
 	side?: PositionSide;
@@ -328,4 +328,4 @@ export type FuturesTradeInputs = {
 	orderPrice?: Wei | undefined;
 };
 
-export type FuturesOrderType = 'market' | 'next-price' | 'stop' | 'limit';
+export type FuturesOrderType = 'market' | 'next-price' | 'stop-market' | 'limit';

--- a/queries/futures/useGetCrossMarginTradePreview.ts
+++ b/queries/futures/useGetCrossMarginTradePreview.ts
@@ -8,6 +8,7 @@ import { useCallback, useMemo } from 'react';
 
 import Connector from 'containers/Connector';
 import useIsL2 from 'hooks/useIsL2';
+import FuturesMarket from 'lib/abis/FuturesMarket.json';
 import { PotentialTradeStatus } from 'sections/futures/types';
 import {
 	zeroBN,
@@ -19,7 +20,6 @@ import {
 } from 'utils/formatters/number';
 import { FuturesMarketAsset, MarketKeyByAsset } from 'utils/futures';
 import logError from 'utils/logError';
-import FuturesMarket from 'lib/abis/FuturesMarket.json';
 
 import { KWENTA_TRACKING_CODE } from './constants';
 import { getFuturesMarketContract } from './utils';

--- a/queries/futures/useGetFuturesPotentialTradeDetails.ts
+++ b/queries/futures/useGetFuturesPotentialTradeDetails.ts
@@ -49,7 +49,7 @@ const useGetFuturesPotentialTradeDetails = () => {
 				!marketAsset ||
 				(!nativeSizeDelta && selectedAccountType === 'isolated_margin') ||
 				(!nativeSizeDelta && (!positionMarginDelta || positionMarginDelta.eq(0))) ||
-				((orderType === 'limit' || orderType === 'stop') && orderPrice?.eq(0)) ||
+				((orderType === 'limit' || orderType === 'stop-market') && orderPrice?.eq(0)) ||
 				!isL2 ||
 				!selectedFuturesAddress
 			) {

--- a/queries/futures/useGetFuturesPotentialTradeDetails.ts
+++ b/queries/futures/useGetFuturesPotentialTradeDetails.ts
@@ -49,7 +49,7 @@ const useGetFuturesPotentialTradeDetails = () => {
 				!marketAsset ||
 				(!nativeSizeDelta && selectedAccountType === 'isolated_margin') ||
 				(!nativeSizeDelta && (!positionMarginDelta || positionMarginDelta.eq(0))) ||
-				((orderType === 'limit' || orderType === 'stop-market') && orderPrice?.eq(0)) ||
+				((orderType === 'limit' || orderType === 'stop market') && orderPrice?.eq(0)) ||
 				!isL2 ||
 				!selectedFuturesAddress
 			) {

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -38,6 +38,7 @@ import {
 	MarginTransfer,
 	FuturesMarket,
 	FuturesOrder,
+	FuturesOrderTypeDisplay,
 } from './types';
 
 export const getFuturesEndpoint = (networkId: NetworkId): string => {
@@ -111,11 +112,11 @@ export const mapFuturesPosition = (
 	};
 };
 
-const mapOrderType = (orderType: Partial<FuturesOrderType>) => {
+const mapOrderType = (orderType: Partial<FuturesOrderType>): FuturesOrderTypeDisplay => {
 	return orderType === 'NextPrice'
-		? 'Next-Price'
+		? 'Next Price'
 		: orderType === 'StopMarket'
-		? 'Stop-Market'
+		? 'Stop Market'
 		: orderType;
 };
 

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -114,8 +114,6 @@ export const mapFuturesPosition = (
 const mapOrderType = (orderType: Partial<FuturesOrderType>) => {
 	return orderType === 'NextPrice'
 		? 'Next-Price'
-		: orderType === 'Stop'
-		? 'Stop-Market'
 		: orderType === 'StopMarket'
 		? 'Stop-Market'
 		: orderType;

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -48,7 +48,7 @@ const FeeInfoBox: React.FC = () => {
 
 	const orderFeeRate = useMemo(
 		() =>
-			orderType === 'limit' ? limitOrderFee : orderType === 'stop-market' ? stopOrderFee : null,
+			orderType === 'limit' ? limitOrderFee : orderType === 'stop market' ? stopOrderFee : null,
 		[orderType, stopOrderFee, limitOrderFee]
 	);
 
@@ -100,7 +100,7 @@ const FeeInfoBox: React.FC = () => {
 				}),
 			},
 		};
-		if (orderType === 'limit' || orderType === 'stop-market') {
+		if (orderType === 'limit' || orderType === 'stop market') {
 			return {
 				...crossMarginFeeInfo,
 				'Keeper Deposit': {
@@ -110,7 +110,7 @@ const FeeInfoBox: React.FC = () => {
 				},
 			};
 		}
-		if (orderType === 'next-price') {
+		if (orderType === 'next price') {
 			return {
 				'Keeper Deposit': {
 					value: !!marketInfo?.keeperDeposit ? formatDollars(marketInfo.keeperDeposit) : NO_VALUE,

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -47,7 +47,8 @@ const FeeInfoBox: React.FC = () => {
 	]);
 
 	const orderFeeRate = useMemo(
-		() => (orderType === 'limit' ? limitOrderFee : orderType === 'stop' ? stopOrderFee : null),
+		() =>
+			orderType === 'limit' ? limitOrderFee : orderType === 'stop-market' ? stopOrderFee : null,
 		[orderType, stopOrderFee, limitOrderFee]
 	);
 
@@ -99,7 +100,7 @@ const FeeInfoBox: React.FC = () => {
 				}),
 			},
 		};
-		if (orderType === 'limit' || orderType === 'stop') {
+		if (orderType === 'limit' || orderType === 'stop-market') {
 			return {
 				...crossMarginFeeInfo,
 				'Keeper Deposit': {

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -124,7 +124,7 @@ const FeeInfoBox: React.FC = () => {
 					value: formatDollars(totalDeposit),
 					spaceBeneath: true,
 				},
-				'Next-Price Discount': {
+				'Next Price Discount': {
 					value: !!nextPriceDiscount ? formatDollars(nextPriceDiscount) : NO_VALUE,
 					color: nextPriceDiscount.lt(0) ? 'green' : nextPriceDiscount.gt(0) ? 'red' : undefined,
 				},

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -65,7 +65,7 @@ const LeverageInput: FC = () => {
 				</LeverageTitle>
 				{modeButton}
 			</LeverageRow>
-			{orderType === 'next-price' && isDisclaimerDisplayed && (
+			{orderType === 'next price' && isDisclaimerDisplayed && (
 				<LeverageDisclaimer>
 					{t('futures.market.trade.input.leverage.disclaimer')}
 				</LeverageDisclaimer>

--- a/sections/futures/MarketInfoBox/MarketInfoBox.tsx
+++ b/sections/futures/MarketInfoBox/MarketInfoBox.tsx
@@ -38,7 +38,7 @@ const MarketInfoBox: React.FC = () => {
 		? totalMargin.sub(availableMargin).div(totalMargin)
 		: zeroBN;
 
-	const isNextPriceOrder = orderType === 'next-price';
+	const isNextPriceOrder = orderType === 'next price';
 
 	const positionSize = position?.position?.size ? wei(position?.position?.size) : zeroBN;
 	const orderDetails = useMemo(() => {

--- a/sections/futures/OrderPriceInput/OrderPriceInput.tsx
+++ b/sections/futures/OrderPriceInput/OrderPriceInput.tsx
@@ -1,5 +1,4 @@
 import { wei } from '@synthetixio/wei';
-import { capitalize } from 'lodash';
 import { ChangeEvent, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilState, useRecoilValue } from 'recoil';

--- a/sections/futures/OrderPriceInput/OrderPriceInput.tsx
+++ b/sections/futures/OrderPriceInput/OrderPriceInput.tsx
@@ -66,7 +66,7 @@ export default function OrderPriceInput({
 	return (
 		<>
 			<StyledInputTitle margin="10px 0">
-				{capitalize(orderType)} Price{' '}
+				{orderType} Price{' '}
 				{minMaxLabelString && (
 					<>
 						&nbsp; —<span>&nbsp; {minMaxLabelString}</span>
@@ -105,6 +105,7 @@ export default function OrderPriceInput({
 }
 
 const StyledInputTitle = styled(InputTitle)`
+	text-transform: capitalize;
 	span {
 		color: ${(props) => props.theme.colors.selectedTheme.red};
 	}

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -117,7 +117,7 @@ const OrderSizing: React.FC<OrderSizingProps> = ({ disabled, isMobile }) => {
 	}, [position?.remainingMargin, disabled, selectedAccountType, freeCrossMargin]);
 
 	const showPosSizeHelper =
-		position?.position?.size && (orderType === 'limit' || orderType === 'stop');
+		position?.position?.size && (orderType === 'limit' || orderType === 'stop-market');
 
 	const invalid =
 		(assetInputType === 'usd' && usdValue !== '' && maxUsdInputAmount.lte(usdValue || 0)) ||

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -117,7 +117,7 @@ const OrderSizing: React.FC<OrderSizingProps> = ({ disabled, isMobile }) => {
 	}, [position?.remainingMargin, disabled, selectedAccountType, freeCrossMargin]);
 
 	const showPosSizeHelper =
-		position?.position?.size && (orderType === 'limit' || orderType === 'stop-market');
+		position?.position?.size && (orderType === 'limit' || orderType === 'stop market');
 
 	const invalid =
 		(assetInputType === 'usd' && usdValue !== '' && maxUsdInputAmount.lte(usdValue || 0)) ||

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -101,7 +101,7 @@ const ManagePosition: React.FC = () => {
 		);
 
 		if (!leverageValid || !!error || marketInfo?.isSuspended || isMarketCapReached) return true;
-		if ((orderType === 'limit' || orderType === 'stop') && !!invalidReason) return true;
+		if ((orderType === 'limit' || orderType === 'stop-market') && !!invalidReason) return true;
 		if (tradeInputs.susdSizeDelta.abs().gt(maxUsdInputAmount)) return true;
 		if (placeOrderTranslationKey === 'futures.market.trade.button.deposit-margin-minimum')
 			return true;

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -101,7 +101,7 @@ const ManagePosition: React.FC = () => {
 		);
 
 		if (!leverageValid || !!error || marketInfo?.isSuspended || isMarketCapReached) return true;
-		if ((orderType === 'limit' || orderType === 'stop-market') && !!invalidReason) return true;
+		if ((orderType === 'limit' || orderType === 'stop market') && !!invalidReason) return true;
 		if (tradeInputs.susdSizeDelta.abs().gt(maxUsdInputAmount)) return true;
 		if (placeOrderTranslationKey === 'futures.market.trade.button.deposit-margin-minimum')
 			return true;
@@ -154,7 +154,7 @@ const ManagePosition: React.FC = () => {
 						noOutline
 						variant="danger"
 						onClick={() => {
-							if (orderType === 'next-price' && position?.position?.size) {
+							if (orderType === 'next price' && position?.position?.size) {
 								const newTradeSize = position.position.size;
 								const newLeverageSide =
 									position.position.side === PositionSide.LONG
@@ -192,7 +192,7 @@ const ManagePosition: React.FC = () => {
 					<TradeConfirmationModalIsolatedMargin />
 				))}
 
-			{isConfirmationModalOpen && orderType === 'next-price' && <NextPriceConfirmationModal />}
+			{isConfirmationModalOpen && orderType === 'next price' && <NextPriceConfirmationModal />}
 		</>
 	);
 };

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -93,7 +93,7 @@ export default function TradeConfirmationModal({
 				value: `${formatNumber(positionDetails?.leverage ?? zeroBN)}x`,
 			},
 
-			orderType === 'limit' || orderType === 'stop-market'
+			orderType === 'limit' || orderType === 'stop market'
 				? {
 						label: orderType + ' order price',
 						value: formatDollars(orderPrice),

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -93,7 +93,7 @@ export default function TradeConfirmationModal({
 				value: `${formatNumber(positionDetails?.leverage ?? zeroBN)}x`,
 			},
 
-			orderType === 'limit' || orderType === 'stop'
+			orderType === 'limit' || orderType === 'stop-market'
 				? {
 						label: orderType + ' order price',
 						value: formatDollars(orderPrice),

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -76,11 +76,11 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 				values={ISOLATED_MARGIN_ORDER_TYPES}
 				selectedIndex={ISOLATED_MARGIN_ORDER_TYPES.indexOf(orderType)}
 				onChange={(oType: number) => {
-					setOrderType(oType === 0 ? 'market' : 'next-price');
+					setOrderType(oType === 0 ? 'market' : 'next price');
 				}}
 			/>
 
-			{orderType === 'next-price' && <NextPrice />}
+			{orderType === 'next price' && <NextPrice />}
 
 			<PositionButtons selected={leverageSide} onSelect={setLeverageSide} />
 

--- a/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
+++ b/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
@@ -107,9 +107,9 @@ function MarginInfoBox({ editingLeverage }: Props) {
 
 		return {
 			showPreview:
-				((orderType === 'market' || orderType === 'next-price') &&
+				((orderType === 'market' || orderType === 'next price') &&
 					(!size.eq(0) || !marginDelta.eq(0))) ||
-				((orderType === 'limit' || orderType === 'stop-market') && !!orderPrice && !size.eq(0)),
+				((orderType === 'limit' || orderType === 'stop market') && !!orderPrice && !size.eq(0)),
 			totalMargin: potentialTrade.data?.margin.sub(crossMarginFee) || zeroBN,
 			freeAccountMargin: crossMarginFreeMargin.sub(marginDelta),
 			availableMargin: previewAvailableMargin.gt(0) ? previewAvailableMargin : zeroBN,

--- a/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
+++ b/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
@@ -109,7 +109,7 @@ function MarginInfoBox({ editingLeverage }: Props) {
 			showPreview:
 				((orderType === 'market' || orderType === 'next-price') &&
 					(!size.eq(0) || !marginDelta.eq(0))) ||
-				((orderType === 'limit' || orderType === 'stop') && !!orderPrice && !size.eq(0)),
+				((orderType === 'limit' || orderType === 'stop-market') && !!orderPrice && !size.eq(0)),
 			totalMargin: potentialTrade.data?.margin.sub(crossMarginFee) || zeroBN,
 			freeAccountMargin: crossMarginFreeMargin.sub(marginDelta),
 			availableMargin: previewAvailableMargin.gt(0) ? previewAvailableMargin : zeroBN,

--- a/sections/futures/TradeCrossMargin/TradeCrossMargin.tsx
+++ b/sections/futures/TradeCrossMargin/TradeCrossMargin.tsx
@@ -107,9 +107,9 @@ export default function TradeCrossMargin({ isMobile }: Props) {
 							setOrderType(type as FuturesOrderType);
 							const price =
 								(type === 'limit' && leverageSide === 'long') ||
-								(type === 'stop' && leverageSide === 'short')
+								(type === 'stop market' && leverageSide === 'short')
 									? floorNumber(marketAssetRate, 0)
-									: (type === 'stop' && leverageSide === 'long') ||
+									: (type === 'stop market' && leverageSide === 'long') ||
 									  (type === 'limit' && leverageSide === 'short')
 									? ceilNumber(marketAssetRate, 0)
 									: '';

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -86,7 +86,7 @@ const OpenOrdersTable: React.FC = () => {
 		async (order: FuturesOrder | undefined) => {
 			if (!order) return;
 			setCancelling(order.id);
-			if (order.orderType === 'Limit' || order.orderType === 'Stop-Market') {
+			if (order.orderType === 'Limit' || order.orderType === 'Stop Market') {
 				try {
 					const id = order.id.split('-')[2];
 					const tx = await crossMarginAccountContract?.cancelOrder(id);

--- a/store/futures/index.ts
+++ b/store/futures/index.ts
@@ -232,7 +232,7 @@ export const isAdvancedOrderState = selector({
 	key: getFuturesKey('isAdvancedOrder'),
 	get: ({ get }) => {
 		const orderType = get(orderTypeState);
-		return orderType === 'limit' || orderType === 'stop';
+		return orderType === 'limit' || orderType === 'stop-market';
 	},
 });
 
@@ -442,7 +442,7 @@ export const placeOrderTranslationKeyState = selector({
 
 		if (orderType === 'next-price') return 'futures.market.trade.button.place-next-price-order';
 		if (orderType === 'limit') return 'futures.market.trade.button.place-limit-order';
-		if (orderType === 'stop') return 'futures.market.trade.button.place-stop-order';
+		if (orderType === 'stop-market') return 'futures.market.trade.button.place-stop-order';
 		if (!!position?.position) return 'futures.market.trade.button.modify-position';
 		return remainingMargin.lt('50')
 			? 'futures.market.trade.button.deposit-margin-minimum'

--- a/store/futures/index.ts
+++ b/store/futures/index.ts
@@ -232,7 +232,7 @@ export const isAdvancedOrderState = selector({
 	key: getFuturesKey('isAdvancedOrder'),
 	get: ({ get }) => {
 		const orderType = get(orderTypeState);
-		return orderType === 'limit' || orderType === 'stop-market';
+		return orderType === 'limit' || orderType === 'stop market';
 	},
 });
 
@@ -306,7 +306,7 @@ export const maxLeverageState = selector({
 		const positionSide = position?.position?.side;
 		const marketMaxLeverage = market?.maxLeverage ?? DEFAULT_MAX_LEVERAGE;
 		const adjustedMaxLeverage =
-			orderType === 'next-price'
+			orderType === 'next price'
 				? marketMaxLeverage.mul(DEFAULT_NP_LEVERAGE_ADJUSTMENT)
 				: marketMaxLeverage;
 
@@ -440,9 +440,9 @@ export const placeOrderTranslationKeyState = selector({
 			remainingMargin = positionMargin.add(freeMargin);
 		}
 
-		if (orderType === 'next-price') return 'futures.market.trade.button.place-next-price-order';
+		if (orderType === 'next price') return 'futures.market.trade.button.place-next-price-order';
 		if (orderType === 'limit') return 'futures.market.trade.button.place-limit-order';
-		if (orderType === 'stop-market') return 'futures.market.trade.button.place-stop-order';
+		if (orderType === 'stop market') return 'futures.market.trade.button.place-stop-order';
 		if (!!position?.position) return 'futures.market.trade.button.modify-position';
 		return remainingMargin.lt('50')
 			? 'futures.market.trade.button.deposit-margin-minimum'

--- a/translations/en.json
+++ b/translations/en.json
@@ -647,9 +647,9 @@
 					"modify-position": "modify",
 					"deposit-margin-minimum": "Deposit Margin",
 					"oi-caps-reached": "Open Interest Cap Reached",
-					"place-next-price-order": "Place Next-Price Order",
+					"place-next-price-order": "Place Next Price Order",
 					"place-limit-order": "Place Limit Order",
-					"place-stop-order": "Place Stop Order",
+					"place-stop-order": "Place Stop Market Order",
 					"connect-wallet": "Connect Wallet"
 				},
 				"margin": {
@@ -684,7 +684,7 @@
 					}
 				},
 				"next-price": {
-					"description": "Next-Price orders are subject to volatility and execute at the very next on-chain price.",
+					"description": "Next Price orders are subject to volatility and execute at the very next on-chain price.",
 					"learn-more": "Learn more"
 				},
 				"cost-basis": {
@@ -775,9 +775,9 @@
 						"gas-fee": "Network Gas Fee",
 						"order-type": "Order Type",
 						"market-order": "Market",
-						"next-price-order": "Next-Price",
+						"next-price-order": "Next Price",
 						"deposit": "Total Deposit",
-						"np-discount": "Next-Price Discount"
+						"np-discount": "Next Price Discount"
 					}
 				},
 				"open-orders": {

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -282,12 +282,12 @@ export const orderPriceInvalidLabel = (
 	if (!orderPrice || Number(orderPrice) <= 0) return null;
 	const isLong = leverageSide === 'long';
 	if (
-		((isLong && orderType === 'limit') || (!isLong && orderType === 'stop')) &&
+		((isLong && orderType === 'limit') || (!isLong && orderType === 'stop-market')) &&
 		wei(orderPrice).gt(currentPrice)
 	)
 		return 'max ' + formatNumber(currentPrice);
 	if (
-		((!isLong && orderType === 'limit') || (isLong && orderType === 'stop')) &&
+		((!isLong && orderType === 'limit') || (isLong && orderType === 'stop-market')) &&
 		wei(orderPrice).lt(currentPrice)
 	)
 		return 'min ' + formatNumber(currentPrice);

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -282,12 +282,12 @@ export const orderPriceInvalidLabel = (
 	if (!orderPrice || Number(orderPrice) <= 0) return null;
 	const isLong = leverageSide === 'long';
 	if (
-		((isLong && orderType === 'limit') || (!isLong && orderType === 'stop-market')) &&
+		((isLong && orderType === 'limit') || (!isLong && orderType === 'stop market')) &&
 		wei(orderPrice).gt(currentPrice)
 	)
 		return 'max ' + formatNumber(currentPrice);
 	if (
-		((!isLong && orderType === 'limit') || (isLong && orderType === 'stop-market')) &&
+		((!isLong && orderType === 'limit') || (isLong && orderType === 'stop market')) &&
 		wei(orderPrice).lt(currentPrice)
 	)
 		return 'min ' + formatNumber(currentPrice);


### PR DESCRIPTION
These changes do not impact any frontend interactions. These are simple changes to align types better and set us up for futures flexibility with orders.

## Description
* Clearly define _subgraph_ order type from _frontend_ order type. They are distinct since the subgraph includes liquidations.
* Remove unused `Stop` order type from subgraph
* Rename frontend `stop` order type to `stop-market` everywhere

## Related issue
* #1489 
* #1497 