### PR TITLE
Added debt-perp deprecated message

### DIFF
--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled, { css } from 'styled-components';
 
+import { selectMarketAsset } from 'state/futures/selectors';
+import { useAppSelector } from 'state/hooks';
 import { FlexDivCentered } from 'styles/common';
 import media from 'styles/media';
 
@@ -14,7 +17,9 @@ type MarketDetailsProps = {
 };
 
 const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
+	const { t } = useTranslation();
 	const marketData = useGetMarketData(mobile);
+	const marketAsset = useAppSelector(selectMarketAsset);
 
 	return (
 		<FlexDivCentered>
@@ -25,15 +30,40 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({ mobile }) => {
 			)}
 
 			<MarketDetailsContainer mobile={mobile}>
-				{Object.entries(marketData).map(([marketKey, data]) => (
-					<MarketDetail {...data} key={marketKey} marketKey={marketKey} mobile={Boolean(mobile)} />
-				))}
-
+				{marketAsset !== 'DebtRatio' ? (
+					Object.entries(marketData).map(([marketKey, data]) => (
+						<MarketDetail
+							{...data}
+							key={marketKey}
+							marketKey={marketKey}
+							mobile={Boolean(mobile)}
+						/>
+					))
+				) : (
+					<DeprecatedBannerContainer>
+						{t('exchange.market-details-card.deprecated-info')}
+					</DeprecatedBannerContainer>
+				)}
 				{mobile && <MobileMarketDetail />}
 			</MarketDetailsContainer>
 		</FlexDivCentered>
 	);
 };
+
+const DeprecatedBannerContainer = styled.div`
+	height: 40px;
+	width: 100%;
+	padding: 22px 5px;
+	border-radius: 8px;
+	margin-top: -5px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 16px;
+	background-color: ${(props) => props.theme.colors.red};
+`;
 
 const MarketDetailsContainer = styled.div<{ mobile?: boolean }>`
 	flex: 1;

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -39,7 +39,7 @@ export type MarketsCurrencyOption = {
 	value: FuturesMarketAsset;
 	label: string;
 	description: string;
-	price?: string;
+	price?: string | JSX.Element;
 	change?: string;
 	negativeChange: boolean;
 	isMarketClosed: boolean;
@@ -49,7 +49,7 @@ export type MarketsCurrencyOption = {
 type AssetToCurrencyOptionArgs = {
 	asset: FuturesMarketAsset;
 	description: string;
-	price?: string;
+	price?: string | JSX.Element;
 	change?: string;
 	negativeChange: boolean;
 	isMarketClosed: boolean;
@@ -167,20 +167,28 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 				value={assetToCurrencyOption({
 					asset: marketAsset,
 					description: getSynthDescription(marketAsset, synthsMap, t),
-					price: mobile
-						? formatCurrency(selectedPriceCurrency.name, selectedBasePriceRate, {
+					price: mobile ? (
+						marketAsset === 'DebtRatio' ? (
+							<DeprecatedBanner>
+								{t('exchange.market-details-card.deprecated-info')}
+							</DeprecatedBanner>
+						) : (
+							formatCurrency(selectedPriceCurrency.name, selectedBasePriceRate, {
 								sign: '$',
 								minDecimals: getMinDecimals(marketAsset),
-						  })
-						: undefined,
+							})
+						)
+					) : undefined,
 					change: mobile
-						? formatPercent(
-								selectedBasePriceRate && selectedPastPrice?.price
-									? wei(selectedBasePriceRate)
-											.sub(selectedPastPrice?.price)
-											.div(selectedBasePriceRate)
-									: zeroBN
-						  )
+						? marketAsset === 'DebtRatio'
+							? undefined
+							: formatPercent(
+									selectedBasePriceRate && selectedPastPrice?.price
+										? wei(selectedBasePriceRate)
+												.sub(selectedPastPrice?.price)
+												.div(selectedBasePriceRate)
+										: zeroBN
+							  )
 						: undefined,
 					negativeChange: mobile
 						? selectedBasePriceRate && selectedPastPrice?.price
@@ -206,6 +214,15 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 		</SelectContainer>
 	);
 };
+
+const DeprecatedBanner = styled.div`
+	font-size: 10px;
+	margin-left: 25px;
+	padding: 5px 10px;
+	white-space: pre-wrap;
+	background-color: ${(props) => props.theme.colors.red};
+	color: ${(props) => props.theme.colors.white};
+`;
 
 const SelectContainer = styled.div<{ mobile?: boolean }>`
 	margin-bottom: 16px;

--- a/translations/en.json
+++ b/translations/en.json
@@ -342,7 +342,8 @@
 				"24h-trades": "Total amount of trades on selected pair within the past 24h",
 				"open-interest": "Total notional value on all outstanding positions of the selected market",
 				"1h-funding-rate": "Funding applies to all open positions. A positive rate means longs pay shorts, a negative rate means shorts pay longs. The rate is calculated as the average funding paid by open positions for the last hour. Funding accrues on a position every time it is opened, modified, or closed. Funding accrues on open positions."
-			}
+			},
+			"deprecated-info": "DEBT-PERP is being deprecated soon. Please close your positions at your earliest convenience."
 		},
 		"summary-info": {
 			"gas-price-gwei": "gas price (GWEI)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
DEBT-PERP as of [SCCP-237](https://sips.synthetix.io/sccp/sccp-237/) now has an OI cap of `0$` and will soon be deprecated. 

## Related issue
#1541 

## Motivation and Context
It's time to inform users on the UI when visiting the DEBT-PERP market that it will be deprecated soon as we should urge users to close their positions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/204684665-c049242e-765a-48f9-a55c-7e739199e06b.png)

![image](https://user-images.githubusercontent.com/4819006/204684719-7c96d995-d06e-457c-b360-c49fabe476c4.png)