### PR TITLE
Hardcoded gas of staking txns

### DIFF
--- a/hooks/useStakingData.ts
+++ b/hooks/useStakingData.ts
@@ -23,7 +23,11 @@ import stakingRewardsABI from 'lib/abis/StakingRewards.json';
 import supplyScheduleABI from 'lib/abis/SupplySchedule.json';
 import veKwentaRedeemerABI from 'lib/abis/veKwentaRedeemer.json';
 import vKwentaRedeemerABI from 'lib/abis/vKwentaRedeemer.json';
-import { getEpochDetails } from 'queries/staking/utils';
+import {
+	getEpochDetails,
+	STAKING_HIGH_GAS_LIMIT,
+	STAKING_LOW_GAS_LIMIT,
+} from 'queries/staking/utils';
 import { formatTruncatedDuration } from 'utils/formatters/date';
 import { zeroBN } from 'utils/formatters/number';
 import logError from 'utils/logError';
@@ -281,6 +285,9 @@ const useStakingData = () => {
 	const { config: getRewardConfig } = usePrepareContractWrite({
 		...stakingRewardsContract,
 		functionName: 'getReward',
+		overrides: {
+			gasLimit: STAKING_HIGH_GAS_LIMIT,
+		},
 		enabled: claimableBalance.gt(0),
 	});
 
@@ -308,6 +315,9 @@ const useStakingData = () => {
 	const { config: vKwentaRedeemConfig } = usePrepareContractWrite({
 		...vKwentaRedeemerContract,
 		functionName: 'redeem',
+		overrides: {
+			gasLimit: STAKING_LOW_GAS_LIMIT,
+		},
 		enabled: !!walletAddress && wei(vKwentaBalance).gt(0),
 	});
 
@@ -315,6 +325,9 @@ const useStakingData = () => {
 		...veKwentaRedeemerContract,
 		functionName: 'redeem',
 		args: [walletAddress],
+		overrides: {
+			gasLimit: STAKING_HIGH_GAS_LIMIT,
+		},
 		enabled: !!walletAddress && wei(veKwentaBalance).gt(0),
 	});
 

--- a/queries/staking/utils.ts
+++ b/queries/staking/utils.ts
@@ -7,6 +7,8 @@ export const WEEK = 604800;
 export const DECAY_RATE = 0.0205;
 export const INITIAL_WEEKLY_SUPPLY = 14463.36923076923076923;
 export const STAKING_REWARDS_RATIO = 0.6;
+export const STAKING_HIGH_GAS_LIMIT = 400000;
+export const STAKING_LOW_GAS_LIMIT = 200000;
 
 export function getEpochDetails(networkId: number, epoch: number) {
 	const currentEpochTime = EPOCH_START[networkId]

--- a/sections/dashboard/Stake/EscrowTable.tsx
+++ b/sections/dashboard/Stake/EscrowTable.tsx
@@ -11,6 +11,7 @@ import { TableCellHead } from 'components/Table/Table';
 import { monitorTransaction } from 'contexts/RelayerContext';
 import { useStakingContext } from 'contexts/StakingContext';
 import { EscrowRow } from 'hooks/useStakingData';
+import { STAKING_LOW_GAS_LIMIT } from 'queries/staking/utils';
 import { truncateNumbers } from 'utils/formatters/number';
 
 import { StakingCard } from './common';
@@ -74,6 +75,9 @@ const EscrowTable = () => {
 	const { config } = usePrepareContractWrite({
 		...rewardEscrowContract,
 		functionName: 'vest',
+		overrides: {
+			gasLimit: STAKING_LOW_GAS_LIMIT,
+		},
 		args: [escrowRows.filter((d, index) => !!checkedState[index]).map((d) => d.id)],
 		enabled: escrowRows.filter((d, index) => !!checkedState[index]).map((d) => d.id).length > 0,
 	});

--- a/sections/dashboard/Stake/InputCards/EscrowInputCard.tsx
+++ b/sections/dashboard/Stake/InputCards/EscrowInputCard.tsx
@@ -11,6 +11,7 @@ import SegmentedControl from 'components/SegmentedControl';
 import { DEFAULT_CRYPTO_DECIMALS, DEFAULT_TOKEN_DECIMALS } from 'constants/defaults';
 import { monitorTransaction } from 'contexts/RelayerContext';
 import { useStakingContext } from 'contexts/StakingContext';
+import { STAKING_LOW_GAS_LIMIT } from 'queries/staking/utils';
 import { truncateNumbers, zeroBN } from 'utils/formatters/number';
 
 import { StakingCard } from '../common';
@@ -64,7 +65,7 @@ const EscrowInputCard: FC = () => {
 		functionName: 'stakeEscrow',
 		args: [amountBN],
 		overrides: {
-			gasLimit: 200000,
+			gasLimit: STAKING_LOW_GAS_LIMIT,
 		},
 		enabled: activeTab === 0 && unstakedEscrowedKwentaBalance.gt(0) && !!parseFloat(amount),
 	});
@@ -73,6 +74,9 @@ const EscrowInputCard: FC = () => {
 		...rewardEscrowContract,
 		functionName: 'unstakeEscrow',
 		args: [amountBN],
+		overrides: {
+			gasLimit: STAKING_LOW_GAS_LIMIT,
+		},
 		enabled: activeTab === 1 && stakedEscrowedBalance.gt(0) && !!parseFloat(amount),
 	});
 

--- a/sections/dashboard/Stake/InputCards/StakeInputCard.tsx
+++ b/sections/dashboard/Stake/InputCards/StakeInputCard.tsx
@@ -11,6 +11,7 @@ import SegmentedControl from 'components/SegmentedControl';
 import { DEFAULT_CRYPTO_DECIMALS, DEFAULT_TOKEN_DECIMALS } from 'constants/defaults';
 import { monitorTransaction } from 'contexts/RelayerContext';
 import { useStakingContext } from 'contexts/StakingContext';
+import { STAKING_LOW_GAS_LIMIT } from 'queries/staking/utils';
 import { truncateNumbers, zeroBN } from 'utils/formatters/number';
 
 import { StakingCard } from '../common';
@@ -52,6 +53,9 @@ const StakeInputCard: FC = () => {
 		...stakingRewardsContract,
 		functionName: 'stake',
 		args: [amountBN],
+		overrides: {
+			gasLimit: STAKING_LOW_GAS_LIMIT,
+		},
 		enabled: activeTab === 0 && kwentaBalance.gt(0) && !!parseFloat(amount),
 	});
 
@@ -59,6 +63,9 @@ const StakeInputCard: FC = () => {
 		...stakingRewardsContract,
 		functionName: 'unstake',
 		args: [amountBN],
+		overrides: {
+			gasLimit: STAKING_LOW_GAS_LIMIT,
+		},
 		enabled: activeTab === 1 && stakedNonEscrowedBalance.gt(0) && !!parseFloat(amount),
 	});
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We find that lots of users reported `out of gas` error so we did an analysis with the existing txns and decided to set a hardcoded value for each function.

#### Rewards Escrow
| Function       | Failed Txns | Total Txns | Failure Rate |
|----------------|-------------|------------|--------------|
| Stake Escrow   |         102 |       1085 |         9.4% |
| Unstake Escrow |           4 |         20 |          20% |
| Vest           |           1 |         37 |         2.7% |
| Total          |         107 |       1156 |         9.3% |

#### Staking Rewards
| Function   | Failed Txns | Total Txns | Failure Rate |
|------------|-------------|------------|--------------|
| Get Reward |          52 |        553 |         9.4% |
| Stake      |          28 |        332 |         8.4% |
| Unstake    |           1 |         66 |         1.5% |
| Total      |          81 |        957 |         8.5% |

#### vKwenta Redeemer
| Function   | Failed Txns | Total Txns | Failure Rate |
|------------|-------------|------------|--------------|
| Redeem |          9 |        264 |         3.4% |

#### veKwenta Redeemer
| Function   | Failed Txns | Total Txns | Failure Rate |
|------------|-------------|------------|--------------|
| Redeem |          9 |        337 |         2.67% |

The different hardcoded value has been set to the following functions.
| Function   | Gas Limit | 
|------------|-------------|
| Get Reward |     400,000 |      
| veKwenta Redeem |   400,000 |      
| Others |   200,000 |      

## Related issue
#1606 

## Motivation and Context
Make UX more smoothly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
