### PR TITLE
Cross Margin Competition

### DIFF
--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -4,6 +4,8 @@
  */
 export const COMPETITION_DATES = {
 	// note: month starts at 0, not 1.
-	START_DATE: new Date(Date.UTC(2022, 7, 16)),
-	END_DATE: new Date(Date.UTC(2022, 7, 23)),
+	START_DATE: new Date(Date.UTC(2022, 10, 9)),
+	END_DATE: new Date(Date.UTC(2022, 10, 16)),
 };
+
+export const COMPETITION_ENABLED = true;

--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -5,7 +5,7 @@
 export const COMPETITION_DATES = {
 	// note: month starts at 0, not 1.
 	START_DATE: new Date(Date.UTC(2022, 10, 10)),
-	END_DATE: new Date(Date.UTC(2022, 10, 17)),
+	END_DATE: new Date(Date.UTC(2022, 10, 24)),
 };
 
 export const COMPETITION_ENABLED = true;

--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -4,8 +4,8 @@
  */
 export const COMPETITION_DATES = {
 	// note: month starts at 0, not 1.
-	START_DATE: new Date(Date.UTC(2022, 10, 9)),
-	END_DATE: new Date(Date.UTC(2022, 10, 16)),
+	START_DATE: new Date(Date.UTC(2022, 10, 10)),
+	END_DATE: new Date(Date.UTC(2022, 10, 17)),
 };
 
 export const COMPETITION_ENABLED = true;

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -52,7 +52,7 @@ export const EXTERNAL_LINKS = {
 		Home: 'https://kips.kwenta.io/all-kip/',
 	},
 	Competition: {
-		LearnMore: 'https://mirror.xyz/kwenta.eth/WghvQFjEslsC0kwnGVP0QZnY1F7ZU3w5hpWxDPLbBsE',
+		LearnMore: 'https://mirror.xyz/kwenta.eth/s_PO64SxvuwDHz9fdHebsYeQAOOc73D3bL2q4nC6LvU',
 	},
 	Aelin: {
 		Pool: 'https://app.aelin.xyz/pool/mainnet/0x21f4F88a95f656ef4ee1ea107569b3b38cf8daef',

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -49,6 +49,7 @@ export const ROUTES = {
 	Leaderboard: {
 		Home: '/leaderboard',
 		Trader: (trader: string) => `/leaderboard/?trader=${trader}`,
+		Competition: (round: string) => `/leaderboard/?competitionRound=${round}`,
 	},
 	Earn: {
 		Home: '/earn',

--- a/sections/dashboard/DashboardLayout/DashboardLayout.tsx
+++ b/sections/dashboard/DashboardLayout/DashboardLayout.tsx
@@ -1,16 +1,13 @@
 import { useRouter } from 'next/router';
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import NavButton from 'components/Button/NavButton';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import { TabList, TabPanel } from 'components/Tab';
 import ROUTES from 'constants/routes';
-import Leaderboard from 'sections/leaderboard/Leaderboard';
 import AppLayout from 'sections/shared/Layout/AppLayout';
-import { isCompetitionActive } from 'store/ui';
 import { MainContent, LeftSideContent, FullHeightContainer, PageContent } from 'styles/common';
 
 import EligibilityBox from '../EligibilityBox';
@@ -28,7 +25,6 @@ enum Tab {
 const Tabs = Object.values(Tab);
 
 const DashboardLayout: FC = ({ children }) => {
-	const competitionActive = useRecoilValue(isCompetitionActive);
 	const { t } = useTranslation();
 	const router = useRouter();
 
@@ -131,7 +127,6 @@ const DashboardLayout: FC = ({ children }) => {
 								{children}
 							</TabPanel>
 						</MainContent>
-						{competitionActive && <Leaderboard compact />}
 						<EligibilityBox />
 					</StyledFullHeightContainer>
 				</PageContent>

--- a/sections/leaderboard/Competition/Competition.tsx
+++ b/sections/leaderboard/Competition/Competition.tsx
@@ -8,6 +8,7 @@ import Currency from 'components/Currency';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import Table, { TableNoResults } from 'components/Table';
 import Connector from 'containers/Connector';
+import useENSs from 'hooks/useENSs';
 import useGetFile from 'queries/files/useGetFile';
 import { AccountStat } from 'queries/futures/types';
 import { formatPercent } from 'utils/formatters/number';
@@ -19,7 +20,6 @@ import { getCompetitionDataLocation } from './constants';
 type CompetitionProps = {
 	round: CompetitionRound;
 	activeTier: Tier;
-	ensInfo: Record<string, string>;
 	compact?: boolean;
 	onClickTrader: (trader: string) => void;
 	searchTerm?: string | undefined;
@@ -28,7 +28,6 @@ type CompetitionProps = {
 const Competition: FC<CompetitionProps> = ({
 	round,
 	activeTier,
-	ensInfo,
 	compact,
 	onClickTrader,
 	searchTerm,
@@ -44,6 +43,17 @@ const Competition: FC<CompetitionProps> = ({
 		);
 		return walletStat ? walletStat.tier : null;
 	}, [walletAddress, competitionQuery]);
+
+	const traders = useMemo(
+		() =>
+			competitionQuery?.data?.map((stat: AccountStat) => {
+				return stat.account;
+			}) ?? [],
+		[competitionQuery?.data]
+	);
+
+	const ensInfoQuery = useENSs(traders);
+	const ensInfo = useMemo(() => ensInfoQuery.data ?? {}, [ensInfoQuery]);
 
 	let data = useMemo(() => {
 		const competitionData = competitionQuery?.data ?? [];

--- a/sections/leaderboard/Competition/Competition.tsx
+++ b/sections/leaderboard/Competition/Competition.tsx
@@ -13,10 +13,11 @@ import { AccountStat } from 'queries/futures/types';
 import { formatPercent } from 'utils/formatters/number';
 import { truncateAddress } from 'utils/formatters/string';
 
-import { getMedal, PIN, StyledTrader, Tier } from '../common';
-import { COMPETITION_DATA_LOCATION, MOBILE_COMPETITION_START } from './constants';
+import { CompetitionRound, getMedal, PIN, StyledTrader, Tier } from '../common';
+import { getCompetitionDataLocation } from './constants';
 
 type CompetitionProps = {
+	round: CompetitionRound;
 	activeTier: Tier;
 	ensInfo: Record<string, string>;
 	compact?: boolean;
@@ -25,6 +26,7 @@ type CompetitionProps = {
 };
 
 const Competition: FC<CompetitionProps> = ({
+	round,
 	activeTier,
 	ensInfo,
 	compact,
@@ -33,7 +35,7 @@ const Competition: FC<CompetitionProps> = ({
 }: CompetitionProps) => {
 	const { t } = useTranslation();
 	const { walletAddress } = Connector.useContainer();
-	const competitionQuery = useGetFile(COMPETITION_DATA_LOCATION);
+	const competitionQuery = useGetFile(getCompetitionDataLocation(round));
 
 	const walletTier = useMemo(() => {
 		const competitionData = competitionQuery?.data ?? [];
@@ -56,6 +58,7 @@ const Competition: FC<CompetitionProps> = ({
 					rankText: trader.rank.toString(),
 					traderShort: truncateAddress(trader.account),
 					pnl: wei(trader.pnl),
+					pnlNumber: wei(trader.pnl).toNumber(),
 					pnlPct: `(${formatPercent(trader?.pnl_pct)})`,
 					totalVolume: trader.volume,
 					totalTrades: trader.trades,
@@ -81,11 +84,6 @@ const Competition: FC<CompetitionProps> = ({
 		return [...pinRow, ...cleanCompetitionData];
 	}, [competitionQuery, ensInfo, searchTerm, activeTier, walletAddress, walletTier, compact]);
 
-	const noResultsMessage =
-		Date.now() > MOBILE_COMPETITION_START.getTime()
-			? t('leaderboard.competition.table.started')
-			: t('leaderboard.competition.table.starting-soon');
-
 	return (
 		<>
 			<DesktopOnlyView>
@@ -97,7 +95,9 @@ const Competition: FC<CompetitionProps> = ({
 					isLoading={competitionQuery.isLoading}
 					data={data}
 					hiddenColumns={!compact ? undefined : ['totalTrades', 'liquidations', 'totalVolume']}
-					noResultsMessage={<TableNoResults>{noResultsMessage}</TableNoResults>}
+					noResultsMessage={
+						<TableNoResults>{t('leaderboard.competition.table.no-results')}</TableNoResults>
+					}
 					columns={[
 						{
 							Header: (
@@ -170,7 +170,7 @@ const Competition: FC<CompetitionProps> = ({
 								},
 								{
 									Header: <TableHeader>{t('leaderboard.leaderboard.table.pnl')}</TableHeader>,
-									accessor: 'pnl',
+									accessor: 'pnlNumber',
 									sortType: 'basic',
 									Cell: (cellProps: CellProps<any>) => (
 										<PnlContainer direction={'column'}>

--- a/sections/leaderboard/Competition/constants.tsx
+++ b/sections/leaderboard/Competition/constants.tsx
@@ -1,3 +1,5 @@
-export const COMPETITION_DATA_LOCATION = 'competition/leaderboard_latest.json';
+import { CompetitionRound } from '../common';
 
-export const MOBILE_COMPETITION_START = new Date('2022-08-16');
+export const getCompetitionDataLocation = (round: CompetitionRound) => {
+	return `crossmargin_competition_${round}/leaderboard_latest.json`;
+};

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -189,7 +189,6 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 						<Competition
 							round={competitionRound}
 							activeTier={activeTier}
-							ensInfo={ensInfo}
 							compact={compact}
 							onClickTrader={onClickTrader}
 							searchTerm={searchTerm !== '' ? searchTerm : searchInput}

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -15,7 +15,7 @@ import { FlexDivCol } from 'styles/common';
 import media from 'styles/media';
 
 import AllTime from '../AllTime';
-import { PIN } from '../common';
+import { CompetitionRound, PIN } from '../common';
 import TraderHistory from '../TraderHistory';
 
 type LeaderboardProps = {
@@ -32,6 +32,7 @@ const LEADERBOARD_TABS = [LeaderboardTab.Top, LeaderboardTab.Bottom];
 
 const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps) => {
 	const [activeTab, setActiveTab] = useState<LeaderboardTab>(LeaderboardTab.Top);
+	const [competitionRound, setCompetitionRound] = useState<CompetitionRound>();
 	const [searchInput, setSearchInput] = useState('');
 	const [searchTerm, setSearchTerm] = useState('');
 	const [searchAddress, setSearchAddress] = useState('');
@@ -69,11 +70,15 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 		if (router.asPath.startsWith(ROUTES.Leaderboard.Home) && router.query.trader) {
 			const trader = router.query.trader as string;
 			setSelectedTrader(trader);
+		} else if (router.asPath.startsWith(ROUTES.Leaderboard.Home) && router.query.competitionRound) {
+			const round = router.query.competitionRound as CompetitionRound;
+			setCompetitionRound(round);
 		} else {
 			setSearchInput('');
 			setSearchTerm('');
 			setSearchAddress('');
 			setSelectedTrader('');
+			setCompetitionRound(null);
 		}
 		return null;
 	}, [router.query, router.asPath]);
@@ -136,24 +141,27 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 			<LeaderboardContainer>
 				<SearchContainer compact={compact} mobile={mobile}>
 					<TabButtonContainer mobile={mobile}>
-						{LEADERBOARD_TABS.map((tab) => (
-							<StyledTabButton
-								key={tab}
-								title={tab ?? ''}
-								active={activeTab === tab}
-								onClick={() => {
-									setActiveTab(tab);
-									setSelectedTrader('');
-								}}
-							/>
-						))}
+						{!competitionRound &&
+							LEADERBOARD_TABS.map((tab) => (
+								<StyledTabButton
+									key={tab}
+									title={tab ?? ''}
+									active={activeTab === tab}
+									onClick={() => {
+										setActiveTab(tab);
+										setSelectedTrader('');
+									}}
+								/>
+							))}
 					</TabButtonContainer>
 					<SearchBarContainer>
 						<Search value={searchInput} onChange={onChangeSearch} disabled={false} />
 					</SearchBarContainer>
 				</SearchContainer>
 				<TableContainer compact={compact}>
-					{!compact && selectedTrader !== '' ? (
+					{competitionRound ? (
+						<></>
+					) : !compact && selectedTrader !== '' ? (
 						<TraderHistory
 							trader={selectedTrader}
 							ensInfo={ensInfo}

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -15,7 +15,8 @@ import { FlexDivCol } from 'styles/common';
 import media from 'styles/media';
 
 import AllTime from '../AllTime';
-import { CompetitionRound, PIN } from '../common';
+import { CompetitionRound, COMPETITION_TIERS, PIN, Tier } from '../common';
+import Competition from '../Competition';
 import TraderHistory from '../TraderHistory';
 
 type LeaderboardProps = {
@@ -32,6 +33,7 @@ const LEADERBOARD_TABS = [LeaderboardTab.Top, LeaderboardTab.Bottom];
 
 const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps) => {
 	const [activeTab, setActiveTab] = useState<LeaderboardTab>(LeaderboardTab.Top);
+	const [activeTier, setActiveTier] = useState<Tier>('bronze');
 	const [competitionRound, setCompetitionRound] = useState<CompetitionRound>();
 	const [searchInput, setSearchInput] = useState('');
 	const [searchTerm, setSearchTerm] = useState('');
@@ -108,7 +110,12 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 		setSearchTerm('');
 		setSearchAddress('');
 		setSelectedTrader('');
-		router.push(ROUTES.Leaderboard.Home);
+
+		if (competitionRound) {
+			router.push(ROUTES.Leaderboard.Competition(competitionRound));
+		} else {
+			router.push(ROUTES.Leaderboard.Home);
+		}
 	};
 
 	useEffect(() => {
@@ -140,33 +147,51 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 			<CompetitionBanner compact={true} hideBanner={compact} />
 			<LeaderboardContainer>
 				<SearchContainer compact={compact} mobile={mobile}>
-					<TabButtonContainer mobile={mobile}>
-						{!competitionRound &&
-							LEADERBOARD_TABS.map((tab) => (
-								<StyledTabButton
-									key={tab}
-									title={tab ?? ''}
-									active={activeTab === tab}
-									onClick={() => {
-										setActiveTab(tab);
-										setSelectedTrader('');
-									}}
-								/>
-							))}
+					<TabButtonContainer numItems={competitionRound ? 3 : 2} mobile={mobile}>
+						{competitionRound
+							? COMPETITION_TIERS.map((tier) => (
+									<StyledTabButton
+										key={tier}
+										title={tier ?? ''}
+										active={activeTier === tier}
+										onClick={() => {
+											setActiveTier(tier);
+											setSelectedTrader('');
+										}}
+									/>
+							  ))
+							: LEADERBOARD_TABS.map((tab) => (
+									<StyledTabButton
+										key={tab}
+										title={tab ?? ''}
+										active={activeTab === tab}
+										onClick={() => {
+											setActiveTab(tab);
+											setSelectedTrader('');
+										}}
+									/>
+							  ))}
 					</TabButtonContainer>
 					<SearchBarContainer>
 						<Search value={searchInput} onChange={onChangeSearch} disabled={false} />
 					</SearchBarContainer>
 				</SearchContainer>
 				<TableContainer compact={compact}>
-					{competitionRound ? (
-						<></>
-					) : !compact && selectedTrader !== '' ? (
+					{!compact && selectedTrader !== '' ? (
 						<TraderHistory
 							trader={selectedTrader}
 							ensInfo={ensInfo}
 							resetSelection={resetSelection}
 							compact={compact}
+							searchTerm={searchTerm}
+						/>
+					) : competitionRound ? (
+						<Competition
+							round={competitionRound}
+							activeTier={activeTier}
+							ensInfo={ensInfo}
+							compact={compact}
+							onClickTrader={onClickTrader}
 							searchTerm={searchTerm}
 						/>
 					) : searchAddress ? (
@@ -206,9 +231,9 @@ const StyledTabButton = styled(TabButton)`
 	margin-right: 5px;
 `;
 
-const TabButtonContainer = styled.div<{ mobile?: boolean }>`
+const TabButtonContainer = styled.div<{ numItems: number; mobile?: boolean }>`
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: ${({ numItems }) => `repeat(${numItems}, 1fr)`};
 	margin-bottom: ${({ mobile }) => (mobile ? '16px' : '0px')};
 `;
 

--- a/sections/leaderboard/Leaderboard/Leaderboard.tsx
+++ b/sections/leaderboard/Leaderboard/Leaderboard.tsx
@@ -183,7 +183,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 							ensInfo={ensInfo}
 							resetSelection={resetSelection}
 							compact={compact}
-							searchTerm={searchTerm}
+							searchTerm={searchInput}
 						/>
 					) : competitionRound ? (
 						<Competition
@@ -192,7 +192,7 @@ const Leaderboard: FC<LeaderboardProps> = ({ compact, mobile }: LeaderboardProps
 							ensInfo={ensInfo}
 							compact={compact}
 							onClickTrader={onClickTrader}
-							searchTerm={searchTerm}
+							searchTerm={searchTerm !== '' ? searchTerm : searchInput}
 						/>
 					) : searchAddress ? (
 						<AllTime

--- a/sections/leaderboard/common.tsx
+++ b/sections/leaderboard/common.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export type Tier = 'gold' | 'silver' | 'bronze' | null;
+export type CompetitionRound = '1' | '2' | null;
 
 export const getMedal = (position: number) => {
 	switch (position) {

--- a/sections/shared/Layout/AppLayout/Header/Nav/Nav.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Nav/Nav.tsx
@@ -113,9 +113,11 @@ const MenuInside = styled.div<{ isActive: boolean; isDropDown?: boolean }>`
 	font-family: ${(props) => props.theme.fonts.bold};
 	font-size: 15px;
 	text-transform: capitalize;
+	text-align: center;
 	border-radius: 100px;
 	background: transparent;
 	cursor: pointer;
+	width: 100%;
 	color: ${(props) =>
 		props.isActive
 			? props.theme.colors.selectedTheme.button.text.primary
@@ -129,7 +131,6 @@ const MenuInside = styled.div<{ isActive: boolean; isDropDown?: boolean }>`
 const DropDownSelect = styled(Select)`
 	.react-select__control {
 		padding: 0 6px;
-		width: 98px;
 	}
 
 	.react-select__group {
@@ -152,8 +153,21 @@ const DropDownSelect = styled(Select)`
 
 	.react-select__value-container {
 		padding: 0px;
+		width: ${(props) => {
+			//@ts-ignore
+			return props.value?.i18nLabel === 'header.nav.markets'
+				? '75px'
+				: //@ts-ignore
+				props.value?.i18nLabel === 'header.nav.leaderboard'
+				? '110px'
+				: '100%';
+		}};
+	}
+
+	.react-select__single-value {
 		display: flex;
-		justify-content: center;
+		align-items: center;
+		width: 100%;
 	}
 
 	.react-select__menu-notice--no-options {

--- a/sections/shared/Layout/AppLayout/Header/Nav/Nav.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Nav/Nav.tsx
@@ -39,7 +39,7 @@ const Nav: FC = () => {
 		link,
 		isActive,
 	}: ReactSelectOptionProps) => {
-		if (i18nLabel === 'header.nav.markets')
+		if (i18nLabel === 'header.nav.markets' || i18nLabel === 'header.nav.leaderboard')
 			return (
 				<MenuInside isDropDown isActive={isActive}>
 					{t(i18nLabel)}

--- a/sections/shared/Layout/AppLayout/Header/constants.tsx
+++ b/sections/shared/Layout/AppLayout/Header/constants.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { CrossMarginIcon, IsolatedMarginIcon } from 'components/Nav/FuturesIcon';
+import { COMPETITION_ENABLED } from 'constants/competition';
 import { CROSS_MARGIN_ENABLED, DEFAULT_FUTURES_MARGIN_TYPE } from 'constants/defaults';
 import { EXTERNAL_LINKS } from 'constants/links';
 import ROUTES from 'constants/routes';
@@ -94,6 +95,22 @@ export const getMenuLinks = (isMobile: boolean): MenuLinks => [
 	{
 		i18nLabel: 'header.nav.leaderboard',
 		link: ROUTES.Leaderboard.Home,
+		links: COMPETITION_ENABLED
+			? [
+					{
+						link: ROUTES.Leaderboard.Home,
+						i18nLabel: 'header.nav.leaderboard-alltime',
+					},
+					{
+						link: ROUTES.Leaderboard.Competition('1'),
+						i18nLabel: 'header.nav.competition-round-1',
+					},
+					{
+						link: ROUTES.Leaderboard.Competition('2'),
+						i18nLabel: 'header.nav.competition-round-2',
+					},
+			  ]
+			: null,
 	},
 ];
 

--- a/sections/shared/components/CompetitionBanner/CompetitionBanner.tsx
+++ b/sections/shared/components/CompetitionBanner/CompetitionBanner.tsx
@@ -1,12 +1,10 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import CompetitionBannerBg from 'assets/svg/app/competition-banner-bg.svg';
-import { COMPETITION_DATES } from 'constants/competition';
+import { COMPETITION_DATES, COMPETITION_ENABLED } from 'constants/competition';
 import { EXTERNAL_LINKS } from 'constants/links';
-import { isCompetitionActive } from 'store/ui';
 import { ExternalLink } from 'styles/common';
 import media from 'styles/media';
 import { formatDateWithoutYear } from 'utils/formatters/date';
@@ -24,8 +22,7 @@ export const CompetitionBanner: FC<CompetitionBannerProps> = ({
 }: CompetitionBannerProps) => {
 	const { t } = useTranslation();
 
-	const competitionActive = useRecoilValue(isCompetitionActive);
-	if (!competitionActive) return null;
+	if (!COMPETITION_ENABLED) return null;
 
 	const formatedStartDate = formatDateWithoutYear(COMPETITION_DATES.START_DATE);
 	const formatedEndDate = formatDateWithoutYear(COMPETITION_DATES.END_DATE);

--- a/store/ui/index.ts
+++ b/store/ui/index.ts
@@ -23,11 +23,6 @@ export const currentThemeState = atom<ThemeName>({
 	effects: [localStorageEffect('currentTheme')],
 });
 
-export const isCompetitionActive = atom<boolean>({
-	key: getUIKey('isCompetitionActive'),
-	default: process.env.NEXT_PUBLIC_COMPETITION_ACTIVE === 'true',
-});
-
 export const activePositionsTabState = atom<PositionsTab>({
 	key: getUIKey('activePositionsTabState'),
 	default: PositionsTab.CROSS_MARGIN,

--- a/translations/en.json
+++ b/translations/en.json
@@ -935,8 +935,7 @@
 			"title": "Competition",
 			"table": {
 				"table-updates": "Table data updates daily",
-				"starting-soon": "Competition starting soon",
-				"started": "Competition started, leaderboard updates every 3 hours"
+				"starting-soon": "No competition standings available"
 			}
 		}
 	},

--- a/translations/en.json
+++ b/translations/en.json
@@ -16,6 +16,9 @@
 			"markets": "futures",
 			"isolated-margin": "Isolated Margin",
 			"cross-margin": "Cross Margin",
+			"leaderboard-alltime": "All Time",
+			"competition-round-1": "Round 1",
+			"competition-round-2": "Round 2",
 			"leaderboard": "leaderboard",
 			"earn": "earn",
 			"beta-badge": "Beta"

--- a/translations/en.json
+++ b/translations/en.json
@@ -935,7 +935,7 @@
 			"title": "Competition",
 			"table": {
 				"table-updates": "Table data updates daily",
-				"starting-soon": "No competition standings available"
+				"no-results": "No competition standings available"
 			}
 		}
 	},


### PR DESCRIPTION
Enable the leaderboard for the upcoming cross margin competition

## Description
* Adds a dropdown to the "Leaderboard" section on the nav
* Adds a competition leaderboard that will pull either round 1 or 2 depending on inputs
* Dynamic tab buttons based on leaderboard type (competition vs all time)
* Opts for a constant instead of an environment variable and recoil value to set competition
  * This shouldn't make any difference, since if we update an environment variable we would still need to redeploy
