### PR TITLE
Remove WebSocketProvider

### DIFF
--- a/containers/Connector/Connector.tsx
+++ b/containers/Connector/Connector.tsx
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 import { keyBy } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createContainer } from 'unstated-next';
-import { chain, useAccount, useNetwork, useSigner, useWebSocketProvider } from 'wagmi';
+import { chain, useAccount, useNetwork, useSigner, useProvider } from 'wagmi';
 
 import { sdk } from 'state/config';
 import { useAppDispatch } from 'state/hooks';
@@ -30,8 +30,8 @@ const useConnector = () => {
 
 	const walletAddress = useMemo(() => address ?? null, [address]);
 
-	const provider = useWebSocketProvider({ chainId: network.id });
-	const l2Provider = useWebSocketProvider({ chainId: chain.optimism.id });
+	const provider = useProvider({ chainId: network.id });
+	const l2Provider = useProvider({ chainId: chain.optimism.id });
 	const { data: signer } = useSigner();
 
 	// Provides a default mainnet provider, irrespective of the current network
@@ -92,8 +92,8 @@ const useConnector = () => {
 		unsupportedNetwork,
 		isWalletConnected,
 		walletAddress,
-		provider: provider!,
-		l2Provider: l2Provider!,
+		provider,
+		l2Provider,
 		signer,
 		network,
 		synthsMap,

--- a/containers/Connector/config.ts
+++ b/containers/Connector/config.ts
@@ -19,7 +19,7 @@ import Safe from 'components/Rainbowkit/Gnosis';
 import Tally from 'components/Rainbowkit/Tally';
 import { BLAST_NETWORK_LOOKUP } from 'constants/network';
 
-const { chains, provider, webSocketProvider } = configureChains(
+const { chains, provider } = configureChains(
 	[chain.optimism, chain.mainnet, chain.optimismGoerli, chain.goerli],
 	[
 		infuraProvider({
@@ -32,13 +32,9 @@ const { chains, provider, webSocketProvider } = configureChains(
 				return !BLAST_NETWORK_LOOKUP[networkChain.id]
 					? {
 							http: networkChain.rpcUrls.default,
-							webSocket: networkChain.rpcUrls.default.replace('https', 'wss'),
 					  }
 					: {
 							http: `https://${BLAST_NETWORK_LOOKUP[networkChain.id]}.blastapi.io/${
-								process.env.NEXT_PUBLIC_BLASTAPI_PROJECT_ID
-							}`,
-							webSocket: `wss://${BLAST_NETWORK_LOOKUP[networkChain.id]}.blastapi.io/${
 								process.env.NEXT_PUBLIC_BLASTAPI_PROJECT_ID
 							}`,
 					  };
@@ -78,7 +74,6 @@ export const wagmiClient = createClient({
 	autoConnect: true,
 	connectors,
 	provider,
-	webSocketProvider,
 });
 
 export { chains };

--- a/state/config.ts
+++ b/state/config.ts
@@ -2,4 +2,4 @@ import KwentaSDK from 'sdk';
 
 import { wagmiClient } from 'containers/Connector/config';
 
-export const sdk = new KwentaSDK({ networkId: 10, provider: wagmiClient.webSocketProvider! });
+export const sdk = new KwentaSDK({ networkId: 10, provider: wagmiClient.provider });


### PR DESCRIPTION
## Description
This PR switches the app to using regular HTTP requests for contract calls, since the WebSocket solution has proven unreliable, particularly with monitoring transactions.

## Related issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
