### PR TITLE
Futures market key update

### DIFF
--- a/sdk/types/futures.ts
+++ b/sdk/types/futures.ts
@@ -17,7 +17,7 @@ export type MarketClosureReason = SynthSuspensionReason;
 
 export type FuturesMarket<T = Wei> = {
 	market: string;
-	marketKey?: FuturesMarketKey;
+	marketKey: FuturesMarketKey;
 	marketName: string;
 	asset: FuturesMarketAsset;
 	assetHex: string;
@@ -160,6 +160,7 @@ export type FuturesFilledPosition<T = Wei> = {
 
 export type FuturesPosition<T = Wei> = {
 	asset: FuturesMarketAsset;
+	marketKey: FuturesMarketKey;
 	remainingMargin: T;
 	accessibleMargin: T;
 	position: FuturesFilledPosition<T> | null;

--- a/sdk/utils/futures.ts
+++ b/sdk/utils/futures.ts
@@ -8,6 +8,7 @@ import { SECONDS_PER_DAY } from 'sdk/constants/period';
 import {
 	FundingRateUpdate,
 	FuturesMarketAsset,
+	FuturesMarketKey,
 	FuturesPosition,
 	FuturesVolumes,
 	MarketClosureReason,
@@ -133,7 +134,8 @@ export const calculateVolumes = (
 export const mapFuturesPosition = (
 	positionDetail: PositionDetail,
 	canLiquidatePosition: boolean,
-	asset: FuturesMarketAsset
+	asset: FuturesMarketAsset,
+	marketKey: FuturesMarketKey
 ): FuturesPosition => {
 	const {
 		remainingMargin,
@@ -149,6 +151,7 @@ export const mapFuturesPosition = (
 	const pnlPct = initialMargin.gt(0) ? pnl.div(wei(initialMargin)) : wei(0);
 	return {
 		asset,
+		marketKey,
 		remainingMargin: wei(remainingMargin),
 		accessibleMargin: wei(accessibleMargin),
 		position: wei(size).eq(zeroBN)

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -96,7 +96,7 @@ export const fetchCrossMarginPositions = createAsyncThunk<
 	if (!futures.crossMargin.account) return [];
 	const positions = await sdk.futures.getFuturesPositions(
 		futures.crossMargin.account,
-		futures.markets.map((m) => ({ asset: m.asset, address: m.market }))
+		futures.markets.map((m) => ({ asset: m.asset, marketKey: m.marketKey, address: m.market }))
 	);
 	return positions.map((p) => serializeWeiObject(p) as FuturesPosition<string>);
 });
@@ -110,7 +110,7 @@ export const fetchIsolatedMarginPositions = createAsyncThunk<
 	if (!wallet.walletAddress) throw new Error('No wallet connected');
 	const positions = await sdk.futures.getFuturesPositions(
 		wallet.walletAddress,
-		futures.markets.map((m) => ({ asset: m.asset, address: m.market }))
+		futures.markets.map((m) => ({ asset: m.asset, marketKey: m.marketKey, address: m.market }))
 	);
 	return {
 		positions: positions.map((p) => serializeWeiObject(p) as FuturesPosition<string>),
@@ -130,10 +130,10 @@ export const refetchPosition = createAsyncThunk<
 
 	if (!account) throw new Error('No wallet connected');
 	const marketInfo = futures.markets.find(
-		(m) => m.asset === futures.isolatedMargin.selectedMarketAsset
+		(m) => m.marketKey === futures.isolatedMargin.selectedMarketKey
 	);
 	const position = positions[account]?.find(
-		(p) => p.asset === futures.isolatedMargin.selectedMarketAsset
+		(p) => p.marketKey === futures.isolatedMargin.selectedMarketKey
 	);
 
 	if (!marketInfo || !position) throw new Error('Market or position not found');
@@ -141,7 +141,7 @@ export const refetchPosition = createAsyncThunk<
 	const result = await refetchWithComparator(
 		() =>
 			sdk.futures.getFuturesPositions(account!, [
-				{ asset: marketInfo.asset, address: marketInfo.market },
+				{ asset: marketInfo.asset, marketKey: marketInfo.marketKey, address: marketInfo.market },
 			]),
 		position.remainingMargin,
 		(existing, next) => {

--- a/state/futures/reducer.ts
+++ b/state/futures/reducer.ts
@@ -2,12 +2,12 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { DEFAULT_FUTURES_MARGIN_TYPE, DEFAULT_LEVERAGE } from 'constants/defaults';
 import { TransactionStatus } from 'sdk/types/common';
-import { FuturesMarket } from 'sdk/types/futures';
+import { FuturesMarket, FuturesMarketKey } from 'sdk/types/futures';
 import { PositionSide } from 'sections/futures/types';
 import { accountType } from 'state/helpers';
 import { FetchStatus } from 'state/types';
 import { isUserDeniedError } from 'utils/formatters/error';
-import { FuturesMarketAsset } from 'utils/futures';
+import { FuturesMarketAsset, MarketKeyByAsset } from 'utils/futures';
 
 import {
 	fetchCrossMarginBalanceInfo,
@@ -63,6 +63,7 @@ const initialState: FuturesState = {
 	crossMargin: {
 		account: undefined,
 		selectedMarketAsset: FuturesMarketAsset.sETH,
+		selectedMarketKey: FuturesMarketKey.sETH,
 		leverageSide: PositionSide.LONG,
 		orderType: 'market',
 		selectedLeverage: DEFAULT_LEVERAGE,
@@ -83,6 +84,7 @@ const initialState: FuturesState = {
 	},
 	isolatedMargin: {
 		selectedMarketAsset: FuturesMarketAsset.sETH,
+		selectedMarketKey: FuturesMarketKey.sETH,
 		leverageSide: PositionSide.LONG,
 		orderType: 'market',
 		selectedLeverage: DEFAULT_LEVERAGE,
@@ -98,6 +100,8 @@ const futuresSlice = createSlice({
 	reducers: {
 		setMarketAsset: (state, action) => {
 			state[accountType(state.selectedType)].selectedMarketAsset = action.payload;
+			state[accountType(state.selectedType)].selectedMarketKey =
+				MarketKeyByAsset[action.payload as FuturesMarketAsset];
 			if (state.selectedType === 'cross_margin') {
 				state.crossMargin.selectedMarketAsset = action.payload;
 				state.crossMargin.tradeInputs = ZERO_STATE_CM_TRADE_INPUTS;
@@ -221,7 +225,7 @@ const futuresSlice = createSlice({
 			if (action.payload && positions[action.payload.wallet]) {
 				const existingPositions = [...positions[action.payload.wallet]];
 				const index = existingPositions.findIndex(
-					(p) => p.asset === action.payload!.position.asset
+					(p) => p.marketKey === action.payload!.position.marketKey
 				);
 				existingPositions[index] = action.payload.position;
 				futuresState.isolatedMargin.positions[action.payload.wallet] = existingPositions;

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -198,7 +198,7 @@ export const selectPosition = createSelector(
 	selectFuturesPositions,
 	selectMarketInfo,
 	(positions, market) => {
-		const position = positions.find((p) => p.asset === market?.asset);
+		const position = positions.find((p) => p.marketKey === market?.marketKey);
 		return position
 			? (deserializeWeiObject(position, futuresPositionKeys) as FuturesPosition)
 			: undefined;

--- a/state/futures/types.ts
+++ b/state/futures/types.ts
@@ -88,6 +88,7 @@ export type CrossMarginState = {
 	orderType: CrossMarginOrderType;
 	selectedLeverage: string;
 	leverageSide: PositionSide;
+	selectedMarketKey: FuturesMarketKey;
 	selectedMarketAsset: FuturesMarketAsset;
 	showCrossMarginOnboard: boolean;
 	position?: FuturesPosition<string>;
@@ -107,6 +108,7 @@ export type IsolatedMarginState = {
 	orderType: IsolatedMarginOrderType;
 	selectedLeverage: string;
 	leverageSide: PositionSide;
+	selectedMarketKey: FuturesMarketKey;
 	selectedMarketAsset: FuturesMarketAsset;
 	position?: FuturesPosition<string>;
 	positions: {

--- a/utils/__tests__/futures.test.ts
+++ b/utils/__tests__/futures.test.ts
@@ -1,11 +1,12 @@
 import { wei } from '@synthetixio/wei';
 
 import { PositionSide } from 'sections/futures/types';
-import { calculateMarginDelta, FuturesMarketAsset } from 'utils/futures';
+import { calculateMarginDelta, FuturesMarketAsset, FuturesMarketKey } from 'utils/futures';
 
 const ETH_PRICE = 1500;
 
 const getPosition = (initialSize: number = 1, leverage = 10, side = 'long') => ({
+	marketKey: 'sETH' as FuturesMarketKey,
 	asset: 'sETH' as FuturesMarketAsset,
 	order: null,
 	remainingMargin: wei((initialSize * ETH_PRICE) / leverage),


### PR DESCRIPTION
Improve the futures refactor by using the `marketKey` as an index instead of the `marketAsset`. 

## Description
`marketAsset -> marketKey` is a "one-to-many" since we will have a V1 and V2 market with the same asset (`sETH`). Start migrating the UI to use the `marketKey` as the unique index for markets and positions.
