### PR TITLE
update banner and competition dates

### DIFF
--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -4,8 +4,8 @@
  */
 export const COMPETITION_DATES = {
 	// note: month starts at 0, not 1.
-	START_DATE: new Date(Date.UTC(2022, 10, 9)),
-	END_DATE: new Date(Date.UTC(2022, 10, 24)),
+	START_DATE: new Date(Date.UTC(2022, 10, 10)),
+	END_DATE: new Date(Date.UTC(2022, 10, 23)),
 };
 
 export const COMPETITION_ENABLED = true;

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -49,8 +49,9 @@ export const EXTERNAL_LINKS = {
 	Trade: {
 		NextPriceBlogPost: 'https://docs.kwenta.io/products/futures/next-price',
 	},
-	Kips: {
-		Home: 'https://kips.kwenta.io/all-kip/',
+	Governance: {
+		Kips: 'https://kips.kwenta.io/all-kip/',
+		Vote: 'https://snapshot.org/#/kwenta.eth',
 	},
 	Competition: {
 		LearnMore: 'https://mirror.xyz/kwenta.eth/s_PO64SxvuwDHz9fdHebsYeQAOOc73D3bL2q4nC6LvU',

--- a/sections/dashboard/DashboardLayout/DashboardLayout.tsx
+++ b/sections/dashboard/DashboardLayout/DashboardLayout.tsx
@@ -6,12 +6,12 @@ import styled from 'styled-components';
 import NavButton from 'components/Button/NavButton';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import { TabList, TabPanel } from 'components/Tab';
+import { EXTERNAL_LINKS } from 'constants/links';
 import ROUTES from 'constants/routes';
 import AppLayout from 'sections/shared/Layout/AppLayout';
 import { MainContent, LeftSideContent, FullHeightContainer, PageContent } from 'styles/common';
 
 import Links from '../Links';
-import { EXTERNAL_LINKS } from 'constants/links';
 
 enum Tab {
 	Overview = 'overview',

--- a/sections/dashboard/DashboardLayout/DashboardLayout.tsx
+++ b/sections/dashboard/DashboardLayout/DashboardLayout.tsx
@@ -11,6 +11,7 @@ import AppLayout from 'sections/shared/Layout/AppLayout';
 import { MainContent, LeftSideContent, FullHeightContainer, PageContent } from 'styles/common';
 
 import Links from '../Links';
+import { EXTERNAL_LINKS } from 'constants/links';
 
 enum Tab {
 	Overview = 'overview',
@@ -75,8 +76,7 @@ const DashboardLayout: FC = ({ children }) => {
 				name: Tab.Governance,
 				label: t('dashboard.tabs.governance'),
 				active: activeTab === Tab.Governance,
-				disabled: true,
-				onClick: () => {},
+				onClick: () => window.open(EXTERNAL_LINKS.Governance.Vote, '_blank'),
 			},
 		],
 		[t, activeTab, router]

--- a/sections/dashboard/DashboardLayout/DashboardLayout.tsx
+++ b/sections/dashboard/DashboardLayout/DashboardLayout.tsx
@@ -60,13 +60,6 @@ const DashboardLayout: FC = ({ children }) => {
 				onClick: () => router.push(ROUTES.Dashboard.Markets),
 			},
 			{
-				name: Tab.Governance,
-				label: t('dashboard.tabs.governance'),
-				active: activeTab === Tab.Governance,
-				disabled: true,
-				onClick: () => {},
-			},
-			{
 				name: Tab.Stake,
 				label: t('dashboard.tabs.staking'),
 				active: activeTab === Tab.Stake,
@@ -77,6 +70,13 @@ const DashboardLayout: FC = ({ children }) => {
 				label: t('dashboard.tabs.earn'),
 				active: activeTab === Tab.Earn,
 				onClick: () => router.push(ROUTES.Dashboard.Earn),
+			},
+			{
+				name: Tab.Governance,
+				label: t('dashboard.tabs.governance'),
+				active: activeTab === Tab.Governance,
+				disabled: true,
+				onClick: () => {},
 			},
 		],
 		[t, activeTab, router]
@@ -90,7 +90,7 @@ const DashboardLayout: FC = ({ children }) => {
 						<LeftSideContent>
 							<StyledTabList>
 								<TabGroupTitle>{t('dashboard.titles.trading')}</TabGroupTitle>
-								{TABS.slice(0, 4).map(({ name, label, active, disabled, onClick }) => (
+								{TABS.slice(0, 3).map(({ name, label, active, disabled, onClick }) => (
 									<NavButton
 										key={name}
 										title={name}
@@ -104,7 +104,7 @@ const DashboardLayout: FC = ({ children }) => {
 								))}
 
 								<TabGroupTitle>{t('dashboard.titles.community')}</TabGroupTitle>
-								{TABS.slice(4).map(({ name, label, active, disabled, onClick }) => (
+								{TABS.slice(3).map(({ name, label, active, disabled, onClick }) => (
 									<NavButton
 										key={name}
 										title={name}

--- a/sections/shared/Layout/AppLayout/Header/MobileUserMenu/common.ts
+++ b/sections/shared/Layout/AppLayout/Header/MobileUserMenu/common.ts
@@ -43,7 +43,7 @@ export const SUB_MENUS = {
 	],
 	[ROUTES.Home.Root]: [
 		{ label: 'Overview', link: EXTERNAL_LINKS.Docs.Governance },
-		{ label: 'KIPs', link: EXTERNAL_LINKS.Kips.Home },
+		{ label: 'KIPs', link: EXTERNAL_LINKS.Governance.Kips },
 	],
 };
 

--- a/sections/shared/Layout/HomeLayout/Footer.tsx
+++ b/sections/shared/Layout/HomeLayout/Footer.tsx
@@ -91,7 +91,7 @@ const Footer: React.FC = () => {
 				{
 					key: 'kips',
 					title: t('homepage.footer.community.kips'),
-					link: EXTERNAL_LINKS.Kips.Home,
+					link: EXTERNAL_LINKS.Governance.Kips,
 				},
 			],
 		},

--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -72,7 +72,7 @@ const Header: FC = () => {
 		{
 			id: 'kips',
 			label: t('homepage.nav.governance.kips'),
-			onClick: () => window.open(EXTERNAL_LINKS.Kips.Home, '_blank'),
+			onClick: () => window.open(EXTERNAL_LINKS.Governance.Kips, '_blank'),
 		},
 	];
 

--- a/sections/shared/Layout/HomeLayout/HomeLayout.tsx
+++ b/sections/shared/Layout/HomeLayout/HomeLayout.tsx
@@ -24,11 +24,11 @@ const HomeLayout: FC<HomeLayoutProps> = ({ children }) => (
 				<FuturesBannerLinkWrapper>
 					<>
 						<FuturesLink
-							href="https://mirror.xyz/kwenta.eth/ueasaL_H0IdPe5-U1Z6jqGfa_B2HW3xf0_CSIR34ueE"
+							href="https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff"
 							target="_blank"
 						>
-							Council nominations are live in the Kwenta Discord until Nov 22nd. Click to learn
-							more.
+							Council elections are live on Snapshot until Nov 29th. $KWENTA staker go cast your
+							vote!
 						</FuturesLink>
 					</>
 				</FuturesBannerLinkWrapper>
@@ -38,10 +38,10 @@ const HomeLayout: FC<HomeLayoutProps> = ({ children }) => (
 			<FuturesBannerContainer>
 				<>
 					<FuturesLink
-						href="https://mirror.xyz/kwenta.eth/ueasaL_H0IdPe5-U1Z6jqGfa_B2HW3xf0_CSIR34ueE"
+						href="https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff"
 						target="_blank"
 					>
-						Council nominations are live in the Kwenta Discord until Nov 22nd. Click to learn more.
+						Council elections are live on Snapshot until Nov 29th. $KWENTA staker go cast your vote!
 					</FuturesLink>
 				</>
 			</FuturesBannerContainer>

--- a/sections/shared/Layout/HomeLayout/HomeLayout.tsx
+++ b/sections/shared/Layout/HomeLayout/HomeLayout.tsx
@@ -27,7 +27,7 @@ const HomeLayout: FC<HomeLayoutProps> = ({ children }) => (
 							href="https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff"
 							target="_blank"
 						>
-							Council elections are live on Snapshot until Nov 29th. $KWENTA staker go cast your
+							Council elections are live on Snapshot until Nov 29th. $KWENTA stakers go cast your
 							vote!
 						</FuturesLink>
 					</>
@@ -41,7 +41,8 @@ const HomeLayout: FC<HomeLayoutProps> = ({ children }) => (
 						href="https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff"
 						target="_blank"
 					>
-						Council elections are live on Snapshot until Nov 29th. $KWENTA staker go cast your vote!
+						Council elections are live on Snapshot until Nov 29th. $KWENTA stakers go cast your
+						vote!
 					</FuturesLink>
 				</>
 			</FuturesBannerContainer>


### PR DESCRIPTION
## Description
- update competition banner to show correct closing date
- update landing page banner to link visitors to snapshot elections
- move Governance placeholder from "Trading" to "Community"

## Screenshots (if appropriate):

<img width="944" alt="Screenshot 2022-11-23 at 10 19 29" src="https://user-images.githubusercontent.com/548702/203556759-81029194-4a61-4fbd-8283-fcf27f941a67.png">

<img width="944" alt="Screenshot 2022-11-23 at 10 20 53" src="https://user-images.githubusercontent.com/548702/203557045-816ee69b-9217-4f9d-b369-6b6c1685db60.png">


<img width="208" alt="Screenshot 2022-11-23 at 10 38 22" src="https://user-images.githubusercontent.com/548702/203560702-db7d98a6-79b9-40e0-9706-8dfb57c2cd98.png">


