### PR TITLE
Fixed the APY

### DIFF
--- a/hooks/useStakingData.ts
+++ b/hooks/useStakingData.ts
@@ -97,6 +97,7 @@ const useStakingData = () => {
 	};
 
 	const [epochPeriod, setEpochPeriod] = useState(0);
+	const [weekCounter, setWeekCounter] = useState(1);
 	const { walletAddress } = Connector.useContainer();
 	const [kwentaBalance, setKwentaBalance] = useState(zeroBN);
 	const [escrowedBalance, setEscrowedBalance] = useState(zeroBN);
@@ -104,7 +105,6 @@ const useStakingData = () => {
 	const [stakedEscrowedBalance, setStakedEscrowedBalance] = useState(zeroBN);
 	const [totalStakedBalance, setTotalStakedBalance] = useState(zeroBN);
 	const [claimableBalance, setClaimableBalance] = useState(zeroBN);
-	const [apy, setApy] = useState(zeroBN);
 	const [vKwentaBalance, setVKwentaBalance] = useState(zeroBN);
 	const [vKwentaAllowance, setVKwentaAllowance] = useState(zeroBN);
 	const [kwentaAllowance, setKwentaAllowance] = useState(zeroBN);
@@ -137,14 +137,6 @@ const useStakingData = () => {
 				...kwentaTokenContract,
 				functionName: 'balanceOf',
 				args: [walletAddress ?? undefined],
-			},
-			{
-				...supplyScheduleContract,
-				functionName: 'DECAY_RATE',
-			},
-			{
-				...supplyScheduleContract,
-				functionName: 'INITIAL_WEEKLY_SUPPLY',
 			},
 			{
 				...supplyScheduleContract,
@@ -195,24 +187,14 @@ const useStakingData = () => {
 				setStakedEscrowedBalance(wei(data[2] ?? zeroBN));
 				setClaimableBalance(wei(data[3] ?? zeroBN));
 				setKwentaBalance(wei(data[4] ?? zeroBN));
-				setTotalStakedBalance(wei(data[8] ?? zeroBN));
-				const supplyRate = wei(1).sub(wei(data[5] ?? zeroBN));
-				const initialWeeklySupply = wei(data[6] ?? zeroBN);
-				const weekCounter = Number(data[7] ?? zeroBN);
-				const startWeeklySupply = initialWeeklySupply.mul(supplyRate.pow(weekCounter));
-				const yearlyRewards =
-					totalStakedBalance.gt(zeroBN) && supplyRate.gt(zeroBN)
-						? startWeeklySupply.mul(wei(1).sub(supplyRate.pow(52))).div(wei(1).sub(supplyRate))
-						: zeroBN;
-				setApy(
-					totalStakedBalance.gt(zeroBN) ? yearlyRewards.div(totalStakedBalance).div(100) : zeroBN
-				);
-				setVKwentaBalance(wei(data[9] ?? zeroBN));
-				setVKwentaAllowance(wei(data[10] ?? zeroBN));
-				setKwentaAllowance(wei(data[11] ?? zeroBN));
-				setEpochPeriod(Number(data[12] ?? 0) ?? 0);
-				setVEKwentaBalance(wei(data[13] ?? zeroBN));
-				setVEKwentaAllowance(wei(data[14] ?? zeroBN));
+				setWeekCounter(Number(data[5] ?? 1) ?? 1);
+				setTotalStakedBalance(wei(data[6] ?? zeroBN));
+				setVKwentaBalance(wei(data[7] ?? zeroBN));
+				setVKwentaAllowance(wei(data[8] ?? zeroBN));
+				setKwentaAllowance(wei(data[9] ?? zeroBN));
+				setEpochPeriod(Number(data[10] ?? 0) ?? 0);
+				setVEKwentaBalance(wei(data[11] ?? zeroBN));
+				setVEKwentaAllowance(wei(data[12] ?? zeroBN));
 			}
 		},
 	});
@@ -348,6 +330,8 @@ const useStakingData = () => {
 		resetStakingState,
 		resetVesting,
 		resetVestingClaimable,
+		weekCounter,
+		totalStakedBalance: Number(totalStakedBalance),
 		periods,
 		resetTime,
 		epochPeriod,
@@ -358,7 +342,6 @@ const useStakingData = () => {
 		stakedEscrowedBalance,
 		claimableBalance,
 		kwentaBalance,
-		apy,
 		vKwentaBalance,
 		veKwentaBalance,
 		vKwentaAllowance,

--- a/queries/staking/utils.ts
+++ b/queries/staking/utils.ts
@@ -4,6 +4,9 @@ export const EPOCH_START: Record<number, number> = {
 };
 
 export const WEEK = 604800;
+export const DECAY_RATE = 0.0205;
+export const INITIAL_WEEKLY_SUPPLY = 14463.36923076923076923;
+export const STAKING_REWARDS_RATIO = 0.6;
 
 export function getEpochDetails(networkId: number, epoch: number) {
 	const currentEpochTime = EPOCH_START[networkId]
@@ -14,4 +17,12 @@ export function getEpochDetails(networkId: number, epoch: number) {
 		epochStart: currentEpochTime,
 		epochEnd: epochEndTime,
 	};
+}
+
+export function getStakingApy(totalStakedBalance: number, weekCounter: number) {
+	const supplyRate = 1 - DECAY_RATE;
+	const initialWeeklySupply = INITIAL_WEEKLY_SUPPLY;
+	const startWeeklySupply = initialWeeklySupply * supplyRate ** weekCounter;
+	const yearlyRewards = (startWeeklySupply * (1 - supplyRate ** 52)) / (1 - supplyRate);
+	return totalStakedBalance > 0 ? (yearlyRewards * STAKING_REWARDS_RATIO) / totalStakedBalance : 0;
 }

--- a/sections/dashboard/Stake/StakingTab.tsx
+++ b/sections/dashboard/Stake/StakingTab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { useContractWrite } from 'wagmi';
@@ -5,6 +6,7 @@ import { useContractWrite } from 'wagmi';
 import Button from 'components/Button';
 import { monitorTransaction } from 'contexts/RelayerContext';
 import { useStakingContext } from 'contexts/StakingContext';
+import { getStakingApy } from 'queries/staking/utils';
 import media from 'styles/media';
 import { formatPercent, truncateNumbers } from 'utils/formatters/number';
 
@@ -13,7 +15,18 @@ import StakeInputCard from './InputCards/StakeInputCard';
 
 const StakingTab = () => {
 	const { t } = useTranslation();
-	const { claimableBalance, apy, getRewardConfig, resetStakingState } = useStakingContext();
+	const {
+		claimableBalance,
+		totalStakedBalance,
+		weekCounter,
+		getRewardConfig,
+		resetStakingState,
+	} = useStakingContext();
+
+	const apy = useMemo(() => getStakingApy(totalStakedBalance, weekCounter), [
+		totalStakedBalance,
+		weekCounter,
+	]);
 
 	const { writeAsync: getReward } = useContractWrite(getRewardConfig);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. The user only sees APY after staking (by re-fetching the state). This is a side-effect of disabling watch-mode.
2. The APY number is incorrect. Only 60% of inflation goes to staking rewards. Also the % is on the wrong place.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/202319817-950761ce-2f39-4e33-b30a-f2463c69b645.png)
