### PR TITLE
Cross margin: Market key bug

### DIFF
--- a/queries/futures/useGetCrossMarginTradePreview.ts
+++ b/queries/futures/useGetCrossMarginTradePreview.ts
@@ -8,6 +8,7 @@ import { useCallback, useMemo } from 'react';
 
 import Connector from 'containers/Connector';
 import useIsL2 from 'hooks/useIsL2';
+import FuturesMarket from 'lib/abis/FuturesMarket.json';
 import { PotentialTradeStatus } from 'sections/futures/types';
 import {
 	zeroBN,
@@ -19,7 +20,6 @@ import {
 } from 'utils/formatters/number';
 import { FuturesMarketAsset, MarketKeyByAsset } from 'utils/futures';
 import logError from 'utils/logError';
-import FuturesMarket from 'lib/abis/FuturesMarket.json';
 
 import { KWENTA_TRACKING_CODE } from './constants';
 import { getFuturesMarketContract } from './utils';

--- a/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
+++ b/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
@@ -12,11 +12,11 @@ import useEstimateGasCost from 'hooks/useEstimateGasCost';
 import { currentMarketState, positionState } from 'store/futures';
 import { isUserDeniedError } from 'utils/formatters/error';
 import { zeroBN } from 'utils/formatters/number';
+import { MarketKeyByAsset } from 'utils/futures';
 import logError from 'utils/logError';
 
 import { PositionSide } from '../types';
 import ClosePositionModal from './ClosePositionModal';
-import { MarketKeyByAsset } from 'utils/futures';
 
 type Props = {
 	onDismiss: () => void;

--- a/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
+++ b/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
@@ -16,6 +16,7 @@ import logError from 'utils/logError';
 
 import { PositionSide } from '../types';
 import ClosePositionModal from './ClosePositionModal';
+import { MarketKeyByAsset } from 'utils/futures';
 
 type Props = {
 	onDismiss: () => void;
@@ -40,7 +41,7 @@ export default function ClosePositionModalCrossMargin({ onDismiss }: Props) {
 
 	const crossMarginCloseParams = useMemo(() => {
 		return {
-			marketKey: formatBytes32String(currencyKey),
+			marketKey: formatBytes32String(MarketKeyByAsset[currencyKey]),
 			marginDelta: zeroBN.toBN(),
 			sizeDelta:
 				position?.position?.side === PositionSide.LONG


### PR DESCRIPTION
Fixing a bug where one market asset -> key conversion was missed on closing cross margin positions.