### PR TITLE
Add check for existing account during cross margin onboarding

### DIFF
--- a/queries/futures/useQueryCrossMarginAccount.ts
+++ b/queries/futures/useQueryCrossMarginAccount.ts
@@ -110,7 +110,7 @@ export default function useQueryCrossMarginAccount() {
 		try {
 			return await handleAccountQuery();
 		} catch (err) {
-			// This a hacky workaround to deal with the delayed Metamask error
+			// This is a hacky workaround to deal with the delayed Metamask error
 			// which causes the logs query to fail on network switching
 			// https://github.com/MetaMask/metamask-extension/issues/13375#issuecomment-1046125113
 			if (err.message.includes('underlying network changed') && retryCount < 5) {

--- a/sections/futures/CrossMarginOnboard/CrossMarginOnboard.tsx
+++ b/sections/futures/CrossMarginOnboard/CrossMarginOnboard.tsx
@@ -20,8 +20,10 @@ import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRefetchContext } from 'contexts/RefetchContext';
 import useCrossMarginAccountContracts from 'hooks/useCrossMarginContracts';
 import useSUSDContract from 'hooks/useSUSDContract';
+import useQueryCrossMarginAccount from 'queries/futures/useQueryCrossMarginAccount';
 import { balancesState, futuresAccountState } from 'store/futures';
 import { FlexDivRowCentered } from 'styles/common';
+import { isUserDeniedError } from 'utils/formatters/error';
 import { zeroBN } from 'utils/formatters/number';
 import logError from 'utils/logError';
 
@@ -44,6 +46,7 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 	} = useCrossMarginAccountContracts();
 	const susdContract = useSUSDContract();
 	const { handleRefetch, refetchUntilUpdate } = useRefetchContext();
+	const queryCrossMarginAccount = useQueryCrossMarginAccount();
 
 	const futuresAccount = useRecoilValue(futuresAccountState);
 	const balances = useRecoilValue(balancesState);
@@ -52,6 +55,7 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 	const [depositComplete, setDepositComplete] = useState(false);
 	const [submitting, setSubmitting] = useState<null | 'approve' | 'create' | 'deposit'>(null);
 	const [allowance, setAllowance] = useState(zeroBN);
+	const [error, setError] = useState<string | null>(null);
 
 	const susdBal = balances?.susdWalletBalance;
 
@@ -76,6 +80,7 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 	}, [crossMarginAccountContract?.address, walletAddress]);
 
 	const createAccount = useCallback(async () => {
+		setError(null);
 		try {
 			if (!synthetixjs || !crossMarginContractFactory) throw new Error('Signer or snx lib missing');
 
@@ -83,6 +88,13 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 				CROSS_MARGIN_BASE_SETTINGS[String(network?.id as NetworkId)];
 
 			if (!crossMarginSettingsAddress) throw new Error('Unsupported network');
+			const existing = await queryCrossMarginAccount();
+			if (existing) {
+				// This is a safety measure in the case a user gets
+				// into this flow when they already have an account
+				setSubmitting(null);
+				return;
+			}
 
 			setSubmitting('create');
 			const tx = await crossMarginContractFactory.newAccount();
@@ -97,8 +109,11 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 				},
 			});
 		} catch (err) {
+			if (!isUserDeniedError(err.message)) {
+				setError('Failed to create account');
+				logError(err);
+			}
 			setSubmitting(null);
-			logError(err);
 		}
 	}, [
 		synthetixjs,
@@ -107,6 +122,7 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 		setSubmitting,
 		monitorTransaction,
 		refetchUntilUpdate,
+		queryCrossMarginAccount,
 	]);
 
 	const submitDeposit = useCallback(
@@ -277,6 +293,7 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 	return (
 		<StyledBaseModal onDismiss={onClose} isOpen={isOpen} title={t('futures.modals.onboard.title')}>
 			{renderContent()}
+			{error && <ErrorView message={error} containerStyle={{ marginTop: '20px' }} />}
 		</StyledBaseModal>
 	);
 }


### PR DESCRIPTION
There was a user that managed to remain in the onboarding state once they created an account, this could potentially be to do with the logs query failing. These changes ensure if a user does get into that state that they will not be able to create another account, as an existing account will always be queried before submitting to create a new one. If the logs query fails it will error and if the query succeeds with an account the state will be updated and move the user to the next step.