### PR TITLE
Fix isolated margin withdraw error and update margin info box

### DIFF
--- a/sections/futures/MarketInfoBox/MarketInfoBox.tsx
+++ b/sections/futures/MarketInfoBox/MarketInfoBox.tsx
@@ -113,11 +113,6 @@ const MarketInfoBox: React.FC = () => {
 		<StyledInfoBox
 			dataTestId="market-info-box"
 			details={{
-				'Total Margin': {
-					value: `${formatDollars(totalMargin, {
-						currencyKey: undefined,
-					})}`,
-				},
 				'Available Margin': {
 					value: `${formatDollars(availableMargin, {
 						currencyKey: undefined,

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components';
 
 import SegmentedControl from 'components/SegmentedControl';
 import { ISOLATED_MARGIN_ORDER_TYPES } from 'constants/futures';
-import { balancesState, leverageSideState, orderTypeState } from 'store/futures';
+import { balancesState, leverageSideState, orderTypeState, positionState } from 'store/futures';
+import { zeroBN } from 'utils/formatters/number';
 
 import FeeInfoBox from '../FeeInfoBox';
 import LeverageInput from '../LeverageInput';
@@ -23,15 +24,17 @@ type Props = {
 const TradeIsolatedMargin = ({ isMobile }: Props) => {
 	const [leverageSide, setLeverageSide] = useRecoilState(leverageSideState);
 	const { susdWalletBalance } = useRecoilValue(balancesState);
+	const position = useRecoilValue(positionState);
 
 	const [orderType, setOrderType] = useRecoilState(orderTypeState);
 	const [openTransferModal, setOpenTransferModal] = useState<boolean>(false);
+	const totalMargin = position?.remainingMargin ?? zeroBN;
 
 	return (
 		<div>
 			<TradePanelHeader
 				onManageBalance={() => setOpenTransferModal(true)}
-				balance={susdWalletBalance}
+				balance={totalMargin}
 				accountType={'isolated_margin'}
 			/>
 

--- a/sections/futures/Trade/TransferIsolatedMarginModal.tsx
+++ b/sections/futures/Trade/TransferIsolatedMarginModal.tsx
@@ -81,7 +81,7 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, sUSDBalance, 
 		'transferMargin',
 		[wei(amount || 0).toBN()],
 		gasPrice || undefined,
-		{ enabled: !!market && !!amount && !isDisabled }
+		{ enabled: !!market && !!amount && !isDisabled && transferType === 0 }
 	);
 
 	const withdrawTxn = useSynthetixTxn(
@@ -89,7 +89,7 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, sUSDBalance, 
 		'transferMargin',
 		[computedWithdrawAmount],
 		gasPrice || undefined,
-		{ enabled: !!market && !!amount }
+		{ enabled: !!market && !!amount && transferType === 1 }
 	);
 
 	const transactionFee = estimateSnxTxGasCost(transferType === 0 ? depositTxn : withdrawTxn);

--- a/translations/en.json
+++ b/translations/en.json
@@ -683,7 +683,7 @@
 						"gas-fee": "Gas Fee",
 						"max": "Max",
 						"deposit": {
-							"title": "Deposit Margin",
+							"title": "Transfer Margin",
 							"button": "Deposit Margin",
 							"approve-button": "Approve sUSD",
 							"disclaimer": "A $50 margin minimum is required to open a position.",


### PR DESCRIPTION
Fixes an issue where a safe math error was appearing on isolated margin withdraw.

Also replaces isolated margin header value with market margin instead of wallet balance and removes the total margin line from the info box.

<img width="389" alt="Screenshot 2022-11-14 at 13 10 12" src="https://user-images.githubusercontent.com/3802342/201668614-73508cc6-b25e-4380-b885-d6d7c5b2126e.png">
