### PR TITLE
Increase the default trade number to 1000

### DIFF
--- a/queries/staking/useGetFuturesFeeForAccount.ts
+++ b/queries/staking/useGetFuturesFeeForAccount.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 
-import { DEFAULT_NUMBER_OF_TRADES } from 'constants/defaults';
+import { DEFAULT_NUMBER_OF_FUTURES_FEE } from 'constants/defaults';
 import QUERY_KEYS from 'constants/queryKeys';
 import { FUTURES_ENDPOINT_OP_MAINNET } from 'queries/futures/constants';
 import { getFuturesTrades } from 'queries/futures/subgraph';
@@ -19,7 +19,7 @@ const useGetFuturesFeeForAccount = (
 			const response = await getFuturesTrades(
 				FUTURES_ENDPOINT_OP_MAINNET,
 				{
-					first: DEFAULT_NUMBER_OF_TRADES,
+					first: DEFAULT_NUMBER_OF_FUTURES_FEE,
 					where: {
 						account: account,
 						timestamp_gt: start,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The default number of trading fee query results is only 16. This PR is increasing the default number.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
