### PR TITLE
Get local date formatting string from browser

### DIFF
--- a/sections/futures/Trades/TimeDisplay.tsx
+++ b/sections/futures/Trades/TimeDisplay.tsx
@@ -16,9 +16,10 @@ const TimeDisplay: FC<TimeDisplayProps> = ({ cellPropsValue, horizontal }) => {
 		setShow12h(!show12hr);
 	};
 
-	const date = format(new Date(cellPropsValue), 'MM/dd/yy', {
-		locale: getLocale(),
-	});
+	const date = format(
+		new Date(cellPropsValue),
+		getLocale().formatLong?.date({ width: 'short' }) ?? 'MM/dd/yy'
+	);
 	const time12hr = new Date(cellPropsValue).toLocaleTimeString(getLocale().code);
 	const time24hr = format(new Date(cellPropsValue), 'HH:mm:ss', {
 		locale: getLocale(),

--- a/utils/formatters/date.ts
+++ b/utils/formatters/date.ts
@@ -4,6 +4,7 @@ import getISOWeeksInYear from 'date-fns/getISOWeeksInYear';
 import subHours from 'date-fns/subHours';
 import { TFunction } from 'i18next';
 
+import getLocale from './getLocale';
 import { strPadLeft } from './string';
 
 export const formatTxTimestamp = (timestamp: number | Date) =>
@@ -59,8 +60,7 @@ export const timePresentation = (timestamp: string, t: TFunction) => {
 			timeDelta: Math.floor(seconds / 604800),
 		});
 	}
-
-	return format(actionTime, 'MM/dd/yyyy');
+	return format(actionTime, getLocale().formatLong?.date({ width: 'short' }) ?? 'MM/dd/yyyy');
 };
 
 export const formatDateWithoutYear = (date: Date) => formatDate(date, 'MMMM dd');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When formatting dateTime presentation, call `getLocale` function to compute local dateTime formatting string, e.g.
- enUS: MM/dd/yyyy
- zhCN: yy-mm-dd
- etc

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Kwenta/kwenta/issues/1484

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
All displayed dates/times on Kwenta are displayed using a format local to the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Take example on futures transfer table
- zhCN
![Screenshot 2022-11-07 at 21 02 33](https://user-images.githubusercontent.com/3646680/200393905-1c22f177-78e4-4124-9c89-cbf34b8c909a.png)
- enUs
![Screenshot 2022-11-07 at 21 02 20](https://user-images.githubusercontent.com/3646680/200393908-9adaac62-e54a-422b-aa2f-935177ce764f.png)

