### PR TITLE
Add gas buffer to `distributeMargin` calls

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -18,6 +18,7 @@ export const DEFAULT_PRICE_CURRENCY: Synth = localStore.get(priceCurrencyStateKe
 export const DEFAULT_NETWORK_ID = NetworkIdByName['mainnet-ovm'];
 
 export const DEFAULT_GAS_BUFFER = 5000;
+export const DEFAULT_CROSSMARGIN_GAS_BUFFER = 50000;
 export const DEFAULT_GAS_LIMIT = 500000;
 
 // ui defaults

--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -18,8 +18,8 @@ export const DEFAULT_PRICE_CURRENCY: Synth = localStore.get(priceCurrencyStateKe
 export const DEFAULT_NETWORK_ID = NetworkIdByName['mainnet-ovm'];
 
 export const DEFAULT_GAS_BUFFER = 5000;
-export const DEFAULT_CROSSMARGIN_GAS_BUFFER = 50000;
 export const DEFAULT_GAS_LIMIT = 500000;
+export const DEFAULT_CROSSMARGIN_GAS_BUFFER_PCT = 5;
 
 // ui defaults
 export const DEFAULT_SEARCH_DEBOUNCE_MS = 300;

--- a/hooks/useEstimateGasCost.ts
+++ b/hooks/useEstimateGasCost.ts
@@ -8,7 +8,6 @@ import { sdk } from 'state/config';
 import { gasSpeedState } from 'store/wallet';
 import { newGetExchangeRatesForCurrencies } from 'utils/currencies';
 import { zeroBN } from 'utils/formatters/number';
-import logError from 'utils/logError';
 import { getTransactionPrice } from 'utils/network';
 
 export default function useEstimateGasCost() {
@@ -52,7 +51,7 @@ export default function useEstimateGasCost() {
 			const metaTx = await contract?.populateTransaction[method](...params);
 			if (!metaTx || !gasLimit || !gasPrice?.gasPrice) return { gasPrice: null, gasLimit: null };
 			const gasBuffer = gasLimit.mul(buffer).div(100);
-			const gasLimitWithBuffer = buffer ? gasLimit.add(gasBuffer) : gasLimit;
+			const gasLimitWithBuffer = gasLimit.add(gasBuffer);
 			const l1Fee = await sdk.transactions.getOptimismLayerOneFees({
 				...metaTx,
 				gasPrice: gasPrice?.gasPrice?.toNumber(),

--- a/hooks/useEstimateGasCost.ts
+++ b/hooks/useEstimateGasCost.ts
@@ -1,5 +1,5 @@
 import useSynthetixQueries from '@synthetixio/queries';
-import Wei from '@synthetixio/wei';
+import Wei, { wei } from '@synthetixio/wei';
 import { Contract } from 'ethers';
 import { useMemo, useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -61,5 +61,19 @@ export default function useEstimateGasCost() {
 		[gasPrice, ethPriceRate]
 	);
 
-	return { estimateSnxTxGasCost, estimateEthersContractTxCost };
+	const estimateEthersContractGasLimit = useCallback(
+		async (contract: Contract, method: string, params: any[]): Promise<Wei | undefined> => {
+			try {
+				if (!contract?.estimateGas[method]) throw new Error('Invalid contract method');
+				const gasLimit = await contract?.estimateGas[method](...params);
+				return wei(gasLimit, 0, true);
+			} catch (err) {
+				logError(err);
+				return;
+			}
+		},
+		[]
+	);
+
+	return { estimateSnxTxGasCost, estimateEthersContractTxCost, estimateEthersContractGasLimit };
 }

--- a/hooks/useEstimateGasCost.ts
+++ b/hooks/useEstimateGasCost.ts
@@ -41,39 +41,34 @@ export default function useEstimateGasCost() {
 	);
 
 	const estimateEthersContractTxCost = useCallback(
-		async (contract: Contract, method: string, params: any[]): Promise<Wei> => {
+		async (
+			contract: Contract,
+			method: string,
+			params: any[],
+			buffer?: number
+		): Promise<[Wei, Wei | undefined]> => {
 			try {
 				if (!contract?.estimateGas[method]) throw new Error('Invalid contract method');
 				const gasLimit = await contract?.estimateGas[method](...params);
 				const metaTx = await contract?.populateTransaction[method](...params);
-				if (!metaTx || !gasLimit || !gasPrice?.gasPrice) return zeroBN;
+				if (!metaTx || !gasLimit || !gasPrice?.gasPrice) return [zeroBN, undefined];
+				const gasLimitWithBuffer = buffer ? gasLimit.add(buffer) : gasLimit;
 				const l1Fee = await sdk.transactions.getOptimismLayerOneFees({
 					...metaTx,
 					gasPrice: gasPrice?.gasPrice?.toNumber(),
-					gasLimit: Number(gasLimit),
+					gasLimit: Number(gasLimitWithBuffer),
 				});
-				return getTransactionPrice(gasPrice, gasLimit, ethPriceRate, l1Fee) || zeroBN;
+				return [
+					getTransactionPrice(gasPrice, gasLimit, ethPriceRate, l1Fee) || zeroBN,
+					wei(gasLimitWithBuffer, 0, true),
+				];
 			} catch (err) {
 				logError(err);
-				return zeroBN;
+				return [zeroBN, undefined];
 			}
 		},
 		[gasPrice, ethPriceRate]
 	);
 
-	const estimateEthersContractGasLimit = useCallback(
-		async (contract: Contract, method: string, params: any[]): Promise<Wei | undefined> => {
-			try {
-				if (!contract?.estimateGas[method]) throw new Error('Invalid contract method');
-				const gasLimit = await contract?.estimateGas[method](...params);
-				return wei(gasLimit, 0, true);
-			} catch (err) {
-				logError(err);
-				return;
-			}
-		},
-		[]
-	);
-
-	return { estimateSnxTxGasCost, estimateEthersContractTxCost, estimateEthersContractGasLimit };
+	return { estimateSnxTxGasCost, estimateEthersContractTxCost };
 }

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -472,7 +472,7 @@ const useFuturesData = () => {
 	);
 
 	const submitCrossMarginOrder = useCallback(
-		async (fromEditLeverage?: boolean) => {
+		async (fromEditLeverage?: boolean, gasLimit?: Wei) => {
 			if (!crossMarginAccountContract) return;
 			if (orderType === 'market' || fromEditLeverage) {
 				const newPosition = [
@@ -482,7 +482,9 @@ const useFuturesData = () => {
 						sizeDelta: tradeInputs.nativeSizeDelta.toBN(),
 					},
 				];
-				return await crossMarginAccountContract.distributeMargin(newPosition);
+				return await crossMarginAccountContract.distributeMargin(newPosition, {
+					gasLimit: gasLimit?.toBN(),
+				});
 			}
 			const enumType = orderType === 'limit' ? 0 : 1;
 

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -472,7 +472,7 @@ const useFuturesData = () => {
 	);
 
 	const submitCrossMarginOrder = useCallback(
-		async (fromEditLeverage?: boolean, gasLimit?: Wei) => {
+		async (fromEditLeverage?: boolean, gasLimit?: Wei | null) => {
 			if (!crossMarginAccountContract) return;
 			if (orderType === 'market' || fromEditLeverage) {
 				const newPosition = [

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -123,7 +123,7 @@ function ClosePositionModal({
 					variant="flat"
 					size="lg"
 					onClick={onClosePosition}
-					disabled={!!error || disabled}
+					disabled={!!error || disabled || gasFee.eq(0)}
 				>
 					{t('futures.market.user.position.modal.title')}
 				</StyledButton>

--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -19,7 +19,7 @@ import { formatCurrency, formatDollars, formatNumber, zeroBN } from 'utils/forma
 import { PositionSide } from '../types';
 
 type ClosePositionModalProps = {
-	gasFee: Wei;
+	gasFee: Wei | null;
 	positionDetails: FuturesFilledPosition | null | undefined;
 	disabled?: boolean;
 	errorMessage?: string | null | undefined;
@@ -123,7 +123,7 @@ function ClosePositionModal({
 					variant="flat"
 					size="lg"
 					onClick={onClosePosition}
-					disabled={!!error || disabled || gasFee.eq(0)}
+					disabled={!!error || disabled || !!gasFee}
 				>
 					{t('futures.market.user.position.modal.title')}
 				</StyledButton>

--- a/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
+++ b/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
@@ -4,6 +4,7 @@ import { useMemo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
+import { DEFAULT_CROSSMARGIN_GAS_BUFFER } from 'constants/defaults';
 import { useFuturesContext } from 'contexts/FuturesContext';
 import { useRefetchContext } from 'contexts/RefetchContext';
 import { monitorTransaction } from 'contexts/RelayerContext';
@@ -17,7 +18,6 @@ import logError from 'utils/logError';
 
 import { PositionSide } from '../types';
 import ClosePositionModal from './ClosePositionModal';
-import { DEFAULT_CROSSMARGIN_GAS_BUFFER } from 'constants/defaults';
 
 type Props = {
 	onDismiss: () => void;

--- a/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
+++ b/sections/futures/PositionCard/ClosePositionModalCrossMargin.tsx
@@ -4,7 +4,7 @@ import { useMemo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
-import { DEFAULT_CROSSMARGIN_GAS_BUFFER } from 'constants/defaults';
+import { DEFAULT_CROSSMARGIN_GAS_BUFFER_PCT } from 'constants/defaults';
 import { useFuturesContext } from 'contexts/FuturesContext';
 import { useRefetchContext } from 'contexts/RefetchContext';
 import { monitorTransaction } from 'contexts/RelayerContext';
@@ -30,8 +30,8 @@ export default function ClosePositionModalCrossMargin({ onDismiss }: Props) {
 	const { resetTradeState } = useFuturesContext();
 	const { estimateEthersContractTxCost } = useEstimateGasCost();
 
-	const [crossMarginGasFee, setCrossMarginGasFee] = useState<Wei>(zeroBN);
-	const [crossMarginGasLimit, setCrossMarginGasLimit] = useState<Wei | undefined>();
+	const [crossMarginGasFee, setCrossMarginGasFee] = useState<Wei | null>(null);
+	const [crossMarginGasLimit, setCrossMarginGasLimit] = useState<Wei | null>(null);
 	const [error, setError] = useState<null | string>(null);
 
 	const currencyKey = useRecoilValue(currentMarketState);
@@ -69,13 +69,13 @@ export default function ClosePositionModalCrossMargin({ onDismiss }: Props) {
 	useEffect(() => {
 		if (!crossMarginAccountContract) return;
 		const estimateGas = async () => {
-			const [fee, gasLimit] = await estimateEthersContractTxCost(
+			const { gasPrice, gasLimit } = await estimateEthersContractTxCost(
 				crossMarginAccountContract,
 				'distributeMargin',
 				[crossMarginCloseParams],
-				DEFAULT_CROSSMARGIN_GAS_BUFFER
+				DEFAULT_CROSSMARGIN_GAS_BUFFER_PCT
 			);
-			setCrossMarginGasFee(fee);
+			setCrossMarginGasFee(gasPrice);
 			setCrossMarginGasLimit(gasLimit);
 		};
 		estimateGas();

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -26,7 +26,7 @@ import BaseDrawer from '../MobileTrade/drawers/BaseDrawer';
 import { PositionSide } from '../types';
 
 type Props = {
-	gasFee: Wei;
+	gasFee: Wei | null;
 	tradeFee: Wei;
 	keeperFee?: Wei | null;
 	errorMessage?: string | null | undefined;
@@ -155,7 +155,7 @@ export default function TradeConfirmationModal({
 						data-testid="trade-open-position-confirm-order-button"
 						variant="flat"
 						onClick={onConfirmOrder}
-						disabled={!positionDetails || !!disabledReason || gasFee.eq(0)}
+						disabled={!positionDetails || !!disabledReason || !!gasFee}
 					>
 						{disabledReason || t('futures.market.trade.confirmation.modal.confirm-order')}
 					</ConfirmTradeButton>

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -155,7 +155,7 @@ export default function TradeConfirmationModal({
 						data-testid="trade-open-position-confirm-order-button"
 						variant="flat"
 						onClick={onConfirmOrder}
-						disabled={!positionDetails || !!disabledReason}
+						disabled={!positionDetails || !!disabledReason || gasFee.eq(0)}
 					>
 						{disabledReason || t('futures.market.trade.confirmation.modal.confirm-order')}
 					</ConfirmTradeButton>

--- a/sections/futures/Trade/TradeConfirmationModalCrossMargin.tsx
+++ b/sections/futures/Trade/TradeConfirmationModalCrossMargin.tsx
@@ -28,7 +28,7 @@ export default function TradeConfirmationModalCrossMargin() {
 	const { t } = useTranslation();
 	const { handleRefetch, refetchUntilUpdate } = useRefetchContext();
 	const { crossMarginAccountContract } = useCrossMarginAccountContracts();
-	const { estimateEthersContractTxCost, estimateEthersContractGasLimit } = useEstimateGasCost();
+	const { estimateEthersContractTxCost } = useEstimateGasCost();
 
 	const marketAsset = useRecoilValue(currentMarketState);
 	const crossMarginMarginDelta = useRecoilValue(crossMarginMarginDeltaState);
@@ -53,15 +53,15 @@ export default function TradeConfirmationModalCrossMargin() {
 					sizeDelta: tradeInputs.nativeSizeDelta.toBN(),
 				},
 			];
-			const [estimatedFee, estimatedGasLimit] = await Promise.all([
-				estimateEthersContractTxCost(crossMarginAccountContract, 'distributeMargin', [newPosition]),
-				estimateEthersContractGasLimit(crossMarginAccountContract, 'distributeMargin', [
-					newPosition,
-				]),
-			]);
+			const [estimatedFee, estimatedGasLimit] = await estimateEthersContractTxCost(
+				crossMarginAccountContract,
+				'distributeMargin',
+				[newPosition],
+				DEFAULT_CROSSMARGIN_GAS_BUFFER
+			);
 
 			setGasFee(estimatedFee);
-			setGasLimit(estimatedGasLimit?.add(DEFAULT_CROSSMARGIN_GAS_BUFFER));
+			setGasLimit(estimatedGasLimit);
 		};
 		estimateGas();
 	}, [
@@ -70,7 +70,6 @@ export default function TradeConfirmationModalCrossMargin() {
 		crossMarginMarginDelta,
 		tradeInputs.nativeSizeDelta,
 		estimateEthersContractTxCost,
-		estimateEthersContractGasLimit,
 	]);
 
 	const onDismiss = useCallback(() => {

--- a/sections/futures/Trade/TradeConfirmationModalCrossMargin.tsx
+++ b/sections/futures/Trade/TradeConfirmationModalCrossMargin.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-import { DEFAULT_CROSSMARGIN_GAS_BUFFER } from 'constants/defaults';
+import { DEFAULT_CROSSMARGIN_GAS_BUFFER_PCT } from 'constants/defaults';
 import { useFuturesContext } from 'contexts/FuturesContext';
 import { useRefetchContext } from 'contexts/RefetchContext';
 import { monitorTransaction } from 'contexts/RelayerContext';
@@ -40,8 +40,8 @@ export default function TradeConfirmationModalCrossMargin() {
 	const setConfirmationModalOpen = useSetRecoilState(confirmationModalOpenState);
 
 	const [error, setError] = useState<null | string>(null);
-	const [gasFee, setGasFee] = useState<Wei>(zeroBN);
-	const [gasLimit, setGasLimit] = useState<Wei | undefined>();
+	const [gasFee, setGasFee] = useState<Wei | null>(null);
+	const [gasLimit, setGasLimit] = useState<Wei | null>(null);
 
 	useEffect(() => {
 		if (!crossMarginAccountContract) return;
@@ -53,15 +53,15 @@ export default function TradeConfirmationModalCrossMargin() {
 					sizeDelta: tradeInputs.nativeSizeDelta.toBN(),
 				},
 			];
-			const [estimatedFee, estimatedGasLimit] = await estimateEthersContractTxCost(
+			const { gasPrice, gasLimit } = await estimateEthersContractTxCost(
 				crossMarginAccountContract,
 				'distributeMargin',
 				[newPosition],
-				DEFAULT_CROSSMARGIN_GAS_BUFFER
+				DEFAULT_CROSSMARGIN_GAS_BUFFER_PCT
 			);
 
-			setGasFee(estimatedFee);
-			setGasLimit(estimatedGasLimit);
+			setGasFee(gasPrice);
+			setGasLimit(gasLimit);
 		};
 		estimateGas();
 	}, [
@@ -119,7 +119,7 @@ export default function TradeConfirmationModalCrossMargin() {
 			onConfirmOrder={handleConfirmOrder}
 			tradeFee={tradeFees.total}
 			keeperFee={isAdvancedOrder ? tradeFees.keeperEthDeposit : null}
-			gasFee={gasFee}
+			gasFee={gasFee ?? zeroBN}
 			errorMessage={error}
 		/>
 	);


### PR DESCRIPTION
Add a 50k gas buffer when calling `distributeMargin`

## Issue
- #1606 

## Description
* Add 50k gas buffer constant
* Add optional gas limit parameter to cross margin trades
* Submit gas estimate + buffer when modifying or closing cross margin positions
