### PR TITLE
Add Market Settings

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -24,7 +24,6 @@ import {
 import {
 	selectCrossMarginBalanceInfo,
 	selectCrossMarginAccount,
-	selectMarketAssetRate,
 	selectPosition,
 	selectMaxLeverage,
 	selectAboveMaxLeverage,
@@ -39,6 +38,7 @@ import {
 	selectCrossMarginTradeFees,
 	selectDynamicFeeRate,
 	selectCrossMarginMarginDelta,
+	selectPerpsMarketRate,
 } from 'state/futures/selectors';
 import { selectMarketAsset, selectMarketInfo } from 'state/futures/selectors';
 import { useAppSelector, useAppDispatch } from 'state/hooks';
@@ -93,7 +93,7 @@ const useFuturesData = () => {
 		selectCrossMarginSettings
 	);
 	const isAdvancedOrder = useAppSelector(selectIsAdvancedOrder);
-	const marketAssetRate = useAppSelector(selectMarketAssetRate);
+	const marketAssetRate = useAppSelector(selectPerpsMarketRate);
 	const orderPrice = useAppSelector(selectCrossMarginOrderPrice);
 	const market = useAppSelector(selectMarketInfo);
 

--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -475,13 +475,14 @@ export default class FuturesService {
 	public async getIsolatedTradePreview(
 		marketAddress: string,
 		sizeDelta: Wei,
+		priceOracle: Wei,
 		price: Wei,
 		leverageSide: PositionSide
 	) {
 		const market = PerpsV2Market__factory.connect(marketAddress, this.sdk.context.signer);
 		const details = await market.postTradeDetails(
 			sizeDelta.toBN(),
-			price.toBN(), // TODO: Replace this price with the fill price
+			priceOracle.toBN(),
 			this.sdk.context.walletAddress
 		);
 		return formatPotentialIsolatedTrade(details, price, sizeDelta, leverageSide);

--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -20,6 +20,7 @@ import {
 	PerpsV2MarketData,
 	PerpsV2Market__factory,
 } from 'sdk/contracts/types';
+import { IPerpsV2MarketSettings } from 'sdk/contracts/types/PerpsV2MarketData';
 import { NetworkOverrideOptions } from 'sdk/types/common';
 import {
 	FundingRateInput,
@@ -103,13 +104,15 @@ export default class FuturesService {
 			PerpsV2MarketData.globals(),
 		]);
 
-		const filteredMarkets = markets.filter((m: any) => {
-			const marketKey = parseBytes32String(m.key) as FuturesMarketKey;
-			const market = enabledMarkets.find((market) => {
-				return marketKey === market.key;
-			});
-			return !!market;
-		}) as PerpsV2MarketData.MarketSummaryStructOutput[];
+		const filteredMarkets = (markets as PerpsV2MarketData.MarketSummaryStructOutput[]).filter(
+			(m) => {
+				const marketKey = parseBytes32String(m.key) as FuturesMarketKey;
+				const market = enabledMarkets.find((market) => {
+					return marketKey === market.key;
+				});
+				return !!market;
+			}
+		);
 
 		const marketKeys = filteredMarkets.map((m: any) => {
 			return m.key;
@@ -119,17 +122,17 @@ export default class FuturesService {
 			ExchangeRates.getCurrentRoundId(key)
 		);
 
-		const marketLimitCalls = marketKeys.map((key: string) =>
-			PerpsV2MarketSettings.maxMarketValue(key)
-		);
+		const parametersCalls = marketKeys.map((key: string) => PerpsV2MarketSettings.parameters(key));
 
 		const responses = await this.sdk.context.multicallProvider.all([
 			...currentRoundIdCalls,
-			...marketLimitCalls,
+			...parametersCalls,
 		]);
 
 		const currentRoundIds = responses.slice(0, currentRoundIdCalls.length);
-		const marketLimits = responses.slice(currentRoundIdCalls.length);
+		const marketParameters = responses.slice(
+			currentRoundIdCalls.length
+		) as IPerpsV2MarketSettings.ParametersStructOutput[];
 
 		const { suspensions, reasons } = await SystemStatus.getFuturesMarketSuspensions(marketKeys);
 
@@ -182,12 +185,31 @@ export default class FuturesService {
 				marketSkew: wei(marketSkew),
 				maxLeverage: wei(maxLeverage),
 				marketSize: wei(marketSize),
-				marketLimit: wei(marketLimits[i]).mul(wei(price)),
-				price: wei(price),
+				marketLimit: wei(marketParameters[i].maxMarketValue).mul(wei(price)),
+				priceOracle: wei(price),
+				price: wei(price).mul(wei(marketSkew).div(wei(marketParameters[i].skewScale)).add(1)),
 				minInitialMargin: wei(globals.minInitialMargin),
 				keeperDeposit: wei(globals.minKeeperFee),
 				isSuspended: suspensions[i],
 				marketClosureReason: getReasonFromCode(reasons[i]) as MarketClosureReason,
+				settings: {
+					maxMarketValue: wei(marketParameters[i].maxMarketValue),
+					skewScale: wei(marketParameters[i].skewScale),
+					delayedOrderConfirmWindow: wei(
+						marketParameters[i].delayedOrderConfirmWindow,
+						0
+					).toNumber(),
+					offchainDelayedOrderMinAge: wei(
+						marketParameters[i].offchainDelayedOrderMinAge,
+						0
+					).toNumber(),
+					offchainDelayedOrderMaxAge: wei(
+						marketParameters[i].offchainDelayedOrderMaxAge,
+						0
+					).toNumber(),
+					minDelayTimeDelta: wei(marketParameters[i].minDelayTimeDelta, 0).toNumber(),
+					maxDelayTimeDelta: wei(marketParameters[i].maxDelayTimeDelta, 0).toNumber(),
+				},
 			})
 		);
 		return futuresMarkets;

--- a/sdk/types/futures.ts
+++ b/sdk/types/futures.ts
@@ -245,7 +245,7 @@ export type FuturesPotentialTradeDetails<T = Wei> = {
 	status: PotentialTradeStatus;
 	showStatus: boolean;
 	statusMessage: string;
-	slippagePercent: T;
+	priceImpact: T;
 	slippageAmount: T;
 };
 

--- a/sdk/types/futures.ts
+++ b/sdk/types/futures.ts
@@ -42,12 +42,22 @@ export type FuturesMarket<T = Wei> = {
 	marketSkew: T;
 	marketSize: T;
 	maxLeverage: T;
+	priceOracle: T;
 	price: T;
 	minInitialMargin: T;
 	keeperDeposit: T;
 	isSuspended: boolean;
 	marketClosureReason: SynthSuspensionReason;
 	marketLimit: T;
+	settings: {
+		maxMarketValue: T;
+		skewScale: T;
+		delayedOrderConfirmWindow: number;
+		offchainDelayedOrderMinAge: number;
+		offchainDelayedOrderMaxAge: number;
+		minDelayTimeDelta: number;
+		maxDelayTimeDelta: number;
+	};
 };
 
 export type FundingRateUpdate = {

--- a/sdk/utils/futures.ts
+++ b/sdk/utils/futures.ts
@@ -214,7 +214,7 @@ export const serializePotentialTrade = (
 	fee: preview.fee.toString(),
 	leverage: preview.leverage.toString(),
 	notionalValue: preview.notionalValue.toString(),
-	slippagePercent: preview.slippagePercent.toString(),
+	priceImpact: preview.priceImpact.toString(),
 	slippageAmount: preview.slippageAmount.toString(),
 });
 
@@ -230,7 +230,7 @@ export const unserializePotentialTrade = (
 	fee: wei(preview.fee),
 	leverage: wei(preview.leverage),
 	notionalValue: wei(preview.notionalValue),
-	slippagePercent: wei(preview.slippagePercent),
+	priceImpact: wei(preview.priceImpact),
 	slippageAmount: wei(preview.slippageAmount),
 });
 
@@ -281,12 +281,12 @@ export const formatPotentialIsolatedTrade = (
 	const notionalValue = wei(size).mul(wei(basePrice));
 	const leverage = notionalValue.div(wei(margin));
 
-	const slippage = wei(price).sub(basePrice).div(basePrice);
+	const priceImpact = wei(price).sub(basePrice).div(basePrice);
 	const slippageDirection = nativeSizeDelta.gt(0)
-		? slippage.gt(0)
+		? priceImpact.gt(0)
 			? -1
 			: nativeSizeDelta.lt(0)
-			? slippage.lt(0)
+			? priceImpact.lt(0)
 			: -1
 		: 1;
 
@@ -303,8 +303,8 @@ export const formatPotentialIsolatedTrade = (
 		status,
 		showStatus: status > 0, // 0 is success
 		statusMessage: getTradeStatusMessage(status),
-		slippagePercent: slippage.mul(slippageDirection),
-		slippageAmount: slippage.mul(slippageDirection).mul(tradeValueWithoutSlippage),
+		priceImpact: priceImpact,
+		slippageAmount: priceImpact.mul(slippageDirection).mul(tradeValueWithoutSlippage),
 	};
 };
 
@@ -328,7 +328,7 @@ export const formatPotentialTrade = (
 		status,
 		showStatus: status > 0, // 0 is success
 		statusMessage: getTradeStatusMessage(status),
-		slippagePercent: wei(0),
+		priceImpact: wei(0),
 		slippageAmount: wei(0),
 	};
 };

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -6,7 +6,6 @@ import { useRecoilValue } from 'recoil';
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { NO_VALUE } from 'constants/placeholder';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import useExternalPriceQuery from 'queries/rates/useExternalPriceQuery';
 import {
 	selectMarketAsset,
 	selectMarketInfo,
@@ -35,8 +34,6 @@ const useGetMarketData = (mobile?: boolean) => {
 
 	const { selectedPriceCurrency } = useSelectedPriceCurrency();
 
-	const externalPriceQuery = useExternalPriceQuery(marketKey);
-	const externalPrice = externalPriceQuery?.data ?? 0;
 	const minDecimals =
 		isFiatCurrency(selectedPriceCurrency.name) && isDecimalFour(marketKey)
 			? DEFAULT_CRYPTO_DECIMALS
@@ -180,7 +177,6 @@ const useGetMarketData = (mobile?: boolean) => {
 		marketInfo,
 		futuresVolumes,
 		selectedPriceCurrency.name,
-		externalPrice,
 		pastPrice?.price,
 		minDecimals,
 		t,

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -48,6 +48,7 @@ const useGetMarketData = (mobile?: boolean) => {
 		const fundingValue = marketInfo?.currentFundingRate;
 
 		const marketPrice = wei(marketInfo?.price ?? 0);
+		const oraclePrice = wei(marketInfo?.priceOracle ?? 0);
 		const marketName = `${marketInfo?.marketName ?? t('futures.market.info.default-market')}`;
 
 		const futuresTradingVolume = marketInfo?.marketKey
@@ -59,14 +60,19 @@ const useGetMarketData = (mobile?: boolean) => {
 
 		if (mobile) {
 			return {
-				'Live Price': {
-					value:
-						externalPrice === 0
-							? '-'
-							: formatCurrency(selectedPriceCurrency.name, externalPrice, {
-									sign: '$',
-									minDecimals,
-							  }),
+				[marketName]: {
+					value: formatCurrency(selectedPriceCurrency.name, marketPrice, {
+						sign: '$',
+						minDecimals,
+						isAssetPrice: true,
+					}),
+				},
+				[MarketDataKey.oraclePrice]: {
+					value: formatCurrency(selectedPriceCurrency.name, oraclePrice, {
+						sign: '$',
+						minDecimals,
+						isAssetPrice: true,
+					}),
 				},
 				[MarketDataKey.dailyTrades]: {
 					value: `${futuresTradeCount}`,
@@ -119,15 +125,12 @@ const useGetMarketData = (mobile?: boolean) => {
 						isAssetPrice: true,
 					}),
 				},
-				[MarketDataKey.externalPrice]: {
-					value:
-						externalPrice === 0
-							? NO_VALUE
-							: formatCurrency(selectedPriceCurrency.name, externalPrice, {
-									sign: '$',
-									minDecimals,
-									isAssetPrice: true,
-							  }),
+				[MarketDataKey.oraclePrice]: {
+					value: formatCurrency(selectedPriceCurrency.name, oraclePrice, {
+						sign: '$',
+						minDecimals,
+						isAssetPrice: true,
+					}),
 				},
 				[MarketDataKey.dailyChange]: {
 					value:

--- a/sections/futures/MarketDetails/utils.ts
+++ b/sections/futures/MarketDetails/utils.ts
@@ -34,6 +34,7 @@ const map: Record<typeof markets[number], string> = {
 
 export enum MarketDataKey {
 	externalPrice = 'External Price',
+	oraclePrice = 'Oracle Price',
 	dailyChange = '24H Change',
 	dailyVolume = '24H Volume',
 	dailyTrades = '24H Trades',
@@ -44,6 +45,7 @@ export enum MarketDataKey {
 
 export const marketDataKeyMap: Record<MarketDataKey, string> = {
 	[MarketDataKey.externalPrice]: 'external-price',
+	[MarketDataKey.oraclePrice]: 'oracle-price',
 	[MarketDataKey.dailyChange]: '24h-change',
 	[MarketDataKey.dailyVolume]: '24h-vol',
 	[MarketDataKey.dailyTrades]: '24h-trades',

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -102,10 +102,10 @@ const NextPriceConfirmationModal: FC = () => {
 			},
 			{
 				label: 'estimated price impact',
-				value: `${formatPercent(potentialTradeDetails?.slippagePercent ?? zeroBN)}`,
-				color: potentialTradeDetails?.slippageAmount.gt(0)
+				value: `${formatPercent(potentialTradeDetails?.priceImpact ?? zeroBN)}`,
+				color: potentialTradeDetails?.priceImpact.gt(0)
 					? 'green'
-					: potentialTradeDetails?.slippageAmount.lt(0)
+					: potentialTradeDetails?.priceImpact.lt(0)
 					? 'red'
 					: '',
 			},

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -101,17 +101,23 @@ const NextPriceConfirmationModal: FC = () => {
 				value: formatDollars(potentialTradeDetails?.price ?? zeroBN, { isAssetPrice: true }),
 			},
 			{
-				label: 'estimated slippage',
-				value: `${formatDollars(potentialTradeDetails?.slippageAmount ?? zeroBN)} (${formatPercent(
-					potentialTradeDetails?.slippagePercent ?? zeroBN
-				)})`,
+				label: 'estimated price impact',
+				value: `${formatPercent(potentialTradeDetails?.slippagePercent ?? zeroBN)}`,
 				color: potentialTradeDetails?.slippageAmount.gt(0)
 					? 'green'
 					: potentialTradeDetails?.slippageAmount.lt(0)
 					? 'red'
 					: '',
 			},
-
+			{
+				label: 'estimated slippage',
+				value: `${formatDollars(potentialTradeDetails?.slippageAmount ?? zeroBN)}`,
+				color: potentialTradeDetails?.slippageAmount.gt(0)
+					? 'green'
+					: potentialTradeDetails?.slippageAmount.lt(0)
+					? 'red'
+					: '',
+			},
 			{
 				label: t('futures.market.user.position.modal.fee-total'),
 				value: formatCurrency(selectedPriceCurrency.name, totalDeposit, {

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -31,6 +31,7 @@ import { zeroBN, formatCurrency, formatDollars, formatPercent } from 'utils/form
 import BaseDrawer from '../MobileTrade/drawers/BaseDrawer';
 import { PositionSide } from '../types';
 import { MobileConfirmTradeButton } from './TradeConfirmationModal';
+import { getDisplayAsset } from 'sdk/utils/futures';
 
 const NextPriceConfirmationModal: FC = () => {
 	const { t } = useTranslation();
@@ -88,9 +89,13 @@ const NextPriceConfirmationModal: FC = () => {
 			},
 			{
 				label: t('futures.market.user.position.modal.size'),
-				value: formatCurrency(marketAsset || '', orderDetails.nativeSizeDelta.abs(), {
-					sign: marketAsset ? synthsMap[marketAsset]?.sign : '',
-				}),
+				value: formatCurrency(
+					getDisplayAsset(marketAsset) || '',
+					orderDetails.nativeSizeDelta.abs() ?? zeroBN,
+					{
+						currencyKey: getDisplayAsset(marketAsset) ?? '',
+					}
+				),
 			},
 			{
 				label: t('futures.market.user.position.modal.deposit'),

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -152,7 +152,17 @@ export default function TradeConfirmationModal({
 				value: formatDollars(gasFee ?? zeroBN),
 			},
 		],
-		[positionDetails, marketAsset, keeperFee, gasFee, tradeFee, orderType, orderPrice, leverageSide]
+		[
+			positionDetails,
+			marketAsset,
+			keeperFee,
+			gasFee,
+			tradeFee,
+			orderType,
+			orderPrice,
+			leverageSide,
+			potentialTradeDetails,
+		]
 	);
 
 	const disabledReason = useMemo(() => {

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -112,13 +112,20 @@ export default function TradeConfirmationModal({
 						value: formatDollars(positionDetails?.price ?? zeroBN, { isAssetPrice: true }),
 				  },
 			{
-				label: 'slippage',
-				value: `${formatDollars(positionDetails?.slippageAmount ?? zeroBN)} (${formatPercent(
-					positionDetails?.slippagePercent ?? zeroBN
-				)})`,
-				color: positionDetails?.slippageAmount.gt(0)
+				label: 'price impact',
+				value: `${formatPercent(potentialTradeDetails?.slippagePercent ?? zeroBN)}`,
+				color: potentialTradeDetails?.slippageAmount.gt(0)
 					? 'green'
-					: positionDetails?.slippageAmount.lt(0)
+					: potentialTradeDetails?.slippageAmount.lt(0)
+					? 'red'
+					: '',
+			},
+			{
+				label: 'slippage',
+				value: `${formatDollars(potentialTradeDetails?.slippageAmount ?? zeroBN)}`,
+				color: potentialTradeDetails?.slippageAmount.gt(0)
+					? 'green'
+					: potentialTradeDetails?.slippageAmount.lt(0)
 					? 'red'
 					: '',
 			},

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -113,10 +113,10 @@ export default function TradeConfirmationModal({
 				  },
 			{
 				label: 'price impact',
-				value: `${formatPercent(potentialTradeDetails?.slippagePercent ?? zeroBN)}`,
-				color: potentialTradeDetails?.slippageAmount.gt(0)
+				value: `${formatPercent(potentialTradeDetails?.priceImpact ?? zeroBN)}`,
+				color: potentialTradeDetails?.priceImpact.gt(0)
 					? 'green'
-					: potentialTradeDetails?.slippageAmount.lt(0)
+					: potentialTradeDetails?.priceImpact.lt(0)
 					? 'red'
 					: '',
 			},

--- a/sections/futures/UserInfo/OpenOrdersTable.tsx
+++ b/sections/futures/UserInfo/OpenOrdersTable.tsx
@@ -15,7 +15,7 @@ import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
 import { PositionSide } from 'queries/futures/types';
 import { DelayedOrder } from 'sdk/types/futures';
 import { cancelDelayedOrder, executeDelayedOrder } from 'state/futures/actions';
-import { selectMarketAsset, selectOpenOrders } from 'state/futures/selectors';
+import { selectMarketAsset, selectMarkets, selectOpenOrders } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { formatTimer } from 'utils/formatters/date';
 import { formatCurrency, formatDollars } from 'utils/formatters/number';
@@ -37,6 +37,7 @@ const OpenOrdersTable: React.FC = () => {
 	const dispatch = useAppDispatch();
 
 	const marketAsset = useAppSelector(selectMarketAsset);
+	const futuresMarkets = useAppSelector(selectMarkets);
 
 	const isL2 = useIsL2();
 	const openOrders = useAppSelector(selectOpenOrders);
@@ -47,36 +48,45 @@ const OpenOrdersTable: React.FC = () => {
 
 	const rowsData = useMemo(() => {
 		const ordersWithCancel = openOrders
-			.map((o) => ({
-				...o,
-				sizeTxt: formatCurrency(o.asset, o.size.abs(), {
-					currencyKey: getDisplayAsset(o.asset) ?? '',
-					minDecimals: o.size.abs().lt(0.01) ? 4 : 2,
-				}),
-				timeToExecution: countdownTimers ? countdownTimers[o.marketKey]?.timeToExecution : null,
-				timePastExecution: countdownTimers ? countdownTimers[o.marketKey]?.timePastExecution : null,
-				show: !!countdownTimers && countdownTimers[o.marketKey],
-				isStale: countdownTimers
-					? countdownTimers[o.marketKey]?.timeToExecution === 0 &&
-					  countdownTimers[o.marketKey]?.timePastExecution > 60
-					: false,
-				isExecutable: countdownTimers
-					? countdownTimers[o.marketKey]?.timeToExecution === 0 &&
-					  countdownTimers[o.marketKey]?.timePastExecution <= 60 // SET DEFAULT
-					: false,
-				totalDeposit: o.commitDeposit.add(o.keeperDeposit),
-				onCancel: () => {
-					dispatch(
-						cancelDelayedOrder({
-							marketAddress: o.marketAddress,
-							isOffchain: o.isOffchain,
-						})
-					);
-				},
-				onExecute: () => {
-					dispatch(executeDelayedOrder(o.marketAddress));
-				},
-			}))
+			.map((o) => {
+				const market = futuresMarkets.find((m) => m.marketKey === o.marketKey);
+				const order = {
+					...o,
+					sizeTxt: formatCurrency(o.asset, o.size.abs(), {
+						currencyKey: getDisplayAsset(o.asset) ?? '',
+						minDecimals: o.size.abs().lt(0.01) ? 4 : 2,
+					}),
+					timeToExecution: countdownTimers ? countdownTimers[o.marketKey]?.timeToExecution : null,
+					timePastExecution: countdownTimers
+						? countdownTimers[o.marketKey]?.timePastExecution
+						: null,
+					show: !!countdownTimers && countdownTimers[o.marketKey],
+					isStale:
+						countdownTimers && market?.settings
+							? countdownTimers[o.marketKey]?.timeToExecution === 0 &&
+							  countdownTimers[o.marketKey]?.timePastExecution > market.settings.maxDelayTimeDelta
+							: false,
+					isExecutable:
+						countdownTimers && market?.settings
+							? countdownTimers[o.marketKey]?.timeToExecution === 0 &&
+							  countdownTimers[o.marketKey]?.timePastExecution <=
+									market.settings.offchainDelayedOrderMaxAge
+							: false,
+					totalDeposit: o.commitDeposit.add(o.keeperDeposit),
+					onCancel: () => {
+						dispatch(
+							cancelDelayedOrder({
+								marketAddress: o.marketAddress,
+								isOffchain: o.isOffchain,
+							})
+						);
+					},
+					onExecute: () => {
+						dispatch(executeDelayedOrder(o.marketAddress));
+					},
+				};
+				return order;
+			})
 			.sort((a, b) => {
 				return b.asset === marketAsset && a.asset !== marketAsset
 					? 1
@@ -85,7 +95,7 @@ const OpenOrdersTable: React.FC = () => {
 					: -1;
 			});
 		return ordersWithCancel;
-	}, [openOrders, marketAsset, countdownTimers, dispatch]);
+	}, [openOrders, futuresMarkets, marketAsset, countdownTimers, dispatch]);
 
 	useEffect(() => {
 		const timer = setTimeout(() => {

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -288,6 +288,7 @@ export const fetchIsolatedMarginTradePreview = createAsyncThunk<
 			const preview = await sdk.futures.getIsolatedTradePreview(
 				marketInfo?.market,
 				sizeDelta,
+				marketInfo?.priceOracle,
 				marketInfo?.price,
 				leverageSide
 			);

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -102,6 +102,10 @@ export const selectIsolatedPriceImpact = createSelector(
 	(priceImpact) => wei(priceImpact, 0)
 );
 
+export const selectPerpsMarketRate = createSelector(selectMarketInfo, (marketInfo) => {
+	return marketInfo?.price ?? wei(0);
+});
+
 export const selectMarketAssetRate = createSelector(
 	(state: RootState) => state.futures[accountType(state.futures.selectedType)].selectedMarketAsset,
 	selectExchangeRates,

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -414,10 +414,16 @@ export const serializeMarket = (market: FuturesMarket): FuturesMarket<string> =>
 		marketSkew: market.marketSkew.toString(),
 		marketSize: market.marketSize.toString(),
 		maxLeverage: market.maxLeverage.toString(),
+		priceOracle: market.priceOracle.toString(),
 		price: market.price.toString(),
 		minInitialMargin: market.minInitialMargin.toString(),
 		keeperDeposit: market.keeperDeposit.toString(),
 		marketLimit: market.marketLimit.toString(),
+		settings: {
+			...market.settings,
+			maxMarketValue: market.settings.maxMarketValue.toString(),
+			skewScale: market.settings.skewScale.toString(),
+		},
 	};
 };
 
@@ -449,10 +455,16 @@ export const unserializeMarkets = (markets: FuturesMarket<string>[]): FuturesMar
 		marketSkew: wei(m.marketSkew),
 		marketSize: wei(m.marketSize),
 		maxLeverage: wei(m.maxLeverage),
+		priceOracle: wei(m.priceOracle),
 		price: wei(m.price),
 		minInitialMargin: wei(m.minInitialMargin),
 		keeperDeposit: wei(m.keeperDeposit),
 		marketLimit: wei(m.marketLimit),
+		settings: {
+			...m.settings,
+			maxMarketValue: wei(m.settings.maxMarketValue),
+			skewScale: wei(m.settings.skewScale),
+		},
 	}));
 };
 


### PR DESCRIPTION
Update the `FuturesMarket` entity to hold many more settings coming from the `PerpsV2MarketSettings` contract. We already call a single parameter, this change fetches them all

## Description
* Add settings to futures market data fetching
* Use delay times for executable/stale delayed orders
* Use market skew to adjust price by the premium/discount
* Update the futures rate to use this adjusted price instead of the oracle price
