### PR TITLE
Extracted Banner component from HomeLayout for easier management

### DIFF
--- a/constants/announcement.ts
+++ b/constants/announcement.ts
@@ -1,5 +1,5 @@
 // Shows or hides the home page banner entirely when set to true/false
-export const BANNER_ENABLED = true;
+export const BANNER_ENABLED = false;
 // Sets the link destination for the banner component, or renders the banner as
 // plain, un-clickable text if set to a falsey value (`false`, `null`, '', etc...)
 export const BANNER_LINK_URL =

--- a/constants/announcement.ts
+++ b/constants/announcement.ts
@@ -1,0 +1,9 @@
+// The announcement banner on the home page can be toggled on and off by setting
+// the `BANNER_TEXT` constant to a falsey value (`false`, `null`, '', etc...).
+// In addition, the URL that the banner text links out to can be set using the
+// `BANNER_LINK_URL` constant-- if this is falsey, the `BANNER_TEXT` will render
+// as non-interactive text instead of a link.
+export const BANNER_LINK_URL =
+	'https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff';
+export const BANNER_TEXT =
+	'Council elections are live on Snapshot until Nov 29th. $KWENTA stakers go cast your vote!';

--- a/constants/announcement.ts
+++ b/constants/announcement.ts
@@ -1,9 +1,9 @@
-// The announcement banner on the home page can be toggled on and off by setting
-// the `BANNER_TEXT` constant to a falsey value (`false`, `null`, '', etc...).
-// In addition, the URL that the banner text links out to can be set using the
-// `BANNER_LINK_URL` constant-- if this is falsey, the `BANNER_TEXT` will render
-// as non-interactive text instead of a link.
+// Shows or hides the home page banner entirely when set to true/false
+export const BANNER_ENABLED = true;
+// Sets the link destination for the banner component, or renders the banner as
+// plain, un-clickable text if set to a falsey value (`false`, `null`, '', etc...)
 export const BANNER_LINK_URL =
 	'https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff';
+// Sets the text displayed on the home page banner
 export const BANNER_TEXT =
 	'Council elections are live on Snapshot until Nov 29th. $KWENTA stakers go cast your vote!';

--- a/sections/shared/Layout/HomeLayout/Banner.tsx
+++ b/sections/shared/Layout/HomeLayout/Banner.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
-import { BANNER_LINK_URL, BANNER_TEXT } from 'constants/announcement';
+import { BANNER_ENABLED, BANNER_LINK_URL, BANNER_TEXT } from 'constants/announcement';
 import media from 'styles/media';
 
 const Banner = () => {
-	if (!BANNER_TEXT) return null;
+	if (!BANNER_ENABLED) return null;
 
 	const linkProps = BANNER_LINK_URL
 		? { href: BANNER_LINK_URL, target: '_blank' }

--- a/sections/shared/Layout/HomeLayout/Banner.tsx
+++ b/sections/shared/Layout/HomeLayout/Banner.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+
+import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import { BANNER_LINK_URL, BANNER_TEXT } from 'constants/announcement';
+import media from 'styles/media';
+
+const Banner = () => {
+	if (!BANNER_TEXT) return null;
+
+	const linkProps = BANNER_LINK_URL
+		? { href: BANNER_LINK_URL, target: '_blank' }
+		: { as: 'p' as const };
+	const bannerLink = <FuturesLink {...linkProps}>{BANNER_TEXT}</FuturesLink>;
+
+	return (
+		<>
+			<DesktopOnlyView>
+				<FuturesBannerContainer>
+					<FuturesBannerLinkWrapper>{bannerLink}</FuturesBannerLinkWrapper>
+				</FuturesBannerContainer>
+			</DesktopOnlyView>
+			<MobileOrTabletView>
+				<FuturesBannerContainer>{bannerLink}</FuturesBannerContainer>
+			</MobileOrTabletView>
+		</>
+	);
+};
+
+const FuturesLink = styled.a`
+	margin-right: 5px;
+	background: #313131;
+	padding: 4px 9px;
+	border-radius: 20px;
+`;
+
+const FuturesBannerContainer = styled.div`
+	height: 70px;
+	width: 100%;
+	display: flex;
+	align-items: center;
+	margin-bottom: -35px;
+
+	${media.lessThan('md')`
+		position: relative;
+		width: 100%;
+		display: flex;
+		margin-bottom: 0px;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		text-align: center;
+		background: transaparent;
+		padding: 22px 10px;
+		border-radius: 0px;
+		gap: 5px;
+	`}
+`;
+
+const FuturesBannerLinkWrapper = styled.div`
+	width: 100%;
+	text-align: center;
+	position: absolute;
+
+	color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 16px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+export default Banner;

--- a/sections/shared/Layout/HomeLayout/HomeLayout.tsx
+++ b/sections/shared/Layout/HomeLayout/HomeLayout.tsx
@@ -1,14 +1,13 @@
 import { FC } from 'react';
-import styled, { ThemeProvider, createGlobalStyle } from 'styled-components';
+import { ThemeProvider, createGlobalStyle } from 'styled-components';
 
-import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import { RefetchProvider } from 'contexts/RefetchContext';
 import { FullScreenContainer } from 'styles/common';
-import media from 'styles/media';
 import { themes } from 'styles/theme';
 import darkTheme from 'styles/theme/colors/dark';
 
 import Background from './Background';
+import Banner from './Banner';
 import Footer from './Footer';
 import Header from './Header';
 
@@ -19,34 +18,7 @@ type HomeLayoutProps = {
 const HomeLayout: FC<HomeLayoutProps> = ({ children }) => (
 	<ThemeProvider theme={themes['dark']}>
 		<Background />
-		<DesktopOnlyView>
-			<FuturesBannerContainer>
-				<FuturesBannerLinkWrapper>
-					<>
-						<FuturesLink
-							href="https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff"
-							target="_blank"
-						>
-							Council elections are live on Snapshot until Nov 29th. $KWENTA stakers go cast your
-							vote!
-						</FuturesLink>
-					</>
-				</FuturesBannerLinkWrapper>
-			</FuturesBannerContainer>
-		</DesktopOnlyView>
-		<MobileOrTabletView>
-			<FuturesBannerContainer>
-				<>
-					<FuturesLink
-						href="https://snapshot.org/#/kwenta.eth/proposal/0x4a2dbd3839de2b6407ebbdc47e7d51a5d69f3363a803a93ffd8cf4e5d08011ff"
-						target="_blank"
-					>
-						Council elections are live on Snapshot until Nov 29th. $KWENTA stakers go cast your
-						vote!
-					</FuturesLink>
-				</>
-			</FuturesBannerContainer>
-		</MobileOrTabletView>
+		<Banner />
 
 		<FullScreenContainer>
 			<GlobalStyle />
@@ -63,49 +35,6 @@ const GlobalStyle = createGlobalStyle`
 		background-color: ${darkTheme.background};
 		color: ${darkTheme.text.value};
 	}
-`;
-
-const FuturesLink = styled.a`
-	margin-right: 5px;
-	background: #313131;
-	padding: 4px 9px;
-	border-radius: 20px;
-`;
-
-const FuturesBannerContainer = styled.div`
-	height: 70px;
-	width: 100%;
-	display: flex;
-	align-items: center;
-	margin-bottom: -35px;
-
-	${media.lessThan('md')`
-		position: relative;
-		width: 100%;
-		display: flex;
-		margin-bottom: 0px;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		text-align: center;
-		background: transaparent;
-		padding: 22px 10px;
-		border-radius: 0px;
-		gap: 5px;
-	`}
-`;
-
-const FuturesBannerLinkWrapper = styled.div`
-	width: 100%;
-	text-align: center;
-	position: absolute;
-
-	color: ${(props) => props.theme.colors.white};
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 16px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 `;
 
 export default HomeLayout;


### PR DESCRIPTION
Extracted the banner on the `HomeLayout.tsx` page into its own component to make it easier to toggle on/off and modify. I just pulled it out to a separate component under `sections/shared/Layout/HomeLayout` since it didn't seem likely that this would be used elsewhere in the app, but can move it somewhere else if there's a better place for it.

I introduced 3 new constants in `constants/announcements` for controlling the behavior of the home page banner:
- `BANNER_ENABLED` - displays the banner if set to `true`, hides it if `false`
- `BANNER_TEXT` - the text displayed in the banner
- `BANNER_LINK_URL` - the location to link out to when clicking on the banner, if set to something falsey (`''`, `false`, `null`, etc...) then the banner will just render as text and won't be clickable.

## Related issue
https://github.com/Kwenta/kwenta/issues/1693

## How Has This Been Tested?
Tested locally at both desktop and mobile breakpoints.

## Video:
https://user-images.githubusercontent.com/109358247/204582039-abe0b65a-8eb9-46d5-b9ca-44e326e4f132.mov
