### PR TITLE
Fix issues with ETH/sETH pair

### DIFF
--- a/sdk/services/exchange.ts
+++ b/sdk/services/exchange.ts
@@ -927,7 +927,7 @@ export default class ExchangeService {
 
 	private async getQuoteCurrencyContract(quoteCurrencyKey: string) {
 		if (quoteCurrencyKey && this.allTokensMap[quoteCurrencyKey]) {
-			const quoteTknAddress = this.allTokensMap[quoteCurrencyKey].address;
+			const quoteTknAddress = this.getTokenAddress(quoteCurrencyKey, true);
 			return this.createERC20Contract(quoteTknAddress);
 		}
 


### PR DESCRIPTION
## Description
This PR (potentially) fixes issues with making swaps on the ETH/sETH pair, by using the Coingecko WETH address as opposed to the one returned from 1inch's token list.

## Related issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
