### PR TITLE
Fix error when increasing short position size

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -267,7 +267,7 @@ const useFuturesData = () => {
 		async (nextTrade: FuturesTradeInputs, fees: TradeFees) => {
 			if (nextTrade.nativeSizeDelta.add(position?.position?.size || 0).eq(zeroBN)) return zeroBN;
 			const currentSize = position?.position?.notionalValue || zeroBN;
-			const newNotionalValue = currentSize.add(nextTrade.susdSizeDelta);
+			const newNotionalValue = currentSize.add(nextTrade.susdSizeDelta.abs());
 			const fullMargin = newNotionalValue.abs().div(nextTrade.leverage);
 
 			let marginDelta = fullMargin.sub(position?.remainingMargin || '0').add(fees.total);


### PR DESCRIPTION
## Description
Fixes an issue with incorrect margin delta calculation when trying to increase an existing short position in cross margin.

### Steps to reproduce:
Open a short position then try and increase that position, you will get strange results in the trade preview or the preview might fail.