### PR TITLE
CM onboarding modal step 3 improvements

### DIFF
--- a/components/Input/InputBalanceLabel.tsx
+++ b/components/Input/InputBalanceLabel.tsx
@@ -8,9 +8,10 @@ import { formatCurrency } from 'utils/formatters/number';
 type Props = {
 	balance: Wei;
 	currencyKey: string;
+	onSetAmount: (amount: string) => void;
 };
 
-export default function InputBalanceLabel({ balance, currencyKey }: Props) {
+export default function InputBalanceLabel({ balance, currencyKey, onSetAmount }: Props) {
 	const { t } = useTranslation();
 
 	const key = currencyKey.toLowerCase();
@@ -18,7 +19,7 @@ export default function InputBalanceLabel({ balance, currencyKey }: Props) {
 	return (
 		<BalanceContainer>
 			<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
-			<BalanceText>
+			<BalanceButton as="button" onClick={() => onSetAmount(balance.toString())}>
 				<span>
 					{formatCurrency(currencyKey, balance, {
 						sign: isUsd ? '$' : '',
@@ -26,7 +27,7 @@ export default function InputBalanceLabel({ balance, currencyKey }: Props) {
 					})}
 				</span>{' '}
 				{currencyKey}
-			</BalanceText>
+			</BalanceButton>
 		</BalanceContainer>
 	);
 }
@@ -42,5 +43,17 @@ export const BalanceText = styled.p`
 	color: ${(props) => props.theme.colors.selectedTheme.gray};
 	span {
 		color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	}
+`;
+
+export const BalanceButton = styled(BalanceText)`
+	padding: 0;
+	font-size: 12px;
+	line-height: 11px;
+	background-color: transparent;
+	border: none;
+	cursor: pointer;
+	&:hover {
+		text-decoration: underline;
 	}
 `;

--- a/constants/futures.ts
+++ b/constants/futures.ts
@@ -7,3 +7,4 @@ export const CROSS_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'limit', 
 export const ORDER_KEEPER_ETH_DEPOSIT = wei(0.01);
 export const DEFAULT_MAX_LEVERAGE = wei(10);
 export const MAX_POSITION_BUFFER = 0.01;
+export const MIN_MARGIN_AMOUNT = wei(50);

--- a/sections/futures/CrossMarginOnboard/CrossMarginOnboard.tsx
+++ b/sections/futures/CrossMarginOnboard/CrossMarginOnboard.tsx
@@ -1,7 +1,7 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
 import { wei } from '@synthetixio/wei';
 import { constants } from 'ethers';
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
@@ -15,6 +15,7 @@ import NumericInput from 'components/Input/NumericInput';
 import Loader from 'components/Loader';
 import ProgressSteps from 'components/ProgressSteps';
 import { CROSS_MARGIN_BASE_SETTINGS } from 'constants/address';
+import { MIN_MARGIN_AMOUNT } from 'constants/futures';
 import Connector from 'containers/Connector';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRefetchContext } from 'contexts/RefetchContext';
@@ -58,6 +59,12 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 	const [error, setError] = useState<string | null>(null);
 
 	const susdBal = balances?.susdWalletBalance;
+
+	const isDepositDisabled = useMemo(() => {
+		if (!depositAmount) return true;
+
+		return wei(depositAmount).lt(MIN_MARGIN_AMOUNT);
+	}, [depositAmount]);
 
 	const fetchAllowance = useCallback(async () => {
 		if (!crossMarginAccountContract || !susdContract || !walletAddress) return;
@@ -265,10 +272,24 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 			return (
 				<>
 					<Intro>{t('futures.modals.onboard.step3-intro')}</Intro>
-					<InputBalanceLabel balance={susdBal || zeroBN} currencyKey="sUSD" />
+					<InputBalanceLabel
+						balance={susdBal || zeroBN}
+						currencyKey="sUSD"
+						onSetAmount={setDepositAmount}
+					/>
 					<NumericInput placeholder="0.00" value={depositAmount} onChange={onEditAmount} />
 					{renderProgress(3)}
-					<StyledButton variant="flat" onClick={depositToAccount}>
+					{isDepositDisabled && (
+						<MinimumAmountDisclaimer>
+							{t('futures.market.trade.margin.modal.deposit.disclaimer')}
+						</MinimumAmountDisclaimer>
+					)}
+					<StyledButton
+						disabled={isDepositDisabled}
+						variant="flat"
+						textTransform="none"
+						onClick={depositToAccount}
+					>
 						{submitting === 'deposit' ? <Loader /> : 'Deposit sUSD'}
 					</StyledButton>
 				</>
@@ -348,4 +369,11 @@ const Complete = styled.div`
 
 const LoaderContainer = styled.div`
 	height: 120px;
+`;
+
+const MinimumAmountDisclaimer = styled.div`
+	font-size: 12px;
+	margin: 20px 0 0;
+	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	text-align: center;
 `;

--- a/sections/futures/Trade/DepositMarginModal.tsx
+++ b/sections/futures/Trade/DepositMarginModal.tsx
@@ -9,6 +9,7 @@ import BaseModal from 'components/BaseModal';
 import Button from 'components/Button';
 import Error from 'components/Error';
 import CustomInput from 'components/Input/CustomInput';
+import { MIN_MARGIN_AMOUNT } from 'constants/futures';
 import { NO_VALUE } from 'constants/placeholder';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRefetchContext } from 'contexts/RefetchContext';
@@ -25,7 +26,6 @@ type DepositMarginModalProps = {
 };
 
 const PLACEHOLDER = '$0.00';
-const MIN_MARGIN_AMOUNT = wei('50');
 
 const DepositMarginModal: React.FC<DepositMarginModalProps> = ({ onDismiss, sUSDBalance }) => {
 	const { t } = useTranslation();

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import Wei, { wei } from '@synthetixio/wei';
+import Wei from '@synthetixio/wei';
 import { capitalize } from 'lodash';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +9,7 @@ import BaseModal from 'components/BaseModal';
 import Button from 'components/Button';
 import ErrorView from 'components/Error';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import { MIN_MARGIN_AMOUNT } from 'constants/futures';
 import {
 	currentMarketState,
 	futuresOrderPriceState,
@@ -129,7 +130,7 @@ export default function TradeConfirmationModal({
 	);
 
 	const disabledReason = useMemo(() => {
-		if (positionDetails?.margin.lt(wei(50)))
+		if (positionDetails?.margin.lt(MIN_MARGIN_AMOUNT))
 			return t('futures.market.trade.confirmation.modal.disabled-min-margin');
 	}, [positionDetails?.margin, t]);
 

--- a/sections/futures/TradeCrossMargin/DepositWithdrawCrossMargin.tsx
+++ b/sections/futures/TradeCrossMargin/DepositWithdrawCrossMargin.tsx
@@ -11,6 +11,7 @@ import ErrorView from 'components/Error';
 import CustomInput from 'components/Input/CustomInput';
 import Loader from 'components/Loader';
 import SegmentedControl from 'components/SegmentedControl';
+import { MIN_MARGIN_AMOUNT } from 'constants/futures';
 import Connector from 'containers/Connector';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRefetchContext } from 'contexts/RefetchContext';
@@ -28,7 +29,6 @@ type DepositMarginModalProps = {
 };
 
 const PLACEHOLDER = '$0.00';
-const MIN_DEPOSIT_AMOUNT = wei('50');
 
 export default function DepositWithdrawCrossMargin({
 	defaultTab = 'deposit',
@@ -156,7 +156,7 @@ export default function DepositWithdrawCrossMargin({
 		const amtWei = wei(amount || 0);
 		if (transferType === 0) {
 			const total = wei(freeMargin).add(amtWei);
-			if (total.lt(MIN_DEPOSIT_AMOUNT))
+			if (total.lt(MIN_MARGIN_AMOUNT))
 				return t('futures.market.trade.margin.modal.deposit.min-deposit');
 			if (amtWei.gt(susdBal)) return t('futures.market.trade.margin.modal.deposit.exceeds-balance');
 		} else {


### PR DESCRIPTION
- Adds the ability to set the deposit amount to the maximum sUSD balance available by clicking on the displayed balance.
- Disables the "Deposit sUSD" button and shows a warning message when the amount being deposited is less than 50 sUSD
- Fixes the capitalization on the deposit button text from "SUSD" -> "sUSD"

Also includes a minor refactor to extract the `wei(50)` minimum margin amount to a shared constant since it was being defined in a few places. Always happy to revert that if it isn't desired or if there are any concerns about sharing this value across isolated and cross-margin code, however!

## Related issue
https://github.com/Kwenta/kwenta/issues/1509

## How Has This Been Tested?
Tested locally against Optimism Goerli

## Screenshots (if appropriate):
