### PR TITLE
Position HIstory: Add limit and sort

### DIFF
--- a/queries/futures/useGetFuturesPositionHistoryForAccount.ts
+++ b/queries/futures/useGetFuturesPositionHistoryForAccount.ts
@@ -32,6 +32,9 @@ const useGetFuturesPositionHistoryForAccount = (
 						where: {
 							account: account,
 						},
+						first: 99999,
+						orderBy: 'openTimestamp',
+						orderDirection: 'desc',
 					},
 					{
 						id: true,


### PR DESCRIPTION
Add a limit and sorting to the position history query to ensure we get the most recent positions. This corrects a bug where "Avg Entry" and "Realized Pnl" and missing data on the position card for open positions.
