### PR TITLE
fix: disabled claim rewards button if the reward is not greater that 0.

### DIFF
--- a/sections/earn/StakeGrid.tsx
+++ b/sections/earn/StakeGrid.tsx
@@ -45,7 +45,14 @@ const StakeGrid = () => {
 		<GridContainer>
 			<GridData title="Your Yield / Day" value={yieldPerDay} hasKwentaLogo />
 			<GridData title="Your Rewards" value={truncateNumbers(earnedRewards, 4)} hasKwentaLogo>
-				<Button fullWidth variant="flat" size="sm" style={{ marginTop: 10 }} onClick={handleClaim}>
+				<Button
+					fullWidth
+					variant="flat"
+					size="sm"
+					style={{ marginTop: 10 }}
+					disabled={!toWei(earnedRewards).gt(0)}
+					onClick={handleClaim}
+				>
 					Claim Rewards
 				</Button>
 			</GridData>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevent additional gas fees cost.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to `/dashboard/earn/` page and see if the `Claim Rewards` button is disabled.

## Screenshots (if appropriate):
<img width="464" alt="Screen Shot 2022-11-19 at 14 14 02" src="https://user-images.githubusercontent.com/31362988/202837406-c650df39-eb95-4727-8055-619f221d43b4.png">
