### PR TITLE
Redirect the fleek base url to `fleek.one`

### DIFF
--- a/queries/files/constants.ts
+++ b/queries/files/constants.ts
@@ -1,3 +1,3 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket';
 
-export const FLEEK_BASE_URL = 'https://storageapi.fleek.co';
+export const FLEEK_BASE_URL = 'https://storageapi.fleek.one';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`storageapi.fleek.co` will eventually be replaced by `storageapi.fleek.one`. So it's time for us to make the change.

ref: [Deprecation of IPFS Gateway and Storage API URL on Fleek.co](https://blog.fleek.co/posts/fleek-co-gateway-storage-url-deprecation)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the Staking UI and connect the wallet.
2. Check if the info is the same as the prod.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/207963947-d3b7c02f-94fb-4e55-8978-1cc05ac60b59.png)
