### PR TITLE
Fix market links not including accountType

### DIFF
--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -12,6 +12,7 @@ import Currency from 'components/Currency';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import Table from 'components/Table';
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
+import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
 import { FundingRateResponse } from 'queries/futures/useGetAverageFundingRateForMarkets';
 import {
@@ -19,6 +20,7 @@ import {
 	pastRatesState,
 	fundingRatesState,
 	futuresVolumesState,
+	futuresAccountTypeState,
 } from 'store/futures';
 import {
 	getSynthDescription,
@@ -36,6 +38,7 @@ const FuturesMarketsTable: FC = () => {
 	const fundingRates = useRecoilValue(fundingRatesState);
 	const pastRates = useRecoilValue(pastRatesState);
 	const futuresVolumes = useRecoilValue(futuresVolumesState);
+	const accountType = useRecoilValue(futuresAccountTypeState);
 
 	let data = useMemo(() => {
 		return futuresMarkets.map((market) => {
@@ -75,7 +78,7 @@ const FuturesMarketsTable: FC = () => {
 						data={data}
 						showPagination
 						onTableRowClick={(row) => {
-							router.push(`/market/?asset=${row.original.asset}`);
+							router.push(ROUTES.Markets.MarketPair(row.original.asset, accountType));
 						}}
 						highlightRowsOnHover
 						sortBy={[{ id: 'dailyVolume', desc: true }]}
@@ -269,7 +272,7 @@ const FuturesMarketsTable: FC = () => {
 					data={data}
 					showPagination
 					onTableRowClick={(row) => {
-						router.push(`/market/?asset=${row.original.asset}`);
+						router.push(ROUTES.Markets.MarketPair(row.original.asset, accountType));
 					}}
 					columns={[
 						{

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -281,7 +281,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 					) : (
 						data.map((row) => (
 							<MobilePositionRow
-								onClick={() => router.push(`/market/?asset=${row.market?.asset}`)}
+								onClick={() =>
+									router.push(ROUTES.Markets.MarketPair(row.market?.asset ?? 'sETH', accountType))
+								}
 								key={row.market?.asset}
 								row={row}
 							/>

--- a/sections/shared/Layout/AppLayout/Header/BalanceActions.tsx
+++ b/sections/shared/Layout/AppLayout/Header/BalanceActions.tsx
@@ -45,7 +45,7 @@ const BalanceActions: FC = () => {
 				marketRemainingMargin: formatDollars(position.remainingMargin),
 				onClick: () => {
 					setFuturesAccountType(accountType);
-					return router.push(`/market/?asset=${position.asset}&account_type=${accountType}`);
+					return router.push(`/market/?asset=${position.asset}&accountType=${accountType}`);
 				},
 			};
 		},

--- a/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileSubMenu.tsx
+++ b/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileSubMenu.tsx
@@ -6,14 +6,14 @@ import styled, { css } from 'styled-components';
 
 import ChevronDown from 'assets/svg/app/chevron-down.svg';
 import ChevronUp from 'assets/svg/app/chevron-up.svg';
+import Badge from 'components/Badge';
 import ROUTES from 'constants/routes';
 import { currentThemeState } from 'store/ui';
+import { FlexDivRow } from 'styles/common';
 import { ThemeName } from 'styles/theme';
 
 import { SubMenuLink } from '../constants';
 import { MenuButton } from './common';
-import Badge from 'components/Badge';
-import { FlexDivRow } from 'styles/common';
 
 type MobileSubMenuOption = {
 	label: string;


### PR DESCRIPTION
When clicking a link from the markets list on the dashboard it should include the margin account type.