### PR TITLE
Remove the hardcoded gas limit of vest and fix the missing vestable on dashboard

### DIFF
--- a/hooks/useStakingData.ts
+++ b/hooks/useStakingData.ts
@@ -114,6 +114,7 @@ const useStakingData = () => {
 	const [kwentaAllowance, setKwentaAllowance] = useState(zeroBN);
 	const [veKwentaBalance, setVEKwentaBalance] = useState(zeroBN);
 	const [veKwentaAllowance, setVEKwentaAllowance] = useState(zeroBN);
+	const [totalVestable, setTotalVestable] = useState(0);
 
 	const { refetch: resetStakingState } = useContractReads({
 		contracts: [
@@ -255,12 +256,12 @@ const useStakingData = () => {
 				escrowRows[index].vestable = Number(d?.quantity / 1e18) ?? 0;
 				escrowRows[index].fee = Number(d?.fee / 1e18) ?? 0;
 			});
+			setTotalVestable(
+				Object.values(escrowRows)
+					.map((d) => d.vestable)
+					.reduce((acc, curr) => acc + curr, 0)
 		},
 	});
-
-	const totalVestable = useMemo(() => {
-		return escrowRows.reduce((acc, row) => wei(acc).add(wei(row.vestable ?? 0)) ?? zeroBN, zeroBN);
-	}, [escrowRows]);
 
 	const resetTime = useMemo(() => {
 		const { epochEnd } = getEpochDetails(network?.id, epochPeriod);

--- a/hooks/useStakingData.ts
+++ b/hooks/useStakingData.ts
@@ -260,6 +260,7 @@ const useStakingData = () => {
 				Object.values(escrowRows)
 					.map((d) => d.vestable)
 					.reduce((acc, curr) => acc + curr, 0)
+			);
 		},
 	});
 

--- a/sections/dashboard/Stake/EscrowTable.tsx
+++ b/sections/dashboard/Stake/EscrowTable.tsx
@@ -75,9 +75,6 @@ const EscrowTable = () => {
 	const { config } = usePrepareContractWrite({
 		...rewardEscrowContract,
 		functionName: 'vest',
-		overrides: {
-			gasLimit: STAKING_LOW_GAS_LIMIT,
-		},
 		args: [escrowRows.filter((d, index) => !!checkedState[index]).map((d) => d.id)],
 		enabled: escrowRows.filter((d, index) => !!checkedState[index]).map((d) => d.id).length > 0,
 	});

--- a/sections/dashboard/Stake/EscrowTable.tsx
+++ b/sections/dashboard/Stake/EscrowTable.tsx
@@ -11,7 +11,6 @@ import { TableCellHead } from 'components/Table/Table';
 import { monitorTransaction } from 'contexts/RelayerContext';
 import { useStakingContext } from 'contexts/StakingContext';
 import { EscrowRow } from 'hooks/useStakingData';
-import { STAKING_LOW_GAS_LIMIT } from 'queries/staking/utils';
 import { truncateNumbers } from 'utils/formatters/number';
 
 import { StakingCard } from './common';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#### Remove the hardcoded gas limit of vest
This is a reverted change of #1634.
After implementing #1634, the failure rate of all contracts dropped rapidly. 
In the last 24 hrs, the failure rate of `Staking Rewards` is 0.8%, and `Rewards Escrow` is 3%. No new failed txns for `Redeemer`. Also no new `out of gas error` txn is observed except for `vest` function.

However, I observed that the `Vest` has a few more failures than before. One wallet tried to vest a few entries at once and went through after four attempts. This is because the number of the vesting entries is dynamic so the hardcode gas limit is not working well for this case. Thus, I decided to remove the hardcode gas limit of `vest` function.

#### fix the missing vestable on the dashboard
The amount of vestable token  on the dashboard is off because of disabling the watch mode. This PR fixed this issue.

## Related issue
#1634 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Fixed the missing vestable amount
1. Open staking page and connect the wallet
2. The amount of vestable tokens has been updated.

## Screenshots (if appropriate):
Fixed the missing amount of vestable token 
![image](https://user-images.githubusercontent.com/4819006/202903958-49aa9bf7-fc38-4ab9-b590-2aa5e10ec3fc.png)
