### PR TITLE
Retrieve the trading rewards files on different networks

### DIFF
--- a/queries/files/useGetFiles.ts
+++ b/queries/files/useGetFiles.ts
@@ -2,22 +2,37 @@ import axios from 'axios';
 import { useQuery } from 'react-query';
 
 import QUERY_KEYS from 'constants/queryKeys';
+import Connector from 'containers/Connector';
+import useIsL2 from 'hooks/useIsL2';
 
 import { FLEEK_BASE_URL, FLEEK_STORAGE_BUCKET } from './constants';
 
-const useGetFiles = (fileNames: string[]) => {
+const useGetFiles = (periods: number[]) => {
 	const client = axios.create({
 		baseURL: `${FLEEK_BASE_URL}/${FLEEK_STORAGE_BUCKET}/data/`,
 		timeout: 5000,
 	});
-	return useQuery(QUERY_KEYS.Files.GetMultiple(fileNames), async () => {
-		let responses: any[] = [];
-		for (const fileName of fileNames) {
-			const response = await client.get(fileName);
-			responses.push(response.data ?? null);
+	const { network } = Connector.useContainer();
+	const isL2 = useIsL2();
+	const fileNames: string[] = periods
+		.slice(0, -1)
+		.map((i) => `trading-rewards-snapshots/${network.id === 420 ? `goerli-` : ''}epoch-${i}.json`);
+
+	return useQuery(
+		QUERY_KEYS.Files.GetMultiple(fileNames),
+		async () => {
+			if (!isL2) return null;
+			let responses: any[] = [];
+			for (const fileName of fileNames) {
+				const response = await client.get(fileName);
+				responses.push(response.data ?? null);
+			}
+			return responses;
+		},
+		{
+			enabled: isL2,
 		}
-		return responses;
-	});
+	);
 };
 
 export default useGetFiles;

--- a/sections/dashboard/Stake/StakingPortfolio.tsx
+++ b/sections/dashboard/Stake/StakingPortfolio.tsx
@@ -10,6 +10,7 @@ import media from 'styles/media';
 import { truncateNumbers } from 'utils/formatters/number';
 
 import { SplitStakingCard } from './common';
+import { wei } from '@synthetixio/wei';
 
 const StakingPortfolio = () => {
 	const { t } = useTranslation();
@@ -56,7 +57,7 @@ const StakingPortfolio = () => {
 			{
 				key: 'Vestable',
 				title: t('dashboard.stake.portfolio.vestable'),
-				value: truncateNumbers(totalVestable, 2),
+				value: truncateNumbers(wei(totalVestable), 2),
 			},
 		],
 	];

--- a/sections/dashboard/Stake/StakingPortfolio.tsx
+++ b/sections/dashboard/Stake/StakingPortfolio.tsx
@@ -1,3 +1,4 @@
+import { wei } from '@synthetixio/wei';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -10,7 +11,6 @@ import media from 'styles/media';
 import { truncateNumbers } from 'utils/formatters/number';
 
 import { SplitStakingCard } from './common';
-import { wei } from '@synthetixio/wei';
 
 const StakingPortfolio = () => {
 	const { t } = useTranslation();

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -190,7 +190,7 @@ const TradingRewardsTab: React.FC<TradingRewardProps> = ({
 						<div className="title">
 							{t('dashboard.stake.tabs.trading-rewards.future-fee-paid', { EpochPeriod: period })}
 						</div>
-						<div className="value">{formatDollars(feePaid, { minDecimals: 4 })}</div>
+						<div className="value">{formatDollars(futuresFeePaid, { minDecimals: 4 })}</div>
 					</div>
 					<div>
 						<div className="title">

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -54,15 +54,7 @@ const TradingRewardsTab: React.FC<TradingRewardProps> = ({
 		resetVestingClaimable,
 	} = useStakingContext();
 
-	const fileNames = useMemo(() => {
-		let fileNames: string[] = [];
-		periods.slice(0, -1).forEach((i) => {
-			fileNames.push(`trading-rewards-snapshots/epoch-${i}.json`);
-		});
-		return fileNames;
-	}, [periods]);
-
-	const allEpochQuery = useGetFiles(fileNames);
+	const allEpochQuery = useGetFiles(periods);
 	const allEpochData = useMemo(() => allEpochQuery?.data ?? [], [allEpochQuery?.data]);
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1.The logic of retrieving the trading rewards file has been changed as follows:
- If the user connects to the optimism goerli, the dapp will read the files by name `goerli-epoch-${x}.json`, x = [0, the current distribution epoch -1].
- If the user connects to the optimism mainnet, the dapp will read the files by name `epoch-${x}.json`, x = [0, the current distribution epoch -1].

2.Bug fixes:
- Set initial value of the `vestable` on staking dashboard from `0` to `0.00`
- Show the correct `futures fee` (now it shows the `total fees`) under `Trading Rewards` tab

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Waiting for the generation of `epoch-0.json` on optimism mainnet.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/202922979-16b14f71-47a5-4129-9a47-88d494eaae0a.png)
![image](https://user-images.githubusercontent.com/4819006/203412513-cdfcd029-c4f2-4dcb-b52d-0d0a2f6855a7.png)
![image](https://user-images.githubusercontent.com/4819006/203412607-22df6d23-cef3-41c9-9fe9-72b6f9c5ad82.png)
