### PR TITLE
Remove redux-logger logs in prod

### DIFF
--- a/state/store.ts
+++ b/state/store.ts
@@ -8,8 +8,7 @@ import { sdk } from './config';
 import exchangeReducer from './exchange/reducer';
 import walletReducer from './wallet/reducer';
 
-// TODO: Consider creating an env var for this.
-const LOG_REDUX = true;
+const LOG_REDUX = process.env.NODE_ENV !== 'production';
 
 const store = configureStore({
 	reducer: {


### PR DESCRIPTION
## Description
This PR removes `redux-logger` console outputs in staging and prod environments.

## Related issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
