### PR TITLE
Update Aggregations

### DIFF
--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-request';
 import { chain } from 'wagmi';
 
 export const FUTURES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-futures';
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-futures';

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-request';
 import { chain } from 'wagmi';
 
 export const FUTURES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/tburm/optimism-futures';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures';
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-futures';

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -48,6 +48,8 @@ export const FUTURES_POSITION_FRAGMENT = gql`
 `;
 export const KWENTA_TRACKING_CODE = ethersUtils.formatBytes32String('KWENTA');
 
+export const AGGREGATE_ASSET_KEY = '0x';
+
 export const ORDER_PREVIEW_ERRORS = { insufficient_margin: 'Insufficient free margin' };
 export const ORDER_PREVIEW_ERRORS_I18N: Record<string, string> = {
 	insufficient_margin: 'futures.market.trade.preview.insufficient-margin',

--- a/queries/futures/subgraph.ts
+++ b/queries/futures/subgraph.ts
@@ -1087,6 +1087,175 @@ export const getFundingRateUpdates = async function <K extends keyof FundingRate
 	} while (paginationKey && options.first && results.length < options.first);
 	return options.first ? results.slice(0, options.first) : results;
 };
+export type FuturesAggregateStatFilter = {
+	id?: string | null;
+	id_not?: string | null;
+	id_gt?: string | null;
+	id_lt?: string | null;
+	id_gte?: string | null;
+	id_lte?: string | null;
+	id_in?: string[];
+	id_not_in?: string[];
+	period?: WeiSource | null;
+	period_not?: WeiSource | null;
+	period_gt?: WeiSource | null;
+	period_lt?: WeiSource | null;
+	period_gte?: WeiSource | null;
+	period_lte?: WeiSource | null;
+	period_in?: WeiSource[];
+	period_not_in?: WeiSource[];
+	timestamp?: WeiSource | null;
+	timestamp_not?: WeiSource | null;
+	timestamp_gt?: WeiSource | null;
+	timestamp_lt?: WeiSource | null;
+	timestamp_gte?: WeiSource | null;
+	timestamp_lte?: WeiSource | null;
+	timestamp_in?: WeiSource[];
+	timestamp_not_in?: WeiSource[];
+	asset?: string | null;
+	asset_not?: string | null;
+	asset_in?: string[];
+	asset_not_in?: string[];
+	asset_contains?: string | null;
+	asset_not_contains?: string | null;
+	trades?: WeiSource | null;
+	trades_not?: WeiSource | null;
+	trades_gt?: WeiSource | null;
+	trades_lt?: WeiSource | null;
+	trades_gte?: WeiSource | null;
+	trades_lte?: WeiSource | null;
+	trades_in?: WeiSource[];
+	trades_not_in?: WeiSource[];
+	volume?: WeiSource | null;
+	volume_not?: WeiSource | null;
+	volume_gt?: WeiSource | null;
+	volume_lt?: WeiSource | null;
+	volume_gte?: WeiSource | null;
+	volume_lte?: WeiSource | null;
+	volume_in?: WeiSource[];
+	volume_not_in?: WeiSource[];
+	feesKwenta?: WeiSource | null;
+	feesKwenta_not?: WeiSource | null;
+	feesKwenta_gt?: WeiSource | null;
+	feesKwenta_lt?: WeiSource | null;
+	feesKwenta_gte?: WeiSource | null;
+	feesKwenta_lte?: WeiSource | null;
+	feesKwenta_in?: WeiSource[];
+	feesKwenta_not_in?: WeiSource[];
+	feesSynthetix?: WeiSource | null;
+	feesSynthetix_not?: WeiSource | null;
+	feesSynthetix_gt?: WeiSource | null;
+	feesSynthetix_lt?: WeiSource | null;
+	feesSynthetix_gte?: WeiSource | null;
+	feesSynthetix_lte?: WeiSource | null;
+	feesSynthetix_in?: WeiSource[];
+	feesSynthetix_not_in?: WeiSource[];
+	_change_block?: any | null;
+};
+export type FuturesAggregateStatResult = {
+	id: string;
+	period: Wei;
+	timestamp: Wei;
+	asset: string;
+	trades: Wei;
+	volume: Wei;
+	feesKwenta: Wei;
+	feesSynthetix: Wei;
+};
+export type FuturesAggregateStatFields = {
+	id: true;
+	period: true;
+	timestamp: true;
+	asset: true;
+	trades: true;
+	volume: true;
+	feesKwenta: true;
+	feesSynthetix: true;
+};
+export type FuturesAggregateStatArgs<K extends keyof FuturesAggregateStatResult> = {
+	[Property in keyof Pick<FuturesAggregateStatFields, K>]: FuturesAggregateStatFields[Property];
+};
+export const getFuturesAggregateStatById = async function <
+	K extends keyof FuturesAggregateStatResult
+>(
+	url: string,
+	options: SingleQueryOptions,
+	args: FuturesAggregateStatArgs<K>
+): Promise<Pick<FuturesAggregateStatResult, K>> {
+	const res = await axios.post(url, {
+		query: generateGql('futuresAggregateStat', options, args),
+	});
+	const r = res.data as any;
+	if (r.errors && r.errors.length) {
+		throw new Error(r.errors[0].message);
+	}
+	const obj = r.data[Object.keys(r.data)[0]] as any;
+	const formattedObj: any = {};
+	if (obj['id']) formattedObj['id'] = obj['id'];
+	if (obj['period']) formattedObj['period'] = wei(obj['period'], 0);
+	if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
+	if (obj['asset']) formattedObj['asset'] = obj['asset'];
+	if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
+	if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
+	if (obj['feesKwenta']) formattedObj['feesKwenta'] = wei(obj['feesKwenta'], 0);
+	if (obj['feesSynthetix']) formattedObj['feesSynthetix'] = wei(obj['feesSynthetix'], 0);
+	return formattedObj as Pick<FuturesAggregateStatResult, K>;
+};
+export const getFuturesAggregateStats = async function <K extends keyof FuturesAggregateStatResult>(
+	url: string,
+	options: MultiQueryOptions<FuturesAggregateStatFilter, FuturesAggregateStatResult>,
+	args: FuturesAggregateStatArgs<K>
+): Promise<Pick<FuturesAggregateStatResult, K>[]> {
+	const paginatedOptions: Partial<MultiQueryOptions<
+		FuturesAggregateStatFilter,
+		FuturesAggregateStatResult
+	>> = { ...options };
+	let paginationKey: keyof FuturesAggregateStatFilter | null = null;
+	let paginationValue = '';
+	if (options.first && options.first > MAX_PAGE) {
+		paginatedOptions.first = MAX_PAGE;
+		paginatedOptions.orderBy = options.orderBy || 'id';
+		paginatedOptions.orderDirection = options.orderDirection || 'asc';
+		paginationKey = (paginatedOptions.orderBy +
+			(paginatedOptions.orderDirection === 'asc'
+				? '_gt'
+				: '_lt')) as keyof FuturesAggregateStatFilter;
+		paginatedOptions.where = { ...options.where };
+	}
+	let results: Pick<FuturesAggregateStatResult, K>[] = [];
+	do {
+		if (paginationKey && paginationValue)
+			paginatedOptions.where![paginationKey] = paginationValue as any;
+		const res = await axios.post(url, {
+			query: generateGql('futuresAggregateStats', paginatedOptions, args),
+		});
+		const r = res.data as any;
+		if (r.errors && r.errors.length) {
+			throw new Error(r.errors[0].message);
+		}
+		const rawResults = r.data[Object.keys(r.data)[0]] as any[];
+		const newResults = rawResults.map((obj) => {
+			const formattedObj: any = {};
+			if (obj['id']) formattedObj['id'] = obj['id'];
+			if (obj['period']) formattedObj['period'] = wei(obj['period'], 0);
+			if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
+			if (obj['asset']) formattedObj['asset'] = obj['asset'];
+			if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
+			if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
+			if (obj['feesKwenta']) formattedObj['feesKwenta'] = wei(obj['feesKwenta'], 0);
+			if (obj['feesSynthetix']) formattedObj['feesSynthetix'] = wei(obj['feesSynthetix'], 0);
+			return formattedObj as Pick<FuturesAggregateStatResult, K>;
+		});
+		results = results.concat(newResults);
+		if (newResults.length < 1000) {
+			break;
+		}
+		if (paginationKey) {
+			paginationValue = rawResults[rawResults.length - 1][paginatedOptions.orderBy!];
+		}
+	} while (paginationKey && options.first && results.length < options.first);
+	return options.first ? results.slice(0, options.first) : results;
+};
 export type FuturesCumulativeStatFilter = {
 	id?: string | null;
 	id_not?: string | null;
@@ -1806,125 +1975,6 @@ export const getFuturesMarkets = async function <K extends keyof FuturesMarketRe
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
 			if (obj['marketStats']) formattedObj['marketStats'] = obj['marketStats'];
 			return formattedObj as Pick<FuturesMarketResult, K>;
-		});
-		results = results.concat(newResults);
-		if (newResults.length < 1000) {
-			break;
-		}
-		if (paginationKey) {
-			paginationValue = rawResults[rawResults.length - 1][paginatedOptions.orderBy!];
-		}
-	} while (paginationKey && options.first && results.length < options.first);
-	return options.first ? results.slice(0, options.first) : results;
-};
-export type FuturesOneMinStatFilter = {
-	id?: string | null;
-	id_not?: string | null;
-	id_gt?: string | null;
-	id_lt?: string | null;
-	id_gte?: string | null;
-	id_lte?: string | null;
-	id_in?: string[];
-	id_not_in?: string[];
-	trades?: WeiSource | null;
-	trades_not?: WeiSource | null;
-	trades_gt?: WeiSource | null;
-	trades_lt?: WeiSource | null;
-	trades_gte?: WeiSource | null;
-	trades_lte?: WeiSource | null;
-	trades_in?: WeiSource[];
-	trades_not_in?: WeiSource[];
-	volume?: WeiSource | null;
-	volume_not?: WeiSource | null;
-	volume_gt?: WeiSource | null;
-	volume_lt?: WeiSource | null;
-	volume_gte?: WeiSource | null;
-	volume_lte?: WeiSource | null;
-	volume_in?: WeiSource[];
-	volume_not_in?: WeiSource[];
-	timestamp?: WeiSource | null;
-	timestamp_not?: WeiSource | null;
-	timestamp_gt?: WeiSource | null;
-	timestamp_lt?: WeiSource | null;
-	timestamp_gte?: WeiSource | null;
-	timestamp_lte?: WeiSource | null;
-	timestamp_in?: WeiSource[];
-	timestamp_not_in?: WeiSource[];
-	_change_block?: any | null;
-};
-export type FuturesOneMinStatResult = {
-	id: string;
-	trades: Wei;
-	volume: Wei;
-	timestamp: Wei;
-};
-export type FuturesOneMinStatFields = {
-	id: true;
-	trades: true;
-	volume: true;
-	timestamp: true;
-};
-export type FuturesOneMinStatArgs<K extends keyof FuturesOneMinStatResult> = {
-	[Property in keyof Pick<FuturesOneMinStatFields, K>]: FuturesOneMinStatFields[Property];
-};
-export const getFuturesOneMinStatById = async function <K extends keyof FuturesOneMinStatResult>(
-	url: string,
-	options: SingleQueryOptions,
-	args: FuturesOneMinStatArgs<K>
-): Promise<Pick<FuturesOneMinStatResult, K>> {
-	const res = await axios.post(url, {
-		query: generateGql('futuresOneMinStat', options, args),
-	});
-	const r = res.data as any;
-	if (r.errors && r.errors.length) {
-		throw new Error(r.errors[0].message);
-	}
-	const obj = r.data[Object.keys(r.data)[0]] as any;
-	const formattedObj: any = {};
-	if (obj['id']) formattedObj['id'] = obj['id'];
-	if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
-	if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
-	if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
-	return formattedObj as Pick<FuturesOneMinStatResult, K>;
-};
-export const getFuturesOneMinStats = async function <K extends keyof FuturesOneMinStatResult>(
-	url: string,
-	options: MultiQueryOptions<FuturesOneMinStatFilter, FuturesOneMinStatResult>,
-	args: FuturesOneMinStatArgs<K>
-): Promise<Pick<FuturesOneMinStatResult, K>[]> {
-	const paginatedOptions: Partial<MultiQueryOptions<
-		FuturesOneMinStatFilter,
-		FuturesOneMinStatResult
-	>> = { ...options };
-	let paginationKey: keyof FuturesOneMinStatFilter | null = null;
-	let paginationValue = '';
-	if (options.first && options.first > MAX_PAGE) {
-		paginatedOptions.first = MAX_PAGE;
-		paginatedOptions.orderBy = options.orderBy || 'id';
-		paginatedOptions.orderDirection = options.orderDirection || 'asc';
-		paginationKey = (paginatedOptions.orderBy +
-			(paginatedOptions.orderDirection === 'asc' ? '_gt' : '_lt')) as keyof FuturesOneMinStatFilter;
-		paginatedOptions.where = { ...options.where };
-	}
-	let results: Pick<FuturesOneMinStatResult, K>[] = [];
-	do {
-		if (paginationKey && paginationValue)
-			paginatedOptions.where![paginationKey] = paginationValue as any;
-		const res = await axios.post(url, {
-			query: generateGql('futuresOneMinStats', paginatedOptions, args),
-		});
-		const r = res.data as any;
-		if (r.errors && r.errors.length) {
-			throw new Error(r.errors[0].message);
-		}
-		const rawResults = r.data[Object.keys(r.data)[0]] as any[];
-		const newResults = rawResults.map((obj) => {
-			const formattedObj: any = {};
-			if (obj['id']) formattedObj['id'] = obj['id'];
-			if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
-			if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
-			if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
-			return formattedObj as Pick<FuturesOneMinStatResult, K>;
 		});
 		results = results.concat(newResults);
 		if (newResults.length < 1000) {
@@ -3939,9 +3989,9 @@ export type SynthExchangeResult = {
 };
 export type SynthExchangeFields = {
 	id: true;
-	account: true;
-	fromSynth: true;
-	toSynth: true;
+	account: ExchangerFields;
+	fromSynth: SynthFields;
+	toSynth: SynthFields;
 	fromAmount: true;
 	fromAmountInUSD: true;
 	toAmount: true;
@@ -4151,7 +4201,7 @@ export type TotalFields = {
 	timestamp: true;
 	period: true;
 	bucketMagnitude: true;
-	synth: true;
+	synth: SynthFields;
 	trades: true;
 	newExchangers: true;
 	exchangers: true;

--- a/queries/futures/useGetFuturesVolumes.ts
+++ b/queries/futures/useGetFuturesVolumes.ts
@@ -3,6 +3,7 @@ import { useQuery, UseQueryOptions } from 'react-query';
 import { useSetRecoilState } from 'recoil';
 import { chain, useNetwork } from 'wagmi';
 
+import { PERIOD_IN_SECONDS } from 'constants/period';
 import QUERY_KEYS from 'constants/queryKeys';
 import ROUTES from 'constants/routes';
 import useIsL2 from 'hooks/useIsL2';
@@ -11,7 +12,7 @@ import { calculateTimestampForPeriod } from 'utils/formatters/date';
 import logError from 'utils/logError';
 
 import { DAY_PERIOD, FUTURES_ENDPOINT_OP_MAINNET } from './constants';
-import { getFuturesHourlyStats } from './subgraph';
+import { getFuturesAggregateStats } from './subgraph';
 import { FuturesVolumes } from './types';
 import { calculateVolumes, getFuturesEndpoint } from './utils';
 
@@ -30,11 +31,12 @@ const useGetFuturesVolumes = (options?: UseQueryOptions<FuturesVolumes | null>) 
 		async () => {
 			try {
 				const minTimestamp = Math.floor(calculateTimestampForPeriod(DAY_PERIOD) / 1000);
-				const response = await getFuturesHourlyStats(
+				const response = await getFuturesAggregateStats(
 					futuresEndpoint,
 					{
 						first: 999999,
 						where: {
+							period: `${PERIOD_IN_SECONDS.ONE_HOUR}`,
 							timestamp_gte: `${minTimestamp}`,
 						},
 					},
@@ -44,6 +46,9 @@ const useGetFuturesVolumes = (options?: UseQueryOptions<FuturesVolumes | null>) 
 						volume: true,
 						trades: true,
 						timestamp: true,
+						period: true,
+						feesKwenta: true,
+						feesSynthetix: true,
 					}
 				);
 				const futuresVolumes = response ? calculateVolumes(response) : {};

--- a/queries/futures/useGetStatsVolumes.ts
+++ b/queries/futures/useGetStatsVolumes.ts
@@ -8,6 +8,7 @@ import { minTimestampState } from 'store/stats';
 import { weiFromWei } from 'utils/formatters/number';
 import logError from 'utils/logError';
 
+import { AGGREGATE_ASSET_KEY } from './constants';
 import { getFuturesAggregateStats } from './subgraph';
 import { getFuturesEndpoint } from './utils';
 
@@ -33,7 +34,7 @@ export const useGetStatsVolumes = () => {
 					where: {
 						period: `${PERIOD_IN_SECONDS.ONE_DAY}`,
 						timestamp_gt: minTimestamp,
-						asset: '0x',
+						asset: AGGREGATE_ASSET_KEY,
 					},
 				},
 				{

--- a/queries/futures/useGetStatsVolumes.ts
+++ b/queries/futures/useGetStatsVolumes.ts
@@ -1,21 +1,15 @@
+import { wei } from '@synthetixio/wei';
 import { useQuery } from 'react-query';
 import { useRecoilValue } from 'recoil';
 import { chainId } from 'wagmi';
 
+import { PERIOD_IN_SECONDS } from 'constants/period';
 import { minTimestampState } from 'store/stats';
 import { weiFromWei } from 'utils/formatters/number';
 import logError from 'utils/logError';
 
-import { getFuturesHourlyStats } from './subgraph';
+import { getFuturesAggregateStats } from './subgraph';
 import { getFuturesEndpoint } from './utils';
-
-type VolumeStatMap = Record<
-	string,
-	{
-		trades: number;
-		volume: number;
-	}
->;
 
 type VolumeStat = {
 	date: string;
@@ -30,14 +24,16 @@ export const useGetStatsVolumes = () => {
 
 	const query = async () => {
 		try {
-			const response = await getFuturesHourlyStats(
+			const response = await getFuturesAggregateStats(
 				futuresEndpoint,
 				{
 					first: 999999,
 					orderBy: 'timestamp',
 					orderDirection: 'asc',
 					where: {
+						period: `${PERIOD_IN_SECONDS.ONE_DAY}`,
 						timestamp_gt: minTimestamp,
+						asset: '0x',
 					},
 				},
 				{
@@ -48,33 +44,18 @@ export const useGetStatsVolumes = () => {
 				}
 			);
 
-			// aggregate markets into a single object
-			const summary = response.reduce((acc: VolumeStatMap, res) => {
-				const timestamp = res.timestamp.mul(1000).toNumber();
-				const date = new Date(timestamp).toISOString().split('T')[0];
-				const volume = weiFromWei(res.volume ?? 0).toNumber();
-				const trades = res.trades.toNumber();
-
-				acc[date] = {
-					volume: acc[date]?.volume ? acc[date].volume + volume : volume,
-					trades: acc[date]?.trades ? acc[date].trades + trades : trades,
+			let cumulativeTrades = wei(0);
+			const result: VolumeStat[] = response.map(({ timestamp, trades, volume }) => {
+				cumulativeTrades = cumulativeTrades.add(trades);
+				const thisTimestamp = timestamp.mul(1000).toNumber();
+				const date = new Date(thisTimestamp).toISOString().split('T')[0];
+				return {
+					date,
+					trades: trades.toNumber(),
+					volume: weiFromWei(volume ?? 0).toNumber(),
+					cumulativeTrades: cumulativeTrades.toNumber(),
 				};
-				return acc;
-			}, {});
-
-			// convert the object into an array and sort it
-			let cumulativeTrades = 0;
-			const result: VolumeStat[] = Object.entries(summary)
-				.sort((a, b) => (new Date(a[0]) > new Date(b[0]) ? 1 : -1))
-				.map(([date, { trades, volume }]) => {
-					cumulativeTrades += trades;
-					return {
-						date,
-						trades,
-						volume,
-						cumulativeTrades,
-					};
-				});
+			});
 			return result;
 		} catch (e) {
 			logError(e);

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -19,7 +19,7 @@ import {
 import { SECONDS_PER_DAY, FUTURES_ENDPOINTS } from './constants';
 import {
 	CrossMarginAccountTransferResult,
-	FuturesHourlyStatResult,
+	FuturesAggregateStatResult,
 	FuturesMarginTransferResult,
 	FuturesOrderResult,
 	FuturesOrderType,
@@ -194,7 +194,9 @@ export const mapOpenInterest = async (
 	return openInterest;
 };
 
-export const calculateVolumes = (futuresHourlyStats: FuturesHourlyStatResult[]): FuturesVolumes => {
+export const calculateVolumes = (
+	futuresHourlyStats: FuturesAggregateStatResult[]
+): FuturesVolumes => {
 	const volumes: FuturesVolumes = futuresHourlyStats.reduce(
 		(acc: FuturesVolumes, { asset, volume, trades }) => {
 			return {

--- a/testing/unit/mocks/MockProviders.tsx
+++ b/testing/unit/mocks/MockProviders.tsx
@@ -45,7 +45,7 @@ jest.mock('axios', () => ({
 jest.mock('queries/futures/subgraph', () => ({
 	__esModule: true,
 	getFuturesTrades: () => Promise.resolve([]),
-	getFuturesHourlyStats: () => Promise.resolve([]),
+	getFuturesAggregateStats: () => Promise.resolve([]),
 	getFuturesPositions: () => Promise.resolve([]),
 }));
 

--- a/testing/unit/mocks/mockQueries.ts
+++ b/testing/unit/mocks/mockQueries.ts
@@ -11,7 +11,7 @@ export const mockReactQuery = (returnValue?: any) => {
 };
 
 export const mockSubgraphQueries = () => {
-	jest.spyOn(subgraph, 'getFuturesHourlyStats').mockReturnValue(Promise.resolve([]));
+	jest.spyOn(subgraph, 'getFuturesAggregateStats').mockReturnValue(Promise.resolve([]));
 	jest.spyOn(subgraph, 'getFuturesTrades').mockReturnValue(Promise.resolve([]));
 	jest.spyOn(subgraph, 'getFuturesPositions').mockReturnValue(Promise.resolve([]));
 };


### PR DESCRIPTION
Update queries to use new `FuturesAggregateStat` entities

## Description
- Update hourly volume to use the new entity
- Update volume and trades stats to use the "all markets" entity instead of adding all individual markets

Note: The `FuturesHourlyStat` entity can be deprecated on the frontend and subgraph when this is merged.