### PR TITLE
Added estimated rewards by reading file

### DIFF
--- a/sections/dashboard/Stake/StakingTab.tsx
+++ b/sections/dashboard/Stake/StakingTab.tsx
@@ -64,13 +64,7 @@ const StakingTabContainer = styled.div`
 	${media.greaterThan('mdUp')`
 		display: grid;
 		grid-template-columns: 1fr 1fr;
-		& > div {
-			flex: 1;
-
-			&:first-child {
-				margin-right: 15px;
-			}
-		}
+		grid-gap: 15px;
 	`}
 
 	${media.lessThan('mdUp')`

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -1,4 +1,5 @@
 import { wei } from '@synthetixio/wei';
+import { BigNumber } from 'ethers';
 import { formatEther } from 'ethers/lib/utils.js';
 import { useCallback, useMemo, FC } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +26,6 @@ import { formatTruncatedDuration } from 'utils/formatters/date';
 import { formatDollars, formatPercent, truncateNumbers, zeroBN } from 'utils/formatters/number';
 
 import { KwentaLabel, StakingCard } from './common';
-import { BigNumber } from 'ethers';
 
 const TradingRewardsTab: FC<TradingRewardProps> = ({
 	period = 0,

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -177,7 +177,7 @@ const PeriodLabel = styled.div`
 	display: flex;
 	align-items: center;
 	font-family: ${(props) => props.theme.fonts.regular};
-	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	color: ${(props) => props.theme.colors.common.secondaryGray};
 `;
 
 const CustomStyledTooltip = styled(StyledTooltip)`

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -25,6 +25,7 @@ import { formatTruncatedDuration } from 'utils/formatters/date';
 import { formatDollars, formatPercent, truncateNumbers, zeroBN } from 'utils/formatters/number';
 
 import { KwentaLabel, StakingCard } from './common';
+import { BigNumber } from 'ethers';
 
 const TradingRewardsTab: FC<TradingRewardProps> = ({
 	period = 0,
@@ -61,10 +62,10 @@ const TradingRewardsTab: FC<TradingRewardProps> = ({
 		`trading-rewards-snapshots/${network.id === 420 ? `goerli-` : ''}epoch-current.json`
 	);
 	const estimatedReward = useMemo(
-		() => Number(estimatedRewardQuery?.data?.claims[walletAddress!]?.amount) ?? 0,
+		() => BigNumber.from(estimatedRewardQuery?.data?.claims[walletAddress!]?.amount ?? 0),
 		[estimatedRewardQuery?.data?.claims, walletAddress]
 	);
-	const weeklyRewards = useMemo(() => Number(estimatedRewardQuery?.data?.tokenTotal) ?? 0, [
+	const weeklyRewards = useMemo(() => BigNumber.from(estimatedRewardQuery?.data?.tokenTotal ?? 0), [
 		estimatedRewardQuery?.data?.tokenTotal,
 	]);
 
@@ -75,16 +76,11 @@ const TradingRewardsTab: FC<TradingRewardProps> = ({
 	}, [dispatch]);
 
 	const ratio = useMemo(() => {
-		return estimatedReward && wei(estimatedReward).gt(0)
-			? wei(estimatedReward).div(wei(weeklyRewards))
-			: zeroBN;
+		return wei(weeklyRewards).gt(0) ? wei(estimatedReward).div(wei(weeklyRewards)) : zeroBN;
 	}, [estimatedReward, weeklyRewards]);
 
-	const showEstimatedValue = useMemo(() => estimatedReward && wei(period).eq(epochPeriod), [
-		epochPeriod,
-		estimatedReward,
-		period,
-	]);
+	const showEstimatedValue = useMemo(() => wei(period).eq(epochPeriod), [epochPeriod, period]);
+
 	return (
 		<TradingRewardsContainer>
 			<CardGridContainer>
@@ -146,9 +142,7 @@ const TradingRewardsTab: FC<TradingRewardProps> = ({
 								<div className="title">
 									{t('dashboard.stake.tabs.trading-rewards.estimated-rewards')}
 								</div>
-								<KwentaLabel>
-									{truncateNumbers(formatEther(estimatedReward.toString()), 4)}
-								</KwentaLabel>
+								<KwentaLabel>{truncateNumbers(wei(estimatedReward), 4)}</KwentaLabel>
 							</div>
 							<div>
 								<div className="title">
@@ -156,7 +150,7 @@ const TradingRewardsTab: FC<TradingRewardProps> = ({
 										EpochPeriod: period,
 									})}
 								</div>
-								<div className="value">{formatPercent(Number(ratio), { minDecimals: 2 })}</div>
+								<div className="value">{formatPercent(ratio, { minDecimals: 2 })}</div>
 							</div>
 						</>
 					) : null}
@@ -172,12 +166,12 @@ const TradingRewardsTab: FC<TradingRewardProps> = ({
 };
 
 const PeriodLabel = styled.div`
-	font-size: 14px;
-	line-height: 21px;
+	font-size: 13px;
+	line-height: 20px;
 	display: flex;
 	align-items: center;
 	font-family: ${(props) => props.theme.fonts.regular};
-	color: ${(props) => props.theme.colors.common.secondaryGray};
+	color: ${(props) => props.theme.colors.selectedTheme.gray};
 `;
 
 const CustomStyledTooltip = styled(StyledTooltip)`

--- a/state/staking/selectors.ts
+++ b/state/staking/selectors.ts
@@ -130,3 +130,8 @@ export const selectTotalVestable = createSelector(
 	(state: RootState) => state.staking.totalVestable,
 	wei
 );
+
+export const selectEpochPeriod = createSelector(
+	(state: RootState) => state.staking.epochPeriod,
+	wei
+);

--- a/state/staking/selectors.ts
+++ b/state/staking/selectors.ts
@@ -43,7 +43,7 @@ export const selectClaimableBalance = createSelector(
 
 export const selectPeriods = createSelector(
 	(state: RootState) => state.staking.epochPeriod,
-	(epochPeriod) => Array.from(new Array(epochPeriod + 1), (_, i) => i + 1)
+	(epochPeriod) => Array.from(new Array(epochPeriod + 1), (_, i) => i)
 );
 
 export const selectIsKwentaTokenApproved = createSelector(

--- a/translations/en.json
+++ b/translations/en.json
@@ -524,14 +524,15 @@
 					"spot-fee-paid": "Spot Fee Paid: Epoch {{EpochPeriod}}",
 					"future-fee-paid": "Futures Fees Paid: Ep. {{EpochPeriod}}",					
 					"fees-paid": "Total Fees in Pool: Ep. {{EpochPeriod}}",
-					"estimated-rewards": "Estimated Rewards",
-					"estimated-fee-share": "Estimated Fee Share",
+					"estimated-rewards": "*Estimated Rewards",
+					"estimated-reward-share": "*Estimated Reward Share",
 					"trading-activity-reset": "Time until next epoch",
 					"epoch": "Epoch {{EpochPeriod}}: {{EpochDate}}",
 					"claimable-rewards-epoch": "Claimable Rewards: Epoch {{EpochPeriod}}",
 					"claimable-rewards-all": "Claimable Trading Rewards",
 					"claim-epoch": "Claim: Epoch {{EpochPeriod}}",
-					"claim": "Claim"
+					"claim": "Claim",
+					"estimated-info": "* Estimated values do not reflect the final reward value and is subject to change as a result of future fees paid and staked amounts by other participants."
 				},
 				"escrow": {
 					"title": "Escrow",

--- a/translations/en.json
+++ b/translations/en.json
@@ -524,15 +524,15 @@
 					"spot-fee-paid": "Spot Fee Paid: Epoch {{EpochPeriod}}",
 					"future-fee-paid": "Futures Fees Paid: Ep. {{EpochPeriod}}",					
 					"fees-paid": "Total Fees in Pool: Ep. {{EpochPeriod}}",
-					"estimated-rewards": "*Estimated Rewards",
-					"estimated-reward-share": "*Estimated Reward Share",
+					"estimated-rewards": "Estimated Reward*",
+					"estimated-reward-share": "Estimated Reward Share*",
 					"trading-activity-reset": "Time until next epoch",
 					"epoch": "Epoch {{EpochPeriod}}: {{EpochDate}}",
 					"claimable-rewards-epoch": "Claimable Rewards: Epoch {{EpochPeriod}}",
 					"claimable-rewards-all": "Claimable Trading Rewards",
 					"claim-epoch": "Claim: Epoch {{EpochPeriod}}",
 					"claim": "Claim",
-					"estimated-info": "* Estimated values do not reflect the final reward value and is subject to change as a result of future fees paid and staked amounts by other participants."
+					"estimated-info": "* Estimated values do not reflect the final reward value and are subject to change as a result of Futures fees paid and staked amounts by other participants."
 				},
 				"escrow": {
 					"title": "Escrow",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
### Estimated Rewards
- [X] Show the estimated rewards for the ongoing epoch
- [X] Add a text to explain the meaning of estimated rewards
### CSS fix:
- [X] The padding between Kwenta logo and number should be same across different tabs.
- [X] The card of Trading Reward is slighter bigger than that of Staking.

## Related issue
#1675 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/206324918-6b9f86cc-e2b9-4b9e-a16e-e1f777965803.png)
![image](https://user-images.githubusercontent.com/4819006/206324943-1b4c5fee-1057-47c8-826d-ebc3ea1fb751.png)
