### PR TITLE
Fixed the missing period when selecting a new option

### DIFF
--- a/sections/dashboard/Stake/StakingTabs.tsx
+++ b/sections/dashboard/Stake/StakingTabs.tsx
@@ -131,6 +131,9 @@ const StakingTabs: React.FC = () => {
 						optionPadding={'0px'}
 						value={{
 							label: currentEpochLabel,
+							period,
+							start,
+							end,
 						}}
 						menuWidth={240}
 						components={{ IndicatorSeparator, DropdownIndicator }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `period` will be reset to `undefined` randomly when the user uses the epoch selector. So the card may show `Epoch All` under the `trading rewards` tab because `All` is the default value of `period`. This PR fixed this issue.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Click on the epoch selector to browse the options
2. The `trading rewards` card always shows the previous `period`.

## Screenshots (if appropriate):
