### PR TITLE
Bug: Fix modal button conditions

### DIFF
--- a/sections/futures/PositionCard/ClosePositionModal.tsx
+++ b/sections/futures/PositionCard/ClosePositionModal.tsx
@@ -123,7 +123,7 @@ function ClosePositionModal({
 					variant="flat"
 					size="lg"
 					onClick={onClosePosition}
-					disabled={!!error || disabled || !!gasFee}
+					disabled={!!error || disabled || gasFee?.eq(0)}
 				>
 					{t('futures.market.user.position.modal.title')}
 				</StyledButton>

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -155,7 +155,7 @@ export default function TradeConfirmationModal({
 						data-testid="trade-open-position-confirm-order-button"
 						variant="flat"
 						onClick={onConfirmOrder}
-						disabled={!positionDetails || !!disabledReason || !!gasFee}
+						disabled={!positionDetails || !!disabledReason || gasFee?.eq(0)}
 					>
 						{disabledReason || t('futures.market.trade.confirmation.modal.confirm-order')}
 					</ConfirmTradeButton>


### PR DESCRIPTION
Fixing a bug on the trade confirmation modal where the "disabled" condition is set incorrectly.