### PR TITLE
Fix margin calculation and add tests

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -22,12 +22,7 @@ import Connector from 'containers/Connector';
 import TransactionNotifier from 'containers/TransactionNotifier';
 import { useRefetchContext } from 'contexts/RefetchContext';
 import { KWENTA_TRACKING_CODE, ORDER_PREVIEW_ERRORS } from 'queries/futures/constants';
-import {
-	PositionSide,
-	TradeFees,
-	FuturesTradeInputs,
-	FuturesAccountType,
-} from 'queries/futures/types';
+import { PositionSide, FuturesTradeInputs, FuturesAccountType } from 'queries/futures/types';
 import useGetFuturesPotentialTradeDetails from 'queries/futures/useGetFuturesPotentialTradeDetails';
 import { getFuturesMarketContract } from 'queries/futures/utils';
 import {
@@ -54,7 +49,7 @@ import {
 	crossMarginAccountOverviewState,
 } from 'store/futures';
 import { zeroBN, floorNumber, weiToString } from 'utils/formatters/number';
-import { getDisplayAsset, MarketKeyByAsset } from 'utils/futures';
+import { calculateMarginDelta, getDisplayAsset, MarketKeyByAsset } from 'utils/futures';
 import logError from 'utils/logError';
 
 import useCrossMarginAccountContracts from './useCrossMarginContracts';
@@ -263,19 +258,6 @@ const useFuturesData = () => {
 		]
 	);
 
-	const calculateMarginDelta = useCallback(
-		async (nextTrade: FuturesTradeInputs, fees: TradeFees) => {
-			if (nextTrade.nativeSizeDelta.add(position?.position?.size || 0).eq(zeroBN)) return zeroBN;
-			const currentSize = position?.position?.notionalValue || zeroBN;
-			const newNotionalValue = currentSize.add(nextTrade.susdSizeDelta.abs());
-			const fullMargin = newNotionalValue.abs().div(nextTrade.leverage);
-
-			let marginDelta = fullMargin.sub(position?.remainingMargin || '0').add(fees.total);
-			return marginDelta;
-		},
-		[position?.position?.notionalValue, position?.position?.size, position?.remainingMargin]
-	);
-
 	// eslint-disable-next-line
 	const debounceFetchPreview = useCallback(
 		debounce(async (nextTrade: FuturesTradeInputs, fromLeverage = false) => {
@@ -286,7 +268,7 @@ const useFuturesData = () => {
 				if (selectedAccountType === 'cross_margin') {
 					nextMarginDelta =
 						nextTrade.nativeSizeDelta.abs().gt(0) || fromLeverage
-							? await calculateMarginDelta(nextTrade, fees)
+							? await calculateMarginDelta(nextTrade, fees, position)
 							: zeroBN;
 					setCrossMarginMarginDelta(nextMarginDelta);
 				}
@@ -311,6 +293,7 @@ const useFuturesData = () => {
 			calculateFees,
 			getPotentialTrade,
 			calculateMarginDelta,
+			position,
 			orderPrice,
 			orderType,
 			selectedAccountType,

--- a/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
+++ b/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
@@ -187,7 +187,10 @@ function MarginInfoBox({ editingLeverage }: Props) {
 								valueNode: (
 									<>
 										{keeperEthBal.gt(0) && (
-											<ActionButton onClick={() => setOpenModal('keeper-deposit')}>
+											<ActionButton
+												padding={'4px 3px 1px 3px'}
+												onClick={() => setOpenModal('keeper-deposit')}
+											>
 												<WithdrawArrow
 													width="12px"
 													height="9px"
@@ -263,17 +266,16 @@ const Button = styled.span`
 	}
 `;
 
-const ActionButton = styled(Button)<{ hideBorder?: boolean }>`
+const ActionButton = styled(Button)<{ padding?: string }>`
 	margin-left: 8px;
 	cursor: pointer;
 	font-size: 10px;
 	font-family: ${(props) => props.theme.fonts.black};
 	font-variant: all-small-caps;
-	border: 1px solid
-		${(props) => (!props.hideBorder ? props.theme.colors.selectedTheme.yellow : 'none')};
+	border: 1px solid ${(props) => props.theme.colors.selectedTheme.yellow};
 	color: ${(props) => props.theme.colors.selectedTheme.button.pill.background};
 	border-radius: 10px;
-	padding: ${(props) => (props.hideBorder ? '3px 2px 3px 0px' : '3px 5px')};
+	padding: ${(props) => props.padding ?? '3px 5px'};
 	&:hover {
 		background-color: ${(props) => props.theme.colors.selectedTheme.button.pill.background};
 		color: ${(props) => props.theme.colors.selectedTheme.button.pill.hover};

--- a/utils/__tests__/futures.test.ts
+++ b/utils/__tests__/futures.test.ts
@@ -1,0 +1,83 @@
+import { wei } from '@synthetixio/wei';
+
+import { PositionSide } from 'sections/futures/types';
+import { calculateMarginDelta, FuturesMarketAsset } from 'utils/futures';
+
+const ETH_PRICE = 1500;
+
+const getPosition = (initialSize: number = 1, leverage = 10, side = 'long') => ({
+	asset: 'sETH' as FuturesMarketAsset,
+	order: null,
+	remainingMargin: wei((initialSize * ETH_PRICE) / leverage),
+	accessibleMargin: wei(250),
+	position: {
+		canLiquidatePosition: false,
+		side: side as PositionSide,
+		notionalValue: wei(initialSize * ETH_PRICE),
+		accruedFunding: wei(1),
+		initialMargin: wei(initialSize * ETH_PRICE * leverage),
+		profitLoss: wei(10),
+		fundingIndex: 100,
+		lastPrice: wei(ETH_PRICE),
+		size: wei(initialSize),
+		liquidationPrice: wei(ETH_PRICE * 0.6),
+		initialLeverage: wei(leverage),
+		leverage: wei(leverage),
+		pnl: wei(10),
+		pnlPct: wei(10),
+		marginRatio: wei(0.2),
+	},
+});
+
+const getFees = (overrides: Record<string, any> = {}) => ({
+	staticFee: wei(0.01),
+	dynamicFeeRate: wei(0.01),
+	crossMarginFee: wei(5),
+	keeperEthDeposit: wei(0.01),
+	limitStopOrderFee: wei(5),
+	total: wei(10),
+	...overrides,
+});
+
+const getTrade = (sizeDelta: number = 1, leverage = 10) => ({
+	nativeSize: Math.abs(sizeDelta).toString(),
+	susdSize: (Math.abs(sizeDelta) * ETH_PRICE).toString(),
+	leverage: leverage.toString(),
+	nativeSizeDelta: wei(sizeDelta),
+	susdSizeDelta: wei(sizeDelta * ETH_PRICE),
+	orderPrice: wei(ETH_PRICE),
+});
+
+describe('futures utils', () => {
+	test('calculates correct margin when increasing long', () => {
+		const position = getPosition(1, 10);
+		const trade = getTrade(0.2);
+		const fees = getFees();
+		const marginDelta = calculateMarginDelta(trade, fees, position);
+		expect(marginDelta.toNumber()).toEqual(40);
+	});
+
+	test('calculates correct margin when decreasing long', () => {
+		const position = getPosition(1, 10);
+		const trade = getTrade(-0.5);
+		const fees = getFees();
+		const marginDelta = calculateMarginDelta(trade, fees, position);
+		expect(marginDelta.toNumber()).toEqual(-65);
+	});
+
+	test('calculates correct margin when increasing short', () => {
+		const position = getPosition(1, 10, 'short');
+		const trade = getTrade(-0.2);
+		const fees = getFees();
+		const marginDelta = calculateMarginDelta(trade, fees, position);
+		expect(marginDelta.toNumber()).toEqual(40);
+	});
+
+	test('calculates correct margin when decreasing short', () => {
+		const position = getPosition(1, 10, 'short');
+		const trade = getTrade(0.5);
+		const fees = getFees();
+		const marginDelta = calculateMarginDelta(trade, fees, position);
+		expect(marginDelta.toNumber()).toEqual(-65);
+	});
+});


### PR DESCRIPTION
Fixes an issue where incorrect margin was being calculated when placing a trade. For example if you were long and wanted to reduce by shorting it would add margin rather than reduce.

Also added some tests to cover the different cases.