### PR TITLE
Fix drop down appearing on mobile futures stats

### DIFF
--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -18,9 +18,12 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 
 	return (
 		<FlexDivCentered>
-			<MarketDropDownContainer>
-				<MarketsDropdown />
-			</MarketDropDownContainer>
+			{!mobile && (
+				<MarketDropDownContainer>
+					<MarketsDropdown />
+				</MarketDropDownContainer>
+			)}
+
 			<MarketDetailsContainer mobile={mobile}>
 				{Object.entries(marketData).map(([marketKey, data]) => (
 					<MarketDetail {...data} marketKey={marketKey} mobile={Boolean(mobile)}></MarketDetail>


### PR DESCRIPTION
Currently if you click the stats tab on mobile futures page it will also show an extra markets selector.