### PR TITLE
Sort exchange tokens by balance, then lexicographically

### DIFF
--- a/sections/shared/modals/SelectCurrencyModal/SelectCurrencyModal.tsx
+++ b/sections/shared/modals/SelectCurrencyModal/SelectCurrencyModal.tsx
@@ -92,11 +92,14 @@ export const SelectCurrencyModal: FC<SelectCurrencyModalProps> = ({
 		const synthsList = assetSearch ? searchFilteredSynths : categoryFilteredSynths;
 		return orderBy(
 			synthsList,
-			(synth) => {
-				const synthBalance = synthBalancesMap[synth.name as CurrencyKey];
-				return !!synthBalance ? Number(synthBalance.usdBalance) : 0;
-			},
-			'desc'
+			[
+				(synth) => {
+					const synthBalance = synthBalancesMap[synth.name as CurrencyKey];
+					return !!synthBalance ? Number(synthBalance.usdBalance) : 0;
+				},
+				(synth) => synth.name.toLowerCase(),
+			],
+			['desc', 'asc']
 		);
 	}, [assetSearch, searchFilteredSynths, categoryFilteredSynths, synthBalancesMap]);
 
@@ -145,8 +148,11 @@ export const SelectCurrencyModal: FC<SelectCurrencyModalProps> = ({
 							}
 							return token;
 						}),
-						({ usdBalance }) => (usdBalance ? usdBalance.toNumber() : 0),
-						'desc'
+						[
+							({ usdBalance }) => (usdBalance ? usdBalance.toNumber() : 0),
+							({ name }) => name.toLowerCase(),
+						],
+						['desc', 'asc']
 				  )
 				: searchFilteredTokens;
 		if (ordered.length > PAGE_LENGTH) return ordered.slice(0, PAGE_LENGTH * page);


### PR DESCRIPTION
Adds secondary sorting clauses to the token and synth lists in the `SelectCurrencyModal` based on token/synth name. This way the user's holdings will still be at the top, but anything with a 0 balance will have a stable alphabetical ordering below it for more predictability.

## Related issue
https://github.com/Kwenta/kwenta/issues/1753

## How Has This Been Tested?
Tested locally against optimism mainnet (since the list of tokens for exchange is very limited on Goerli)

## Screenshots (if appropriate):
<img width="400" alt="kwenta-1753" src="https://user-images.githubusercontent.com/109358247/207905196-d902a2b1-d44e-47a7-8b02-576fc28e7648.png">
