### PR TITLE
Fixed the hour display

### DIFF
--- a/hooks/useRewardsTimer.ts
+++ b/hooks/useRewardsTimer.ts
@@ -5,7 +5,7 @@ const secondsToDDHHMM = (seconds: number) => {
 	return (
 		Math.floor(seconds / (3600 * 24)) +
 		'd:' +
-		('0' + Math.floor(seconds / 3600)).slice(-2) +
+		('0' + (Math.floor(seconds / 3600) % 24)).slice(-2) +
 		'h:' +
 		('0' + (Math.floor(seconds / 60) % 60)).slice(-2) +
 		'm'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The reward timer shows the wrong hours on `Earn` page. This PR fixed this issue.
![image](https://user-images.githubusercontent.com/4819006/203849828-e4f74d63-4e01-441b-86b2-cade285e51ed.png)


## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Show the correct hours on timer

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/203849970-d2a3bc3d-e7e3-41e3-b674-825e10e064a6.png)
