### PR TITLE
Add `marketKey` to queries

### DIFF
--- a/queries/futures/subgraph.ts
+++ b/queries/futures/subgraph.ts
@@ -1112,6 +1112,12 @@ export type FuturesAggregateStatFilter = {
 	timestamp_lte?: WeiSource | null;
 	timestamp_in?: WeiSource[];
 	timestamp_not_in?: WeiSource[];
+	marketKey?: string | null;
+	marketKey_not?: string | null;
+	marketKey_in?: string[];
+	marketKey_not_in?: string[];
+	marketKey_contains?: string | null;
+	marketKey_not_contains?: string | null;
 	asset?: string | null;
 	asset_not?: string | null;
 	asset_in?: string[];
@@ -1150,27 +1156,39 @@ export type FuturesAggregateStatFilter = {
 	feesSynthetix_lte?: WeiSource | null;
 	feesSynthetix_in?: WeiSource[];
 	feesSynthetix_not_in?: WeiSource[];
+	feesCrossMarginAccounts?: WeiSource | null;
+	feesCrossMarginAccounts_not?: WeiSource | null;
+	feesCrossMarginAccounts_gt?: WeiSource | null;
+	feesCrossMarginAccounts_lt?: WeiSource | null;
+	feesCrossMarginAccounts_gte?: WeiSource | null;
+	feesCrossMarginAccounts_lte?: WeiSource | null;
+	feesCrossMarginAccounts_in?: WeiSource[];
+	feesCrossMarginAccounts_not_in?: WeiSource[];
 	_change_block?: any | null;
 };
 export type FuturesAggregateStatResult = {
 	id: string;
 	period: Wei;
 	timestamp: Wei;
+	marketKey: string;
 	asset: string;
 	trades: Wei;
 	volume: Wei;
 	feesKwenta: Wei;
 	feesSynthetix: Wei;
+	feesCrossMarginAccounts: Wei;
 };
 export type FuturesAggregateStatFields = {
 	id: true;
 	period: true;
 	timestamp: true;
+	marketKey: true;
 	asset: true;
 	trades: true;
 	volume: true;
 	feesKwenta: true;
 	feesSynthetix: true;
+	feesCrossMarginAccounts: true;
 };
 export type FuturesAggregateStatArgs<K extends keyof FuturesAggregateStatResult> = {
 	[Property in keyof Pick<FuturesAggregateStatFields, K>]: FuturesAggregateStatFields[Property];
@@ -1194,11 +1212,14 @@ export const getFuturesAggregateStatById = async function <
 	if (obj['id']) formattedObj['id'] = obj['id'];
 	if (obj['period']) formattedObj['period'] = wei(obj['period'], 0);
 	if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
+	if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 	if (obj['asset']) formattedObj['asset'] = obj['asset'];
 	if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
 	if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
 	if (obj['feesKwenta']) formattedObj['feesKwenta'] = wei(obj['feesKwenta'], 0);
 	if (obj['feesSynthetix']) formattedObj['feesSynthetix'] = wei(obj['feesSynthetix'], 0);
+	if (obj['feesCrossMarginAccounts'])
+		formattedObj['feesCrossMarginAccounts'] = wei(obj['feesCrossMarginAccounts'], 0);
 	return formattedObj as Pick<FuturesAggregateStatResult, K>;
 };
 export const getFuturesAggregateStats = async function <K extends keyof FuturesAggregateStatResult>(
@@ -1239,11 +1260,14 @@ export const getFuturesAggregateStats = async function <K extends keyof FuturesA
 			if (obj['id']) formattedObj['id'] = obj['id'];
 			if (obj['period']) formattedObj['period'] = wei(obj['period'], 0);
 			if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
+			if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
 			if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
 			if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
 			if (obj['feesKwenta']) formattedObj['feesKwenta'] = wei(obj['feesKwenta'], 0);
 			if (obj['feesSynthetix']) formattedObj['feesSynthetix'] = wei(obj['feesSynthetix'], 0);
+			if (obj['feesCrossMarginAccounts'])
+				formattedObj['feesCrossMarginAccounts'] = wei(obj['feesCrossMarginAccounts'], 0);
 			return formattedObj as Pick<FuturesAggregateStatResult, K>;
 		});
 		results = results.concat(newResults);
@@ -1397,135 +1421,6 @@ export const getFuturesCumulativeStats = async function <
 			if (obj['averageTradeSize'])
 				formattedObj['averageTradeSize'] = wei(obj['averageTradeSize'], 0);
 			return formattedObj as Pick<FuturesCumulativeStatResult, K>;
-		});
-		results = results.concat(newResults);
-		if (newResults.length < 1000) {
-			break;
-		}
-		if (paginationKey) {
-			paginationValue = rawResults[rawResults.length - 1][paginatedOptions.orderBy!];
-		}
-	} while (paginationKey && options.first && results.length < options.first);
-	return options.first ? results.slice(0, options.first) : results;
-};
-export type FuturesHourlyStatFilter = {
-	id?: string | null;
-	id_not?: string | null;
-	id_gt?: string | null;
-	id_lt?: string | null;
-	id_gte?: string | null;
-	id_lte?: string | null;
-	id_in?: string[];
-	id_not_in?: string[];
-	asset?: string | null;
-	asset_not?: string | null;
-	asset_in?: string[];
-	asset_not_in?: string[];
-	asset_contains?: string | null;
-	asset_not_contains?: string | null;
-	trades?: WeiSource | null;
-	trades_not?: WeiSource | null;
-	trades_gt?: WeiSource | null;
-	trades_lt?: WeiSource | null;
-	trades_gte?: WeiSource | null;
-	trades_lte?: WeiSource | null;
-	trades_in?: WeiSource[];
-	trades_not_in?: WeiSource[];
-	volume?: WeiSource | null;
-	volume_not?: WeiSource | null;
-	volume_gt?: WeiSource | null;
-	volume_lt?: WeiSource | null;
-	volume_gte?: WeiSource | null;
-	volume_lte?: WeiSource | null;
-	volume_in?: WeiSource[];
-	volume_not_in?: WeiSource[];
-	timestamp?: WeiSource | null;
-	timestamp_not?: WeiSource | null;
-	timestamp_gt?: WeiSource | null;
-	timestamp_lt?: WeiSource | null;
-	timestamp_gte?: WeiSource | null;
-	timestamp_lte?: WeiSource | null;
-	timestamp_in?: WeiSource[];
-	timestamp_not_in?: WeiSource[];
-	_change_block?: any | null;
-};
-export type FuturesHourlyStatResult = {
-	id: string;
-	asset: string;
-	trades: Wei;
-	volume: Wei;
-	timestamp: Wei;
-};
-export type FuturesHourlyStatFields = {
-	id: true;
-	asset: true;
-	trades: true;
-	volume: true;
-	timestamp: true;
-};
-export type FuturesHourlyStatArgs<K extends keyof FuturesHourlyStatResult> = {
-	[Property in keyof Pick<FuturesHourlyStatFields, K>]: FuturesHourlyStatFields[Property];
-};
-export const getFuturesHourlyStatById = async function <K extends keyof FuturesHourlyStatResult>(
-	url: string,
-	options: SingleQueryOptions,
-	args: FuturesHourlyStatArgs<K>
-): Promise<Pick<FuturesHourlyStatResult, K>> {
-	const res = await axios.post(url, {
-		query: generateGql('futuresHourlyStat', options, args),
-	});
-	const r = res.data as any;
-	if (r.errors && r.errors.length) {
-		throw new Error(r.errors[0].message);
-	}
-	const obj = r.data[Object.keys(r.data)[0]] as any;
-	const formattedObj: any = {};
-	if (obj['id']) formattedObj['id'] = obj['id'];
-	if (obj['asset']) formattedObj['asset'] = obj['asset'];
-	if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
-	if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
-	if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
-	return formattedObj as Pick<FuturesHourlyStatResult, K>;
-};
-export const getFuturesHourlyStats = async function <K extends keyof FuturesHourlyStatResult>(
-	url: string,
-	options: MultiQueryOptions<FuturesHourlyStatFilter, FuturesHourlyStatResult>,
-	args: FuturesHourlyStatArgs<K>
-): Promise<Pick<FuturesHourlyStatResult, K>[]> {
-	const paginatedOptions: Partial<MultiQueryOptions<
-		FuturesHourlyStatFilter,
-		FuturesHourlyStatResult
-	>> = { ...options };
-	let paginationKey: keyof FuturesHourlyStatFilter | null = null;
-	let paginationValue = '';
-	if (options.first && options.first > MAX_PAGE) {
-		paginatedOptions.first = MAX_PAGE;
-		paginatedOptions.orderBy = options.orderBy || 'id';
-		paginatedOptions.orderDirection = options.orderDirection || 'asc';
-		paginationKey = (paginatedOptions.orderBy +
-			(paginatedOptions.orderDirection === 'asc' ? '_gt' : '_lt')) as keyof FuturesHourlyStatFilter;
-		paginatedOptions.where = { ...options.where };
-	}
-	let results: Pick<FuturesHourlyStatResult, K>[] = [];
-	do {
-		if (paginationKey && paginationValue)
-			paginatedOptions.where![paginationKey] = paginationValue as any;
-		const res = await axios.post(url, {
-			query: generateGql('futuresHourlyStats', paginatedOptions, args),
-		});
-		const r = res.data as any;
-		if (r.errors && r.errors.length) {
-			throw new Error(r.errors[0].message);
-		}
-		const rawResults = r.data[Object.keys(r.data)[0]] as any[];
-		const newResults = rawResults.map((obj) => {
-			const formattedObj: any = {};
-			if (obj['id']) formattedObj['id'] = obj['id'];
-			if (obj['asset']) formattedObj['asset'] = obj['asset'];
-			if (obj['trades']) formattedObj['trades'] = wei(obj['trades'], 0);
-			if (obj['volume']) formattedObj['volume'] = wei(obj['volume'], 0);
-			if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
-			return formattedObj as Pick<FuturesHourlyStatResult, K>;
 		});
 		results = results.concat(newResults);
 		if (newResults.length < 1000) {
@@ -1884,6 +1779,12 @@ export type FuturesMarketFilter = {
 	asset_not_in?: string[];
 	asset_contains?: string | null;
 	asset_not_contains?: string | null;
+	marketKey?: string | null;
+	marketKey_not?: string | null;
+	marketKey_in?: string[];
+	marketKey_not_in?: string[];
+	marketKey_contains?: string | null;
+	marketKey_not_contains?: string | null;
 	marketStats?: string | null;
 	marketStats_not?: string | null;
 	marketStats_gt?: string | null;
@@ -1910,11 +1811,13 @@ export type FuturesMarketFilter = {
 export type FuturesMarketResult = {
 	id: string;
 	asset: string;
+	marketKey: string;
 	marketStats: Partial<FuturesCumulativeStatResult>;
 };
 export type FuturesMarketFields = {
 	id: true;
 	asset: true;
+	marketKey: true;
 	marketStats: FuturesCumulativeStatFields;
 };
 export type FuturesMarketArgs<K extends keyof FuturesMarketResult> = {
@@ -1936,6 +1839,7 @@ export const getFuturesMarketById = async function <K extends keyof FuturesMarke
 	const formattedObj: any = {};
 	if (obj['id']) formattedObj['id'] = obj['id'];
 	if (obj['asset']) formattedObj['asset'] = obj['asset'];
+	if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 	if (obj['marketStats']) formattedObj['marketStats'] = obj['marketStats'];
 	return formattedObj as Pick<FuturesMarketResult, K>;
 };
@@ -1973,6 +1877,7 @@ export const getFuturesMarkets = async function <K extends keyof FuturesMarketRe
 			const formattedObj: any = {};
 			if (obj['id']) formattedObj['id'] = obj['id'];
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
+			if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 			if (obj['marketStats']) formattedObj['marketStats'] = obj['marketStats'];
 			return formattedObj as Pick<FuturesMarketResult, K>;
 		});
@@ -2257,6 +2162,12 @@ export type FuturesPositionFilter = {
 	asset_not_in?: string[];
 	asset_contains?: string | null;
 	asset_not_contains?: string | null;
+	marketKey?: string | null;
+	marketKey_not?: string | null;
+	marketKey_in?: string[];
+	marketKey_not_in?: string[];
+	marketKey_contains?: string | null;
+	marketKey_not_contains?: string | null;
 	account?: string | null;
 	account_not?: string | null;
 	account_in?: string[];
@@ -2419,6 +2330,7 @@ export type FuturesPositionResult = {
 	timestamp: Wei;
 	market: string;
 	asset: string;
+	marketKey: string;
 	account: string;
 	abstractAccount: string;
 	accountType: Partial<FuturesAccountType>;
@@ -2449,6 +2361,7 @@ export type FuturesPositionFields = {
 	timestamp: true;
 	market: true;
 	asset: true;
+	marketKey: true;
 	account: true;
 	abstractAccount: true;
 	accountType: true;
@@ -2495,6 +2408,7 @@ export const getFuturesPositionById = async function <K extends keyof FuturesPos
 	if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
 	if (obj['market']) formattedObj['market'] = obj['market'];
 	if (obj['asset']) formattedObj['asset'] = obj['asset'];
+	if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 	if (obj['account']) formattedObj['account'] = obj['account'];
 	if (obj['abstractAccount']) formattedObj['abstractAccount'] = obj['abstractAccount'];
 	if (obj['accountType']) formattedObj['accountType'] = obj['accountType'];
@@ -2558,6 +2472,7 @@ export const getFuturesPositions = async function <K extends keyof FuturesPositi
 			if (obj['timestamp']) formattedObj['timestamp'] = wei(obj['timestamp'], 0);
 			if (obj['market']) formattedObj['market'] = obj['market'];
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
+			if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 			if (obj['account']) formattedObj['account'] = obj['account'];
 			if (obj['abstractAccount']) formattedObj['abstractAccount'] = obj['abstractAccount'];
 			if (obj['accountType']) formattedObj['accountType'] = obj['accountType'];
@@ -2824,6 +2739,12 @@ export type FuturesTradeFilter = {
 	asset_not_in?: string[];
 	asset_contains?: string | null;
 	asset_not_contains?: string | null;
+	marketKey?: string | null;
+	marketKey_not?: string | null;
+	marketKey_in?: string[];
+	marketKey_not_in?: string[];
+	marketKey_contains?: string | null;
+	marketKey_not_contains?: string | null;
 	price?: WeiSource | null;
 	price_not?: WeiSource | null;
 	price_gt?: WeiSource | null;
@@ -2883,6 +2804,7 @@ export type FuturesTradeResult = {
 	margin: Wei;
 	size: Wei;
 	asset: string;
+	marketKey: string;
 	price: Wei;
 	positionId: string;
 	positionSize: Wei;
@@ -2900,6 +2822,7 @@ export type FuturesTradeFields = {
 	margin: true;
 	size: true;
 	asset: true;
+	marketKey: true;
 	price: true;
 	positionId: true;
 	positionSize: true;
@@ -2933,6 +2856,7 @@ export const getFuturesTradeById = async function <K extends keyof FuturesTradeR
 	if (obj['margin']) formattedObj['margin'] = wei(obj['margin'], 0);
 	if (obj['size']) formattedObj['size'] = wei(obj['size'], 0);
 	if (obj['asset']) formattedObj['asset'] = obj['asset'];
+	if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 	if (obj['price']) formattedObj['price'] = wei(obj['price'], 0);
 	if (obj['positionId']) formattedObj['positionId'] = obj['positionId'];
 	if (obj['positionSize']) formattedObj['positionSize'] = wei(obj['positionSize'], 0);
@@ -2982,6 +2906,7 @@ export const getFuturesTrades = async function <K extends keyof FuturesTradeResu
 			if (obj['margin']) formattedObj['margin'] = wei(obj['margin'], 0);
 			if (obj['size']) formattedObj['size'] = wei(obj['size'], 0);
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
+			if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 			if (obj['price']) formattedObj['price'] = wei(obj['price'], 0);
 			if (obj['positionId']) formattedObj['positionId'] = obj['positionId'];
 			if (obj['positionSize']) formattedObj['positionSize'] = wei(obj['positionSize'], 0);

--- a/queries/futures/subgraph.ts
+++ b/queries/futures/subgraph.ts
@@ -1632,6 +1632,12 @@ export type FuturesMarginTransferFilter = {
 	asset_not_in?: string[];
 	asset_contains?: string | null;
 	asset_not_contains?: string | null;
+	marketKey?: string | null;
+	marketKey_not?: string | null;
+	marketKey_in?: string[];
+	marketKey_not_in?: string[];
+	marketKey_contains?: string | null;
+	marketKey_not_contains?: string | null;
 	size?: WeiSource | null;
 	size_not?: WeiSource | null;
 	size_gt?: WeiSource | null;
@@ -1668,6 +1674,7 @@ export type FuturesMarginTransferResult = {
 	account: string;
 	market: string;
 	asset: string;
+	marketKey: string;
 	size: Wei;
 	txHash: string;
 };
@@ -1677,6 +1684,7 @@ export type FuturesMarginTransferFields = {
 	account: true;
 	market: true;
 	asset: true;
+	marketKey: true;
 	size: true;
 	txHash: true;
 };
@@ -1704,6 +1712,7 @@ export const getFuturesMarginTransferById = async function <
 	if (obj['account']) formattedObj['account'] = obj['account'];
 	if (obj['market']) formattedObj['market'] = obj['market'];
 	if (obj['asset']) formattedObj['asset'] = obj['asset'];
+	if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 	if (obj['size']) formattedObj['size'] = wei(obj['size'], 0);
 	if (obj['txHash']) formattedObj['txHash'] = obj['txHash'];
 	return formattedObj as Pick<FuturesMarginTransferResult, K>;
@@ -1750,6 +1759,7 @@ export const getFuturesMarginTransfers = async function <
 			if (obj['account']) formattedObj['account'] = obj['account'];
 			if (obj['market']) formattedObj['market'] = obj['market'];
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
+			if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 			if (obj['size']) formattedObj['size'] = wei(obj['size'], 0);
 			if (obj['txHash']) formattedObj['txHash'] = obj['txHash'];
 			return formattedObj as Pick<FuturesMarginTransferResult, K>;
@@ -1914,6 +1924,12 @@ export type FuturesOrderFilter = {
 	asset_not_in?: string[];
 	asset_contains?: string | null;
 	asset_not_contains?: string | null;
+	marketKey?: string | null;
+	marketKey_not?: string | null;
+	marketKey_in?: string[];
+	marketKey_not_in?: string[];
+	marketKey_contains?: string | null;
+	marketKey_not_contains?: string | null;
 	market?: string | null;
 	market_not?: string | null;
 	market_in?: string[];
@@ -1992,6 +2008,7 @@ export type FuturesOrderResult = {
 	id: string;
 	size: Wei;
 	asset: string;
+	marketKey: string;
 	market: string;
 	account: string;
 	abstractAccount: string;
@@ -2008,6 +2025,7 @@ export type FuturesOrderFields = {
 	id: true;
 	size: true;
 	asset: true;
+	marketKey: true;
 	market: true;
 	account: true;
 	abstractAccount: true;
@@ -2040,6 +2058,7 @@ export const getFuturesOrderById = async function <K extends keyof FuturesOrderR
 	if (obj['id']) formattedObj['id'] = obj['id'];
 	if (obj['size']) formattedObj['size'] = wei(obj['size'], 0);
 	if (obj['asset']) formattedObj['asset'] = obj['asset'];
+	if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 	if (obj['market']) formattedObj['market'] = obj['market'];
 	if (obj['account']) formattedObj['account'] = obj['account'];
 	if (obj['abstractAccount']) formattedObj['abstractAccount'] = obj['abstractAccount'];
@@ -2088,6 +2107,7 @@ export const getFuturesOrders = async function <K extends keyof FuturesOrderResu
 			if (obj['id']) formattedObj['id'] = obj['id'];
 			if (obj['size']) formattedObj['size'] = wei(obj['size'], 0);
 			if (obj['asset']) formattedObj['asset'] = obj['asset'];
+			if (obj['marketKey']) formattedObj['marketKey'] = obj['marketKey'];
 			if (obj['market']) formattedObj['market'] = obj['market'];
 			if (obj['account']) formattedObj['account'] = obj['account'];
 			if (obj['abstractAccount']) formattedObj['abstractAccount'] = obj['abstractAccount'];

--- a/queries/futures/useGetAllFuturesTradesForAccount.ts
+++ b/queries/futures/useGetAllFuturesTradesForAccount.ts
@@ -42,6 +42,7 @@ const useGetAllFuturesTradesForAccount = (
 					accountType: true,
 					margin: true,
 					size: true,
+					marketKey: true,
 					asset: true,
 					price: true,
 					positionId: true,

--- a/queries/futures/useGetFuturesPositionHistoryForAccount.ts
+++ b/queries/futures/useGetFuturesPositionHistoryForAccount.ts
@@ -44,6 +44,7 @@ const useGetFuturesPositionHistoryForAccount = (
 						timestamp: true,
 						market: true,
 						asset: true,
+						marketKey: true,
 						account: true,
 						abstractAccount: true,
 						accountType: true,

--- a/queries/futures/useGetFuturesTrades.ts
+++ b/queries/futures/useGetFuturesTrades.ts
@@ -30,7 +30,7 @@ const useGetFuturesTrades = (
 					{
 						first: DEFAULT_NUMBER_OF_TRADES,
 						where: {
-							asset: `${ethersUtils.formatBytes32String(currencyKey)}`,
+							marketKey: `${ethersUtils.formatBytes32String(currencyKey)}`,
 							timestamp_gt: pageParam.minTs,
 							timestamp_lt: pageParam.maxTs,
 						},
@@ -45,6 +45,7 @@ const useGetFuturesTrades = (
 						accountType: true,
 						margin: true,
 						size: true,
+						marketKey: true,
 						asset: true,
 						price: true,
 						positionId: true,

--- a/queries/futures/useGetFuturesTrades.ts
+++ b/queries/futures/useGetFuturesTrades.ts
@@ -6,6 +6,7 @@ import { DEFAULT_NUMBER_OF_TRADES, MAX_TIMESTAMP } from 'constants/defaults';
 import QUERY_KEYS from 'constants/queryKeys';
 import Connector from 'containers/Connector';
 import { notNill } from 'queries/synths/utils';
+import { FuturesMarketKey } from 'sdk/types/futures';
 import logError from 'utils/logError';
 
 import { getFuturesTrades } from './subgraph';
@@ -13,7 +14,7 @@ import { FuturesTrade } from './types';
 import { getFuturesEndpoint, mapTrades } from './utils';
 
 const useGetFuturesTrades = (
-	currencyKey: string | undefined,
+	currencyKey: FuturesMarketKey | undefined,
 	options?: UseInfiniteQueryOptions<FuturesTrade[] | null> & { forceAccount: boolean }
 ) => {
 	const { network } = Connector.useContainer();

--- a/queries/futures/useGetFuturesTradesForAccount.ts
+++ b/queries/futures/useGetFuturesTradesForAccount.ts
@@ -56,6 +56,7 @@ const useGetFuturesTradesForAccount = (
 						margin: true,
 						size: true,
 						asset: true,
+						marketKey: true,
 						price: true,
 						positionId: true,
 						positionSize: true,

--- a/queries/futures/useGetFuturesVolumes.ts
+++ b/queries/futures/useGetFuturesVolumes.ts
@@ -42,11 +42,13 @@ const useGetFuturesVolumes = (options?: UseQueryOptions<FuturesVolumes | null>) 
 					},
 					{
 						id: true,
+						marketKey: true,
 						asset: true,
 						volume: true,
 						trades: true,
 						timestamp: true,
 						period: true,
+						feesCrossMarginAccounts: true,
 						feesKwenta: true,
 						feesSynthetix: true,
 					}

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { ContractsMap, NetworkId } from '@synthetixio/contracts-interface';
 import Wei, { wei } from '@synthetixio/wei';
-import { utils } from 'ethers';
+import { ethers, utils } from 'ethers';
 import { parseBytes32String } from 'ethers/lib/utils';
 import { chain } from 'wagmi';
 
@@ -12,12 +12,13 @@ import { FuturesMarket } from 'sdk/types/futures';
 import { formatCurrency, formatDollars, weiFromWei, zeroBN } from 'utils/formatters/number';
 import {
 	FuturesMarketAsset,
+	FuturesMarketKey,
 	getDisplayAsset,
 	getMarketName,
 	MarketKeyByAsset,
 } from 'utils/futures';
 
-import { SECONDS_PER_DAY, FUTURES_ENDPOINTS } from './constants';
+import { SECONDS_PER_DAY, FUTURES_ENDPOINTS, AGGREGATE_ASSET_KEY } from './constants';
 import {
 	CrossMarginAccountTransferResult,
 	FuturesAggregateStatResult,
@@ -198,12 +199,14 @@ export const calculateVolumes = (
 	futuresHourlyStats: FuturesAggregateStatResult[]
 ): FuturesVolumes => {
 	const volumes: FuturesVolumes = futuresHourlyStats.reduce(
-		(acc: FuturesVolumes, { asset, volume, trades }) => {
+		(acc: FuturesVolumes, { marketKey, volume, trades }) => {
+			const cleanMarketKey =
+				marketKey !== AGGREGATE_ASSET_KEY ? ethers.utils.parseBytes32String(marketKey) : marketKey;
 			return {
 				...acc,
-				[asset]: {
-					volume: volume.div(ETH_UNIT).add(acc[asset]?.volume ?? 0),
-					trades: trades.add(acc[asset]?.trades ?? 0),
+				[cleanMarketKey]: {
+					volume: volume.div(ETH_UNIT).add(acc[cleanMarketKey]?.volume ?? 0),
+					trades: trades.add(acc[cleanMarketKey]?.trades ?? 0),
 				},
 			};
 		},

--- a/queries/futures/utils.ts
+++ b/queries/futures/utils.ts
@@ -12,7 +12,6 @@ import { FuturesMarket } from 'sdk/types/futures';
 import { formatCurrency, formatDollars, weiFromWei, zeroBN } from 'utils/formatters/number';
 import {
 	FuturesMarketAsset,
-	FuturesMarketKey,
 	getDisplayAsset,
 	getMarketName,
 	MarketKeyByAsset,

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -44,7 +44,8 @@ const FuturesMarketsTable: FC = () => {
 	let data = useMemo(() => {
 		return futuresMarkets.map((market) => {
 			const description = getSynthDescription(market.asset, synthsMap, t);
-			const volume = futuresVolumes[market.assetHex]?.volume;
+
+			const volume = futuresVolumes[market?.marketKey ?? '']?.volume;
 			const pastPrice = pastRates.find((price) => price.synth === market.asset);
 			const fundingRate = fundingRates.find(
 				(funding) => (funding as FundingRateResponse)?.asset === MarketKeyByAsset[market.asset]

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -59,12 +59,8 @@ const useGetMarketData = (mobile?: boolean) => {
 		const marketPrice = wei(marketInfo?.price ?? 0);
 		const marketName = `${marketInfo?.marketName ?? t('futures.market.info.default-market')}`;
 
-		const futuresTradingVolume = marketInfo?.assetHex
-			? futuresVolumes[marketInfo.assetHex]?.volume ?? wei(0)
-			: wei(0);
-		const futuresTradeCount = marketInfo?.assetHex
-			? futuresVolumes[marketInfo.assetHex]?.trades.toNumber() ?? 0
-			: 0;
+		const futuresTradingVolume = marketKey ? futuresVolumes[marketKey]?.volume ?? wei(0) : wei(0);
+		const futuresTradeCount = marketKey ? futuresVolumes[marketKey]?.trades.toNumber() ?? 0 : 0;
 
 		if (mobile) {
 			return {

--- a/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
@@ -11,7 +11,7 @@ import { FuturesTrade } from 'queries/futures/types';
 import useGetFuturesTradesForAccount from 'queries/futures/useGetFuturesTradesForAccount';
 import TimeDisplay from 'sections/futures/Trades/TimeDisplay';
 import { PositionSide, TradeStatus } from 'sections/futures/types';
-import { selectMarketAsset } from 'state/futures/selectors';
+import { selectMarketKey } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { GridDivCenteredRow } from 'styles/common';
 import { formatCryptoCurrency } from 'utils/formatters/number';
@@ -23,11 +23,11 @@ import TradeDrawer from '../drawers/TradeDrawer';
 const TradesTab: React.FC = () => {
 	const { t } = useTranslation();
 	const { walletAddress } = Connector.useContainer();
-	const marketAsset = useAppSelector(selectMarketAsset);
+	const marketKey = useAppSelector(selectMarketKey);
 
 	const [selectedTrade, setSelectedTrade] = React.useState<any>();
 
-	const futuresTradesQuery = useGetFuturesTradesForAccount(marketAsset, walletAddress);
+	const futuresTradesQuery = useGetFuturesTradesForAccount(marketKey, walletAddress);
 
 	const { isLoading, isFetched: isLoaded } = futuresTradesQuery;
 

--- a/sections/futures/MobileTrade/UserTabs/TransfersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/TransfersTab.tsx
@@ -4,16 +4,16 @@ import styled from 'styled-components';
 
 import Table, { TableNoResults } from 'components/Table';
 import useGetFuturesMarginTransfers from 'queries/futures/useGetFuturesMarginTransfers';
-import { selectMarketAsset } from 'state/futures/selectors';
+import { selectMarketKey } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { timePresentation } from 'utils/formatters/date';
 
 import { SectionHeader, SectionTitle } from '../common';
 
 const TransfersTab: React.FC = () => {
-	const marketAsset = useAppSelector(selectMarketAsset);
+	const marketKey = useAppSelector(selectMarketKey);
 
-	const marginTransfersQuery = useGetFuturesMarginTransfers(marketAsset);
+	const marginTransfersQuery = useGetFuturesMarginTransfers(marketKey);
 	const marginTransfers = React.useMemo(
 		() => (marginTransfersQuery.isSuccess ? marginTransfersQuery?.data ?? [] : []),
 		[marginTransfersQuery.isSuccess, marginTransfersQuery.data]

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -52,7 +52,7 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 						})
 				: [];
 		return [...new Set(futuresTrades)];
-	}, [futuresTradesQuery.data, marketKey]);
+	}, [futuresTradesQuery.data]);
 
 	const observer = useRef<IntersectionObserver | null>(null);
 	const lastElementRef = useCallback(

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -9,7 +9,7 @@ import { NO_VALUE } from 'constants/placeholder';
 import { blockExplorer } from 'containers/Connector/Connector';
 import { FuturesTrade } from 'queries/futures/types';
 import useGetFuturesTrades from 'queries/futures/useGetFuturesTrades';
-import { selectMarketAsset } from 'state/futures/selectors';
+import { selectMarketKey } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { CapitalizedText, NumericValue } from 'styles/common';
 import { formatNumber } from 'utils/formatters/number';
@@ -27,8 +27,8 @@ enum TableColumnAccessor {
 
 const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 	const { t } = useTranslation();
-	const marketAsset = useAppSelector(selectMarketAsset);
-	const futuresTradesQuery = useGetFuturesTrades(marketAsset);
+	const marketKey = useAppSelector(selectMarketKey);
+	const futuresTradesQuery = useGetFuturesTrades(marketKey);
 
 	let data = useMemo(() => {
 		const futuresTradesPages = futuresTradesQuery?.data?.pages ?? [];
@@ -47,13 +47,12 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 								amount: Number(trade?.size),
 								time: Number(trade?.timestamp),
 								id: trade?.txnHash,
-								marketAsset,
 								orderType: trade?.orderType,
 							};
 						})
 				: [];
 		return [...new Set(futuresTrades)];
-	}, [futuresTradesQuery.data, marketAsset]);
+	}, [futuresTradesQuery.data, marketKey]);
 
 	const observer = useRef<IntersectionObserver | null>(null);
 	const lastElementRef = useCallback(

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -17,7 +17,7 @@ import { FuturesTrade } from 'queries/futures/types';
 import useGetFuturesMarginTransfers from 'queries/futures/useGetFuturesMarginTransfers';
 import useGetFuturesTradesForAccount from 'queries/futures/useGetFuturesTradesForAccount';
 import FuturesPositionsTable from 'sections/dashboard/FuturesPositionsTable';
-import { selectMarketAsset, selectPosition } from 'state/futures/selectors';
+import { selectMarketAsset, selectMarketKey, selectPosition } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { futuresAccountTypeState, openOrdersState } from 'store/futures';
 
@@ -43,6 +43,7 @@ const UserInfo: React.FC = () => {
 	const router = useRouter();
 	const { walletAddress } = Connector.useContainer();
 
+	const marketKey = useAppSelector(selectMarketKey);
 	const marketAsset = useAppSelector(selectMarketAsset);
 	const position = useAppSelector(selectPosition);
 
@@ -53,13 +54,13 @@ const UserInfo: React.FC = () => {
 	const [hasOpenPosition, setHasOpenPosition] = useState(false);
 	const [openProfitCalcModal, setOpenProfitCalcModal] = useState(false);
 
-	const marginTransfersQuery = useGetFuturesMarginTransfers(marketAsset);
+	const marginTransfersQuery = useGetFuturesMarginTransfers(marketKey);
 	const marginTransfers = useMemo(
 		() => (marginTransfersQuery.isSuccess ? marginTransfersQuery?.data ?? [] : []),
 		[marginTransfersQuery.isSuccess, marginTransfersQuery.data]
 	);
 
-	const futuresTradesQuery = useGetFuturesTradesForAccount(marketAsset, walletAddress);
+	const futuresTradesQuery = useGetFuturesTradesForAccount(marketKey, walletAddress);
 
 	const history: FuturesTrade[] = useMemo(
 		() => (futuresTradesQuery.isSuccess ? futuresTradesQuery?.data ?? [] : []),

--- a/sections/homepage/Assets/Assets.tsx
+++ b/sections/homepage/Assets/Assets.tsx
@@ -199,7 +199,8 @@ const Assets = () => {
 		return (
 			futuresMarkets?.map((market) => {
 				const description = getSynthDescription(market.asset, l2SynthsMap, t);
-				const volume = futuresVolumes[market.assetHex]?.volume?.toNumber() ?? 0;
+
+				const volume = futuresVolumes[market?.marketKey ?? '']?.volume?.toNumber() ?? 0;
 				const pastPrice = pastRates.find(
 					(price: Price) => price.synth === market.asset || price.synth === market.asset.slice(1)
 				);


### PR DESCRIPTION
Adds new `marketKey` field to several queries, includes ones where we summarize volume and count trades. This is necessary to transition to Perps V2 since some new markets will contain the same `asset` value (`sETH`) but have a different market key (`pETH` instead of `sETH`)