### PR TITLE
Bug: Add leverage selector

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -25,7 +25,7 @@ import { KWENTA_TRACKING_CODE, ORDER_PREVIEW_ERRORS } from 'queries/futures/cons
 import { PositionSide, FuturesTradeInputs, FuturesAccountType } from 'queries/futures/types';
 import useGetFuturesPotentialTradeDetails from 'queries/futures/useGetFuturesPotentialTradeDetails';
 import { setFuturesAccountType, setOrderType as setReduxOrderType } from 'state/futures/reducer';
-import { selectMarketAssetRate } from 'state/futures/selectors';
+import { selectMarketAssetRate, selectMaxLeverage } from 'state/futures/selectors';
 import { selectMarketAsset, selectMarketInfo } from 'state/futures/selectors';
 import { useAppSelector, useAppDispatch } from 'state/hooks';
 import {
@@ -33,7 +33,6 @@ import {
 	tradeFeesState,
 	futuresAccountState,
 	leverageSideState,
-	maxLeverageState,
 	orderTypeState,
 	positionState,
 	futuresTradeInputsState,
@@ -99,7 +98,7 @@ const useFuturesData = () => {
 	const feeCap = useRecoilValue(orderFeeCapState);
 	const position = useRecoilValue(positionState);
 	const aboveMaxLeverage = useRecoilValue(aboveMaxLeverageState);
-	const maxLeverage = useRecoilValue(maxLeverageState);
+	const maxLeverage = useAppSelector(selectMaxLeverage);
 	const { crossMarginAvailable, crossMarginAddress } = useRecoilValue(futuresAccountState);
 	const { tradeFee: crossMarginTradeFee, stopOrderFee, limitOrderFee } = useRecoilValue(
 		crossMarginSettingsState

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -7,11 +7,10 @@ import Button from 'components/Button';
 import CustomNumericInput from 'components/Input/CustomNumericInput';
 import { DEFAULT_FIAT_DECIMALS } from 'constants/defaults';
 import { useFuturesContext } from 'contexts/FuturesContext';
-import { selectMarketInfo } from 'state/futures/selectors';
+import { selectMarketInfo, selectMaxLeverage } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import {
 	leverageValueCommittedState,
-	maxLeverageState,
 	nextPriceDisclaimerState,
 	orderTypeState,
 	positionState,
@@ -26,13 +25,13 @@ const LeverageInput: FC = () => {
 	const { t } = useTranslation();
 	const [mode, setMode] = useState<'slider' | 'input'>('input');
 	const { leverage } = useRecoilValue(futuresTradeInputsState);
-	const maxLeverage = useRecoilValue(maxLeverageState);
 	const orderType = useRecoilValue(orderTypeState);
 	const isDisclaimerDisplayed = useRecoilValue(nextPriceDisclaimerState);
 	const setIsLeverageValueCommitted = useSetRecoilState(leverageValueCommittedState);
 	const position = useRecoilValue(positionState);
 
 	const marketInfo = useAppSelector(selectMarketInfo);
+	const maxLeverage = useAppSelector(selectMaxLeverage);
 
 	const { onLeverageChange } = useFuturesContext();
 


### PR DESCRIPTION
Fix a bug where the `maxLeverage` value is not set in Recoil due to our migration to Redux.

## Description
* Add a `maxLeverage` selector in redux
* Replace the `maxLeverage` value in `useFuturesData` to use the Redux version
