### PR TITLE
Prevent profit calculator modal from moving when you drag inside an input

### DIFF
--- a/sections/futures/ProfitCalculator/ProfitCalculator.tsx
+++ b/sections/futures/ProfitCalculator/ProfitCalculator.tsx
@@ -136,6 +136,7 @@ const ProfitCalculator: FC<ProfitCalculatorProps> = ({ marketAsset, setOpenProfi
 				isOpen
 				title={t('futures.modals.profit-calculator.title')}
 				rndProps={{
+					cancel: 'input',
 					enableResizing: true,
 					disableDragging: false,
 					minWidth: 500,


### PR DESCRIPTION
The profit calculator modal current behaves a little weirdly since any click-and-drag event inside it results in the whole modal moving, even if the user is trying to select text inside an input on the modal. This is the default behavior of the [react-rnd](https://github.com/bokuweb/react-rnd) library used to provide the dragging implementation for the modal.

This PR fixes the weird behavior by specifying a [cancel-string](https://github.com/bokuweb/react-rnd#cancel-string) to disable the dragging movement on input elements within the modal.

## Related issue
https://github.com/Kwenta/kwenta/issues/1663

## How Has This Been Tested?
Tested on Optimism Goerli

## Video:
https://user-images.githubusercontent.com/109358247/203458855-2522d3b4-bdf0-451b-ae69-d8d103b826af.mov
