### PR TITLE
hotfix: fix competition banner dates

### DIFF
--- a/.github/workflows/audit_build_verify.yml
+++ b/.github/workflows/audit_build_verify.yml
@@ -60,7 +60,7 @@ jobs:
         run: npm run lint:sarif
 
       - name: Upload lint results
-        uses: github/codeql-action/upload-sarif@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # pin@codeql-bundle-20220322
+        uses: github/codeql-action/upload-sarif@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # pin@codeql-bundle-20220322
         with:
           sarif_file: lint-results.sarif
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # pin@codeql-bundle-20220322
+        uses: github/codeql-action/init@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # pin@codeql-bundle-20220322
         with:
           queries: security-and-quality
           languages: javascript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # pin@codeql-bundle-20220322
+        uses: github/codeql-action/autobuild@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # pin@codeql-bundle-20220322
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # pin@codeql-bundle-20220322
+        uses: github/codeql-action/analyze@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # pin@codeql-bundle-20220322

--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -4,7 +4,7 @@
  */
 export const COMPETITION_DATES = {
 	// note: month starts at 0, not 1.
-	START_DATE: new Date(Date.UTC(2022, 10, 10)),
+	START_DATE: new Date(Date.UTC(2022, 10, 9)),
 	END_DATE: new Date(Date.UTC(2022, 10, 24)),
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Competitions will start and end at 00:00 UTC on the respective days. Eg, if `startDate` is 2022/10/9, it means competition starts at 00:00 UTC 2022/11/9,  and `endDate` 2022/10/24 means competition ends at 23:59 UTC on 2022/11/23

```
export const COMPETITION_DATES = {
	// note: month starts at 0, not 1.
	START_DATE: new Date(Date.UTC(2022, 10, 9)),
	END_DATE: new Date(Date.UTC(2022, 10, 24)),
```
