### PR TITLE
Optimize 1inch swap params to reduce the gas

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -33,6 +33,9 @@ export const DEFAULT_TOKEN_DECIMALS = 18;
 // for DEX aggregators like 1inch
 export const DEFAULT_SLIPPAGE = 1;
 export const DEFAULT_1INCH_SLIPPAGE = 3;
+export const COMPLEXITY_LEVEL = 0;
+export const MAIN_ROUTE_PARTS = 1;
+export const SPLIT_PARTS = 1;
 
 // for Trading History
 export const DEFAULT_NUMBER_OF_TRADES: number = 16;

--- a/sdk/services/exchange.ts
+++ b/sdk/services/exchange.ts
@@ -18,7 +18,7 @@ import {
 	ETH_ADDRESS,
 	ETH_COINGECKO_ADDRESS,
 } from 'constants/currency';
-import { DEFAULT_1INCH_SLIPPAGE } from 'constants/defaults';
+import { COMPLEXITY_LEVEL, DEFAULT_1INCH_SLIPPAGE, MAIN_ROUTE_PARTS, SPLIT_PARTS } from 'constants/defaults';
 import { ATOMIC_EXCHANGE_SLIPPAGE } from 'constants/exchange';
 import { ETH_UNIT } from 'constants/network';
 import erc20Abi from 'lib/abis/ERC20.json';
@@ -46,6 +46,7 @@ import {
 	OneInchSwapResponse,
 	OneInchTokenListResponse,
 } from '../types/1inch';
+import { MainContent } from 'styles/common';
 
 type CurrencyRate = ethers.BigNumberish;
 type SynthRatesTuple = [string[], CurrencyRate[]];
@@ -922,6 +923,9 @@ export default class ExchangeService {
 				PROTOCOLS,
 				referrerAddress: KWENTA_REFERRAL_ADDRESS,
 				disableEstimate: true,
+				complexityLevel: COMPLEXITY_LEVEL,
+				mainRouteParts: MAIN_ROUTE_PARTS,
+				parts: SPLIT_PARTS,
 			},
 		});
 
@@ -948,6 +952,9 @@ export default class ExchangeService {
 				amount: params.amount,
 				disableEstimate: true,
 				PROTOCOLS,
+				complexityLevel: COMPLEXITY_LEVEL,
+				mainRouteParts: MAIN_ROUTE_PARTS,
+				parts: SPLIT_PARTS,
 			},
 		});
 

--- a/sdk/services/exchange.ts
+++ b/sdk/services/exchange.ts
@@ -18,7 +18,12 @@ import {
 	ETH_ADDRESS,
 	ETH_COINGECKO_ADDRESS,
 } from 'constants/currency';
-import { COMPLEXITY_LEVEL, DEFAULT_1INCH_SLIPPAGE, MAIN_ROUTE_PARTS, SPLIT_PARTS } from 'constants/defaults';
+import {
+	COMPLEXITY_LEVEL,
+	DEFAULT_1INCH_SLIPPAGE,
+	MAIN_ROUTE_PARTS,
+	SPLIT_PARTS,
+} from 'constants/defaults';
 import { ATOMIC_EXCHANGE_SLIPPAGE } from 'constants/exchange';
 import { ETH_UNIT } from 'constants/network';
 import erc20Abi from 'lib/abis/ERC20.json';
@@ -46,7 +51,6 @@ import {
 	OneInchSwapResponse,
 	OneInchTokenListResponse,
 } from '../types/1inch';
-import { MainContent } from 'styles/common';
 
 type CurrencyRate = ethers.BigNumberish;
 type SynthRatesTuple = [string[], CurrencyRate[]];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The gas cost of our 1inch swap is high compared to that of the same txns on 1inch UI.

## Related issue
#1597 

## Motivation and Context
To reduce the gas cost and make it close to `low gas` mode on 1inch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
