### PR TITLE
Upgrade interfaces

### DIFF
--- a/sdk/contracts/abis/PerpsV2Market.json
+++ b/sdk/contracts/abis/PerpsV2Market.json
@@ -1,48 +1,118 @@
 [
     {
+        "anonymous": false,
         "inputs": [
             {
-                "internalType": "address payable",
-                "name": "_proxy",
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
                 "type": "address"
             },
             {
-                "internalType": "address",
-                "name": "_marketState",
-                "type": "address"
+                "indexed": false,
+                "internalType": "bool",
+                "name": "isOffchain",
+                "type": "bool"
             },
             {
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "currentRoundId",
+                "type": "uint256"
             },
             {
-                "internalType": "address",
-                "name": "_resolver",
-                "type": "address"
+                "indexed": false,
+                "internalType": "int256",
+                "name": "sizeDelta",
+                "type": "int256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "targetRoundId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "commitDeposit",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "keeperDeposit",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "trackingCode",
+                "type": "bytes32"
             }
         ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
+        "name": "DelayedOrderRemoved",
+        "type": "event"
     },
     {
         "anonymous": false,
         "inputs": [
             {
-                "indexed": false,
-                "internalType": "bytes32",
-                "name": "name",
-                "type": "bytes32"
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
             },
             {
                 "indexed": false,
-                "internalType": "address",
-                "name": "destination",
-                "type": "address"
+                "internalType": "bool",
+                "name": "isOffchain",
+                "type": "bool"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "sizeDelta",
+                "type": "int256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "targetRoundId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "intentionTime",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "executableAtTime",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "commitDeposit",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "keeperDeposit",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "trackingCode",
+                "type": "bytes32"
             }
         ],
-        "name": "CacheUpdated",
+        "name": "DelayedOrderSubmitted",
         "type": "event"
     },
     {
@@ -81,6 +151,25 @@
         "inputs": [
             {
                 "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "marginDelta",
+                "type": "int256"
+            }
+        ],
+        "name": "MarginTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
                 "internalType": "bytes32",
                 "name": "trackingCode",
                 "type": "bytes32"
@@ -110,58 +199,7 @@
                 "type": "uint256"
             }
         ],
-        "name": "FuturesTracking",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "int256",
-                "name": "marginDelta",
-                "type": "int256"
-            }
-        ],
-        "name": "MarginTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "oldOwner",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnerChanged",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnerNominated",
+        "name": "PerpsTracking",
         "type": "event"
     },
     {
@@ -261,28 +299,6 @@
         ],
         "name": "PositionModified",
         "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "proxyAddress",
-                "type": "address"
-            }
-        ],
-        "name": "ProxyUpdated",
-        "type": "event"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "acceptOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
     },
     {
         "constant": true,
@@ -479,34 +495,8 @@
         "outputs": [
             {
                 "internalType": "int256",
-                "name": "fundingRateVelocity",
+                "name": "fundingVelocity",
                 "type": "int256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "currentLeverage",
-        "outputs": [
-            {
-                "internalType": "int256",
-                "name": "leverage",
-                "type": "int256"
-            },
-            {
-                "internalType": "bool",
-                "name": "invalid",
-                "type": "bool"
             }
         ],
         "payable": false,
@@ -572,24 +562,9 @@
                         "type": "bytes32"
                     }
                 ],
-                "internalType": "struct IPerpsV2MarketBaseTypes.DelayedOrder",
+                "internalType": "struct IPerpsV2MarketConsolidated.DelayedOrder",
                 "name": "",
                 "type": "tuple"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "entryDebtCorrection",
-        "outputs": [
-            {
-                "internalType": "int256",
-                "name": "",
-                "type": "int256"
             }
         ],
         "payable": false,
@@ -629,37 +604,6 @@
         "outputs": [],
         "payable": true,
         "stateMutability": "payable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "int256",
-                "name": "size",
-                "type": "int256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "basePrice",
-                "type": "uint256"
-            }
-        ],
-        "name": "fillPriceWithBasePrice",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
         "type": "function"
     },
     {
@@ -714,21 +658,6 @@
         "type": "function"
     },
     {
-        "constant": true,
-        "inputs": [],
-        "name": "isResolverCached",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
         "constant": false,
         "inputs": [
             {
@@ -757,27 +686,6 @@
             {
                 "internalType": "uint256",
                 "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "liquidationMargin",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "lMargin",
                 "type": "uint256"
             }
         ],
@@ -897,61 +805,6 @@
         "type": "function"
     },
     {
-        "constant": true,
-        "inputs": [],
-        "name": "marketState",
-        "outputs": [
-            {
-                "internalType": "contract IPerpsV2MarketState",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "maxOrderSizes",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "long",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "short",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "invalid",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "messageSender",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
         "constant": false,
         "inputs": [
             {
@@ -1005,57 +858,6 @@
                 "type": "address"
             }
         ],
-        "name": "netFundingPerUnit",
-        "outputs": [
-            {
-                "internalType": "int256",
-                "name": "",
-                "type": "int256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            }
-        ],
-        "name": "nominateNewOwner",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "nominatedOwner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
         "name": "notionalValue",
         "outputs": [
             {
@@ -1080,6 +882,11 @@
                 "internalType": "int256",
                 "name": "sizeDelta",
                 "type": "int256"
+            },
+            {
+                "internalType": "enum IPerpsV2MarketBaseTypes.OrderType",
+                "name": "orderType",
+                "type": "uint8"
             }
         ],
         "name": "orderFee",
@@ -1093,21 +900,6 @@
                 "internalType": "bool",
                 "name": "invalid",
                 "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
             }
         ],
         "payable": false,
@@ -1153,7 +945,7 @@
                         "type": "int128"
                     }
                 ],
-                "internalType": "struct IPerpsV2MarketBaseTypes.Position",
+                "internalType": "struct IPerpsV2MarketConsolidated.Position",
                 "name": "",
                 "type": "tuple"
             }
@@ -1174,6 +966,11 @@
                 "internalType": "uint256",
                 "name": "tradePrice",
                 "type": "uint256"
+            },
+            {
+                "internalType": "enum IPerpsV2MarketBaseTypes.OrderType",
+                "name": "orderType",
+                "type": "uint8"
             },
             {
                 "internalType": "address",
@@ -1209,7 +1006,7 @@
                 "type": "uint256"
             },
             {
-                "internalType": "enum IPerpsV2MarketBaseTypes.Status",
+                "internalType": "enum IPerpsV2MarketConsolidated.Status",
                 "name": "status",
                 "type": "uint8"
             }
@@ -1242,45 +1039,6 @@
         ],
         "payable": false,
         "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "proportionalSkew",
-        "outputs": [
-            {
-                "internalType": "int256",
-                "name": "",
-                "type": "int256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "proxy",
-        "outputs": [
-            {
-                "internalType": "contract Proxy",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "rebuildCache",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
         "type": "function"
     },
     {
@@ -1322,66 +1080,6 @@
         ],
         "payable": false,
         "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "resolver",
-        "outputs": [
-            {
-                "internalType": "contract AddressResolver",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "resolverAddressesRequired",
-        "outputs": [
-            {
-                "internalType": "bytes32[]",
-                "name": "addresses",
-                "type": "bytes32[]"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "setMessageSender",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address payable",
-                "name": "_proxy",
-                "type": "address"
-            }
-        ],
-        "name": "setProxy",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
         "type": "function"
     },
     {

--- a/sdk/contracts/abis/PerpsV2MarketData.json
+++ b/sdk/contracts/abis/PerpsV2MarketData.json
@@ -64,6 +64,11 @@
                         "type": "int256"
                     },
                     {
+                        "internalType": "int256",
+                        "name": "currentFundingVelocity",
+                        "type": "int256"
+                    },
+                    {
                         "components": [
                             {
                                 "internalType": "uint256",
@@ -93,6 +98,120 @@
                             {
                                 "internalType": "uint256",
                                 "name": "makerFeeOffchainDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "overrideCommitFee",
+                                "type": "uint256"
+                            }
+                        ],
+                        "internalType": "struct PerpsV2MarketData.FeeRates",
+                        "name": "feeRates",
+                        "type": "tuple"
+                    }
+                ],
+                "internalType": "struct PerpsV2MarketData.MarketSummary[]",
+                "name": "",
+                "type": "tuple[]"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "allProxiedMarketSummaries",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "market",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "asset",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "key",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "maxLeverage",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "price",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "marketSize",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "int256",
+                        "name": "marketSkew",
+                        "type": "int256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "marketDebt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "int256",
+                        "name": "currentFundingRate",
+                        "type": "int256"
+                    },
+                    {
+                        "internalType": "int256",
+                        "name": "currentFundingVelocity",
+                        "type": "int256"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "uint256",
+                                "name": "takerFee",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "makerFee",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "takerFeeDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "makerFeeDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "takerFeeOffchainDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "makerFeeOffchainDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "overrideCommitFee",
                                 "type": "uint256"
                             }
                         ],
@@ -205,6 +324,11 @@
                             {
                                 "internalType": "uint256",
                                 "name": "makerFeeOffchainDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "overrideCommitFee",
                                 "type": "uint256"
                             }
                         ],
@@ -371,6 +495,11 @@
                                 "internalType": "uint256",
                                 "name": "makerFeeOffchainDelayedOrder",
                                 "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "overrideCommitFee",
+                                "type": "uint256"
                             }
                         ],
                         "internalType": "struct PerpsV2MarketData.FeeRates",
@@ -536,6 +665,11 @@
                         "type": "int256"
                     },
                     {
+                        "internalType": "int256",
+                        "name": "currentFundingVelocity",
+                        "type": "int256"
+                    },
+                    {
                         "components": [
                             {
                                 "internalType": "uint256",
@@ -565,6 +699,11 @@
                             {
                                 "internalType": "uint256",
                                 "name": "makerFeeOffchainDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "overrideCommitFee",
                                 "type": "uint256"
                             }
                         ],
@@ -641,6 +780,11 @@
                         "type": "int256"
                     },
                     {
+                        "internalType": "int256",
+                        "name": "currentFundingVelocity",
+                        "type": "int256"
+                    },
+                    {
                         "components": [
                             {
                                 "internalType": "uint256",
@@ -670,6 +814,11 @@
                             {
                                 "internalType": "uint256",
                                 "name": "makerFeeOffchainDelayedOrder",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "overrideCommitFee",
                                 "type": "uint256"
                             }
                         ],
@@ -708,6 +857,11 @@
                     {
                         "internalType": "uint256",
                         "name": "makerFee",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "overrideCommitFee",
                         "type": "uint256"
                     },
                     {

--- a/sdk/contracts/abis/PerpsV2MarketSettings.json
+++ b/sdk/contracts/abis/PerpsV2MarketSettings.json
@@ -166,7 +166,7 @@
                 "type": "bytes32"
             }
         ],
-        "name": "ParameterUpdated",
+        "name": "ParameterUpdatedBytes32",
         "type": "event"
     },
     {
@@ -579,6 +579,27 @@
     },
     {
         "constant": true,
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_marketKey",
+                "type": "bytes32"
+            }
+        ],
+        "name": "overrideCommitFee",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
         "inputs": [],
         "name": "owner",
         "outputs": [
@@ -613,6 +634,11 @@
                     {
                         "internalType": "uint256",
                         "name": "makerFee",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "overrideCommitFee",
                         "type": "uint256"
                     },
                     {
@@ -1093,6 +1119,26 @@
                 "type": "bytes32"
             },
             {
+                "internalType": "uint256",
+                "name": "_overrideCommitFee",
+                "type": "uint256"
+            }
+        ],
+        "name": "setOverrideCommitFee",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_marketKey",
+                "type": "bytes32"
+            },
+            {
                 "components": [
                     {
                         "internalType": "uint256",
@@ -1102,6 +1148,11 @@
                     {
                         "internalType": "uint256",
                         "name": "makerFee",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "overrideCommitFee",
                         "type": "uint256"
                     },
                     {

--- a/sdk/contracts/constants.ts
+++ b/sdk/contracts/constants.ts
@@ -44,10 +44,10 @@ export const ADDRESSES: Record<string, Record<number, string>> = {
 		420: '0x0dde87714C3bdACB93bB1d38605aFff209a85998',
 	},
 	PerpsV2MarketData: {
-		420: '0x72EBE50eAE6C73124F07E85138b751eb4981811F',
+		420: '0x0D9eFa310a4771c444233B10bfB57e5b991ad529',
 	},
 	PerpsV2MarketSettings: {
-		420: '0xCC3bc93Be00FaAfD25eca9be262b9b9843e15dcA',
+		420: '0x14fA3376E2ffa41708A0636009A35CAE8D8E2bc7',
 	},
 	SUSD: {
 		1: '0x57Ab1ec28D129707052df4dF418D58a2D46d5f51',

--- a/sdk/contracts/types/PerpsV2Market.ts
+++ b/sdk/contracts/types/PerpsV2Market.ts
@@ -28,7 +28,7 @@ import type {
   PromiseOrValue,
 } from "./common";
 
-export declare namespace IPerpsV2MarketBaseTypes {
+export declare namespace IPerpsV2MarketConsolidated {
   export type DelayedOrderStruct = {
     isOffchain: PromiseOrValue<boolean>;
     sizeDelta: PromiseOrValue<BigNumberish>;
@@ -88,7 +88,6 @@ export declare namespace IPerpsV2MarketBaseTypes {
 
 export interface PerpsV2MarketInterface extends utils.Interface {
   functions: {
-    "acceptOwnership()": FunctionFragment;
     "accessibleMargin(address)": FunctionFragment;
     "accruedFunding(address)": FunctionFragment;
     "assetPrice()": FunctionFragment;
@@ -100,48 +99,29 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     "closePositionWithTracking(uint256,bytes32)": FunctionFragment;
     "currentFundingRate()": FunctionFragment;
     "currentFundingVelocity()": FunctionFragment;
-    "currentLeverage(address)": FunctionFragment;
     "delayedOrders(address)": FunctionFragment;
-    "entryDebtCorrection()": FunctionFragment;
     "executeDelayedOrder(address)": FunctionFragment;
     "executeOffchainDelayedOrder(address,bytes[])": FunctionFragment;
-    "fillPriceWithBasePrice(int256,uint256)": FunctionFragment;
     "fundingLastRecomputed()": FunctionFragment;
     "fundingSequence(uint256)": FunctionFragment;
     "fundingSequenceLength()": FunctionFragment;
-    "isResolverCached()": FunctionFragment;
     "liquidatePosition(address)": FunctionFragment;
     "liquidationFee(address)": FunctionFragment;
-    "liquidationMargin(address)": FunctionFragment;
     "liquidationPrice(address)": FunctionFragment;
     "marketDebt()": FunctionFragment;
     "marketKey()": FunctionFragment;
     "marketSize()": FunctionFragment;
     "marketSizes()": FunctionFragment;
     "marketSkew()": FunctionFragment;
-    "marketState()": FunctionFragment;
-    "maxOrderSizes()": FunctionFragment;
-    "messageSender()": FunctionFragment;
     "modifyPosition(int256,uint256)": FunctionFragment;
     "modifyPositionWithTracking(int256,uint256,bytes32)": FunctionFragment;
-    "netFundingPerUnit(address)": FunctionFragment;
-    "nominateNewOwner(address)": FunctionFragment;
-    "nominatedOwner()": FunctionFragment;
     "notionalValue(address)": FunctionFragment;
-    "orderFee(int256)": FunctionFragment;
-    "owner()": FunctionFragment;
+    "orderFee(int256,uint8)": FunctionFragment;
     "positions(address)": FunctionFragment;
-    "postTradeDetails(int256,uint256,address)": FunctionFragment;
+    "postTradeDetails(int256,uint256,uint8,address)": FunctionFragment;
     "profitLoss(address)": FunctionFragment;
-    "proportionalSkew()": FunctionFragment;
-    "proxy()": FunctionFragment;
-    "rebuildCache()": FunctionFragment;
     "recomputeFunding()": FunctionFragment;
     "remainingMargin(address)": FunctionFragment;
-    "resolver()": FunctionFragment;
-    "resolverAddressesRequired()": FunctionFragment;
-    "setMessageSender(address)": FunctionFragment;
-    "setProxy(address)": FunctionFragment;
     "submitDelayedOrder(int256,uint256,uint256)": FunctionFragment;
     "submitDelayedOrderWithTracking(int256,uint256,uint256,bytes32)": FunctionFragment;
     "submitOffchainDelayedOrder(int256,uint256)": FunctionFragment;
@@ -153,7 +133,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
 
   getFunction(
     nameOrSignatureOrTopic:
-      | "acceptOwnership"
       | "accessibleMargin"
       | "accruedFunding"
       | "assetPrice"
@@ -165,48 +144,29 @@ export interface PerpsV2MarketInterface extends utils.Interface {
       | "closePositionWithTracking"
       | "currentFundingRate"
       | "currentFundingVelocity"
-      | "currentLeverage"
       | "delayedOrders"
-      | "entryDebtCorrection"
       | "executeDelayedOrder"
       | "executeOffchainDelayedOrder"
-      | "fillPriceWithBasePrice"
       | "fundingLastRecomputed"
       | "fundingSequence"
       | "fundingSequenceLength"
-      | "isResolverCached"
       | "liquidatePosition"
       | "liquidationFee"
-      | "liquidationMargin"
       | "liquidationPrice"
       | "marketDebt"
       | "marketKey"
       | "marketSize"
       | "marketSizes"
       | "marketSkew"
-      | "marketState"
-      | "maxOrderSizes"
-      | "messageSender"
       | "modifyPosition"
       | "modifyPositionWithTracking"
-      | "netFundingPerUnit"
-      | "nominateNewOwner"
-      | "nominatedOwner"
       | "notionalValue"
       | "orderFee"
-      | "owner"
       | "positions"
       | "postTradeDetails"
       | "profitLoss"
-      | "proportionalSkew"
-      | "proxy"
-      | "rebuildCache"
       | "recomputeFunding"
       | "remainingMargin"
-      | "resolver"
-      | "resolverAddressesRequired"
-      | "setMessageSender"
-      | "setProxy"
       | "submitDelayedOrder"
       | "submitDelayedOrderWithTracking"
       | "submitOffchainDelayedOrder"
@@ -216,10 +176,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
       | "withdrawAllMargin"
   ): FunctionFragment;
 
-  encodeFunctionData(
-    functionFragment: "acceptOwnership",
-    values?: undefined
-  ): string;
   encodeFunctionData(
     functionFragment: "accessibleMargin",
     values: [PromiseOrValue<string>]
@@ -262,16 +218,8 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     values?: undefined
   ): string;
   encodeFunctionData(
-    functionFragment: "currentLeverage",
-    values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(
     functionFragment: "delayedOrders",
     values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "entryDebtCorrection",
-    values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "executeDelayedOrder",
@@ -280,10 +228,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "executeOffchainDelayedOrder",
     values: [PromiseOrValue<string>, PromiseOrValue<BytesLike>[]]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "fillPriceWithBasePrice",
-    values: [PromiseOrValue<BigNumberish>, PromiseOrValue<BigNumberish>]
   ): string;
   encodeFunctionData(
     functionFragment: "fundingLastRecomputed",
@@ -298,19 +242,11 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     values?: undefined
   ): string;
   encodeFunctionData(
-    functionFragment: "isResolverCached",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
     functionFragment: "liquidatePosition",
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
     functionFragment: "liquidationFee",
-    values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "liquidationMargin",
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
@@ -335,18 +271,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     values?: undefined
   ): string;
   encodeFunctionData(
-    functionFragment: "marketState",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "maxOrderSizes",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "messageSender",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
     functionFragment: "modifyPosition",
     values: [PromiseOrValue<BigNumberish>, PromiseOrValue<BigNumberish>]
   ): string;
@@ -359,26 +283,13 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     ]
   ): string;
   encodeFunctionData(
-    functionFragment: "netFundingPerUnit",
-    values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "nominateNewOwner",
-    values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "nominatedOwner",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
     functionFragment: "notionalValue",
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
     functionFragment: "orderFee",
-    values: [PromiseOrValue<BigNumberish>]
+    values: [PromiseOrValue<BigNumberish>, PromiseOrValue<BigNumberish>]
   ): string;
-  encodeFunctionData(functionFragment: "owner", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "positions",
     values: [PromiseOrValue<string>]
@@ -386,6 +297,7 @@ export interface PerpsV2MarketInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "postTradeDetails",
     values: [
+      PromiseOrValue<BigNumberish>,
       PromiseOrValue<BigNumberish>,
       PromiseOrValue<BigNumberish>,
       PromiseOrValue<string>
@@ -396,33 +308,11 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
-    functionFragment: "proportionalSkew",
-    values?: undefined
-  ): string;
-  encodeFunctionData(functionFragment: "proxy", values?: undefined): string;
-  encodeFunctionData(
-    functionFragment: "rebuildCache",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
     functionFragment: "recomputeFunding",
     values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "remainingMargin",
-    values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(functionFragment: "resolver", values?: undefined): string;
-  encodeFunctionData(
-    functionFragment: "resolverAddressesRequired",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "setMessageSender",
-    values: [PromiseOrValue<string>]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "setProxy",
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
@@ -468,10 +358,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
   ): string;
 
   decodeFunctionResult(
-    functionFragment: "acceptOwnership",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "accessibleMargin",
     data: BytesLike
   ): Result;
@@ -510,15 +396,7 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "currentLeverage",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "delayedOrders",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "entryDebtCorrection",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -527,10 +405,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "executeOffchainDelayedOrder",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "fillPriceWithBasePrice",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -546,19 +420,11 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "isResolverCached",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "liquidatePosition",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "liquidationFee",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "liquidationMargin",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -574,18 +440,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(functionFragment: "marketSkew", data: BytesLike): Result;
   decodeFunctionResult(
-    functionFragment: "marketState",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "maxOrderSizes",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "messageSender",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "modifyPosition",
     data: BytesLike
   ): Result;
@@ -594,38 +448,16 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "netFundingPerUnit",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "nominateNewOwner",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "nominatedOwner",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "notionalValue",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "orderFee", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "positions", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "postTradeDetails",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "profitLoss", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "proportionalSkew",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(functionFragment: "proxy", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "rebuildCache",
-    data: BytesLike
-  ): Result;
   decodeFunctionResult(
     functionFragment: "recomputeFunding",
     data: BytesLike
@@ -634,16 +466,6 @@ export interface PerpsV2MarketInterface extends utils.Interface {
     functionFragment: "remainingMargin",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "resolver", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "resolverAddressesRequired",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "setMessageSender",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(functionFragment: "setProxy", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "submitDelayedOrder",
     data: BytesLike
@@ -674,38 +496,79 @@ export interface PerpsV2MarketInterface extends utils.Interface {
   ): Result;
 
   events: {
-    "CacheUpdated(bytes32,address)": EventFragment;
+    "DelayedOrderRemoved(address,bool,uint256,int256,uint256,uint256,uint256,bytes32)": EventFragment;
+    "DelayedOrderSubmitted(address,bool,int256,uint256,uint256,uint256,uint256,uint256,bytes32)": EventFragment;
     "FundingRecomputed(int256,int256,uint256,uint256)": EventFragment;
-    "FuturesTracking(bytes32,bytes32,bytes32,int256,uint256)": EventFragment;
     "MarginTransferred(address,int256)": EventFragment;
-    "OwnerChanged(address,address)": EventFragment;
-    "OwnerNominated(address)": EventFragment;
+    "PerpsTracking(bytes32,bytes32,bytes32,int256,uint256)": EventFragment;
     "PositionLiquidated(uint256,address,address,int256,uint256,uint256)": EventFragment;
     "PositionModified(uint256,address,uint256,int256,int256,uint256,uint256,uint256)": EventFragment;
-    "ProxyUpdated(address)": EventFragment;
   };
 
-  getEvent(nameOrSignatureOrTopic: "CacheUpdated"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "DelayedOrderRemoved"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "DelayedOrderSubmitted"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "FundingRecomputed"): EventFragment;
-  getEvent(nameOrSignatureOrTopic: "FuturesTracking"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MarginTransferred"): EventFragment;
-  getEvent(nameOrSignatureOrTopic: "OwnerChanged"): EventFragment;
-  getEvent(nameOrSignatureOrTopic: "OwnerNominated"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "PerpsTracking"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "PositionLiquidated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "PositionModified"): EventFragment;
-  getEvent(nameOrSignatureOrTopic: "ProxyUpdated"): EventFragment;
 }
 
-export interface CacheUpdatedEventObject {
-  name: string;
-  destination: string;
+export interface DelayedOrderRemovedEventObject {
+  account: string;
+  isOffchain: boolean;
+  currentRoundId: BigNumber;
+  sizeDelta: BigNumber;
+  targetRoundId: BigNumber;
+  commitDeposit: BigNumber;
+  keeperDeposit: BigNumber;
+  trackingCode: string;
 }
-export type CacheUpdatedEvent = TypedEvent<
-  [string, string],
-  CacheUpdatedEventObject
+export type DelayedOrderRemovedEvent = TypedEvent<
+  [
+    string,
+    boolean,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    string
+  ],
+  DelayedOrderRemovedEventObject
 >;
 
-export type CacheUpdatedEventFilter = TypedEventFilter<CacheUpdatedEvent>;
+export type DelayedOrderRemovedEventFilter =
+  TypedEventFilter<DelayedOrderRemovedEvent>;
+
+export interface DelayedOrderSubmittedEventObject {
+  account: string;
+  isOffchain: boolean;
+  sizeDelta: BigNumber;
+  targetRoundId: BigNumber;
+  intentionTime: BigNumber;
+  executableAtTime: BigNumber;
+  commitDeposit: BigNumber;
+  keeperDeposit: BigNumber;
+  trackingCode: string;
+}
+export type DelayedOrderSubmittedEvent = TypedEvent<
+  [
+    string,
+    boolean,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    BigNumber,
+    string
+  ],
+  DelayedOrderSubmittedEventObject
+>;
+
+export type DelayedOrderSubmittedEventFilter =
+  TypedEventFilter<DelayedOrderSubmittedEvent>;
 
 export interface FundingRecomputedEventObject {
   funding: BigNumber;
@@ -721,20 +584,6 @@ export type FundingRecomputedEvent = TypedEvent<
 export type FundingRecomputedEventFilter =
   TypedEventFilter<FundingRecomputedEvent>;
 
-export interface FuturesTrackingEventObject {
-  trackingCode: string;
-  baseAsset: string;
-  marketKey: string;
-  sizeDelta: BigNumber;
-  fee: BigNumber;
-}
-export type FuturesTrackingEvent = TypedEvent<
-  [string, string, string, BigNumber, BigNumber],
-  FuturesTrackingEventObject
->;
-
-export type FuturesTrackingEventFilter = TypedEventFilter<FuturesTrackingEvent>;
-
 export interface MarginTransferredEventObject {
   account: string;
   marginDelta: BigNumber;
@@ -747,26 +596,19 @@ export type MarginTransferredEvent = TypedEvent<
 export type MarginTransferredEventFilter =
   TypedEventFilter<MarginTransferredEvent>;
 
-export interface OwnerChangedEventObject {
-  oldOwner: string;
-  newOwner: string;
+export interface PerpsTrackingEventObject {
+  trackingCode: string;
+  baseAsset: string;
+  marketKey: string;
+  sizeDelta: BigNumber;
+  fee: BigNumber;
 }
-export type OwnerChangedEvent = TypedEvent<
-  [string, string],
-  OwnerChangedEventObject
+export type PerpsTrackingEvent = TypedEvent<
+  [string, string, string, BigNumber, BigNumber],
+  PerpsTrackingEventObject
 >;
 
-export type OwnerChangedEventFilter = TypedEventFilter<OwnerChangedEvent>;
-
-export interface OwnerNominatedEventObject {
-  newOwner: string;
-}
-export type OwnerNominatedEvent = TypedEvent<
-  [string],
-  OwnerNominatedEventObject
->;
-
-export type OwnerNominatedEventFilter = TypedEventFilter<OwnerNominatedEvent>;
+export type PerpsTrackingEventFilter = TypedEventFilter<PerpsTrackingEvent>;
 
 export interface PositionLiquidatedEventObject {
   id: BigNumber;
@@ -811,13 +653,6 @@ export type PositionModifiedEvent = TypedEvent<
 export type PositionModifiedEventFilter =
   TypedEventFilter<PositionModifiedEvent>;
 
-export interface ProxyUpdatedEventObject {
-  proxyAddress: string;
-}
-export type ProxyUpdatedEvent = TypedEvent<[string], ProxyUpdatedEventObject>;
-
-export type ProxyUpdatedEventFilter = TypedEventFilter<ProxyUpdatedEvent>;
-
 export interface PerpsV2Market extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
   attach(addressOrName: string): this;
@@ -845,10 +680,6 @@ export interface PerpsV2Market extends BaseContract {
   removeListener: OnEvent<this>;
 
   functions: {
-    acceptOwnership(
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
     accessibleMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -899,21 +730,12 @@ export interface PerpsV2Market extends BaseContract {
 
     currentFundingVelocity(
       overrides?: CallOverrides
-    ): Promise<[BigNumber] & { fundingRateVelocity: BigNumber }>;
-
-    currentLeverage(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<
-      [BigNumber, boolean] & { leverage: BigNumber; invalid: boolean }
-    >;
+    ): Promise<[BigNumber] & { fundingVelocity: BigNumber }>;
 
     delayedOrders(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
-    ): Promise<[IPerpsV2MarketBaseTypes.DelayedOrderStructOutput]>;
-
-    entryDebtCorrection(overrides?: CallOverrides): Promise<[BigNumber]>;
+    ): Promise<[IPerpsV2MarketConsolidated.DelayedOrderStructOutput]>;
 
     executeDelayedOrder(
       account: PromiseOrValue<string>,
@@ -925,12 +747,6 @@ export interface PerpsV2Market extends BaseContract {
       priceUpdateData: PromiseOrValue<BytesLike>[],
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
-
-    fillPriceWithBasePrice(
-      size: PromiseOrValue<BigNumberish>,
-      basePrice: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
-    ): Promise<[BigNumber, boolean]>;
 
     fundingLastRecomputed(
       overrides?: CallOverrides
@@ -945,8 +761,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[BigNumber] & { length: BigNumber }>;
 
-    isResolverCached(overrides?: CallOverrides): Promise<[boolean]>;
-
     liquidatePosition(
       account: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -956,11 +770,6 @@ export interface PerpsV2Market extends BaseContract {
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<[BigNumber]>;
-
-    liquidationMargin(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<[BigNumber] & { lMargin: BigNumber }>;
 
     liquidationPrice(
       account: PromiseOrValue<string>,
@@ -985,20 +794,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[BigNumber] & { skew: BigNumber }>;
 
-    marketState(overrides?: CallOverrides): Promise<[string]>;
-
-    maxOrderSizes(
-      overrides?: CallOverrides
-    ): Promise<
-      [BigNumber, BigNumber, boolean] & {
-        long: BigNumber;
-        short: BigNumber;
-        invalid: boolean;
-      }
-    >;
-
-    messageSender(overrides?: CallOverrides): Promise<[string]>;
-
     modifyPosition(
       sizeDelta: PromiseOrValue<BigNumberish>,
       priceImpactDelta: PromiseOrValue<BigNumberish>,
@@ -1012,18 +807,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
-    netFundingPerUnit(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<[BigNumber]>;
-
-    nominateNewOwner(
-      _owner: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
-    nominatedOwner(overrides?: CallOverrides): Promise<[string]>;
-
     notionalValue(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1031,19 +814,19 @@ export interface PerpsV2Market extends BaseContract {
 
     orderFee(
       sizeDelta: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<[BigNumber, boolean] & { fee: BigNumber; invalid: boolean }>;
-
-    owner(overrides?: CallOverrides): Promise<[string]>;
 
     positions(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
-    ): Promise<[IPerpsV2MarketBaseTypes.PositionStructOutput]>;
+    ): Promise<[IPerpsV2MarketConsolidated.PositionStructOutput]>;
 
     postTradeDetails(
       sizeDelta: PromiseOrValue<BigNumberish>,
       tradePrice: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       sender: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<
@@ -1062,14 +845,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[BigNumber, boolean] & { pnl: BigNumber; invalid: boolean }>;
 
-    proportionalSkew(overrides?: CallOverrides): Promise<[BigNumber]>;
-
-    proxy(overrides?: CallOverrides): Promise<[string]>;
-
-    rebuildCache(
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
     recomputeFunding(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -1080,22 +855,6 @@ export interface PerpsV2Market extends BaseContract {
     ): Promise<
       [BigNumber, boolean] & { marginRemaining: BigNumber; invalid: boolean }
     >;
-
-    resolver(overrides?: CallOverrides): Promise<[string]>;
-
-    resolverAddressesRequired(
-      overrides?: CallOverrides
-    ): Promise<[string[]] & { addresses: string[] }>;
-
-    setMessageSender(
-      sender: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
-    setProxy(
-      _proxy: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
 
     submitDelayedOrder(
       sizeDelta: PromiseOrValue<BigNumberish>,
@@ -1138,10 +897,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
   };
-
-  acceptOwnership(
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
 
   accessibleMargin(
     account: PromiseOrValue<string>,
@@ -1191,17 +946,10 @@ export interface PerpsV2Market extends BaseContract {
 
   currentFundingVelocity(overrides?: CallOverrides): Promise<BigNumber>;
 
-  currentLeverage(
-    account: PromiseOrValue<string>,
-    overrides?: CallOverrides
-  ): Promise<[BigNumber, boolean] & { leverage: BigNumber; invalid: boolean }>;
-
   delayedOrders(
     account: PromiseOrValue<string>,
     overrides?: CallOverrides
-  ): Promise<IPerpsV2MarketBaseTypes.DelayedOrderStructOutput>;
-
-  entryDebtCorrection(overrides?: CallOverrides): Promise<BigNumber>;
+  ): Promise<IPerpsV2MarketConsolidated.DelayedOrderStructOutput>;
 
   executeDelayedOrder(
     account: PromiseOrValue<string>,
@@ -1214,12 +962,6 @@ export interface PerpsV2Market extends BaseContract {
     overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  fillPriceWithBasePrice(
-    size: PromiseOrValue<BigNumberish>,
-    basePrice: PromiseOrValue<BigNumberish>,
-    overrides?: CallOverrides
-  ): Promise<[BigNumber, boolean]>;
-
   fundingLastRecomputed(overrides?: CallOverrides): Promise<number>;
 
   fundingSequence(
@@ -1229,19 +971,12 @@ export interface PerpsV2Market extends BaseContract {
 
   fundingSequenceLength(overrides?: CallOverrides): Promise<BigNumber>;
 
-  isResolverCached(overrides?: CallOverrides): Promise<boolean>;
-
   liquidatePosition(
     account: PromiseOrValue<string>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   liquidationFee(
-    account: PromiseOrValue<string>,
-    overrides?: CallOverrides
-  ): Promise<BigNumber>;
-
-  liquidationMargin(
     account: PromiseOrValue<string>,
     overrides?: CallOverrides
   ): Promise<BigNumber>;
@@ -1265,20 +1000,6 @@ export interface PerpsV2Market extends BaseContract {
 
   marketSkew(overrides?: CallOverrides): Promise<BigNumber>;
 
-  marketState(overrides?: CallOverrides): Promise<string>;
-
-  maxOrderSizes(
-    overrides?: CallOverrides
-  ): Promise<
-    [BigNumber, BigNumber, boolean] & {
-      long: BigNumber;
-      short: BigNumber;
-      invalid: boolean;
-    }
-  >;
-
-  messageSender(overrides?: CallOverrides): Promise<string>;
-
   modifyPosition(
     sizeDelta: PromiseOrValue<BigNumberish>,
     priceImpactDelta: PromiseOrValue<BigNumberish>,
@@ -1292,18 +1013,6 @@ export interface PerpsV2Market extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  netFundingPerUnit(
-    account: PromiseOrValue<string>,
-    overrides?: CallOverrides
-  ): Promise<BigNumber>;
-
-  nominateNewOwner(
-    _owner: PromiseOrValue<string>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
-  nominatedOwner(overrides?: CallOverrides): Promise<string>;
-
   notionalValue(
     account: PromiseOrValue<string>,
     overrides?: CallOverrides
@@ -1311,19 +1020,19 @@ export interface PerpsV2Market extends BaseContract {
 
   orderFee(
     sizeDelta: PromiseOrValue<BigNumberish>,
+    orderType: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
   ): Promise<[BigNumber, boolean] & { fee: BigNumber; invalid: boolean }>;
-
-  owner(overrides?: CallOverrides): Promise<string>;
 
   positions(
     account: PromiseOrValue<string>,
     overrides?: CallOverrides
-  ): Promise<IPerpsV2MarketBaseTypes.PositionStructOutput>;
+  ): Promise<IPerpsV2MarketConsolidated.PositionStructOutput>;
 
   postTradeDetails(
     sizeDelta: PromiseOrValue<BigNumberish>,
     tradePrice: PromiseOrValue<BigNumberish>,
+    orderType: PromiseOrValue<BigNumberish>,
     sender: PromiseOrValue<string>,
     overrides?: CallOverrides
   ): Promise<
@@ -1342,14 +1051,6 @@ export interface PerpsV2Market extends BaseContract {
     overrides?: CallOverrides
   ): Promise<[BigNumber, boolean] & { pnl: BigNumber; invalid: boolean }>;
 
-  proportionalSkew(overrides?: CallOverrides): Promise<BigNumber>;
-
-  proxy(overrides?: CallOverrides): Promise<string>;
-
-  rebuildCache(
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
   recomputeFunding(
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -1360,20 +1061,6 @@ export interface PerpsV2Market extends BaseContract {
   ): Promise<
     [BigNumber, boolean] & { marginRemaining: BigNumber; invalid: boolean }
   >;
-
-  resolver(overrides?: CallOverrides): Promise<string>;
-
-  resolverAddressesRequired(overrides?: CallOverrides): Promise<string[]>;
-
-  setMessageSender(
-    sender: PromiseOrValue<string>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
-  setProxy(
-    _proxy: PromiseOrValue<string>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
 
   submitDelayedOrder(
     sizeDelta: PromiseOrValue<BigNumberish>,
@@ -1417,8 +1104,6 @@ export interface PerpsV2Market extends BaseContract {
   ): Promise<ContractTransaction>;
 
   callStatic: {
-    acceptOwnership(overrides?: CallOverrides): Promise<void>;
-
     accessibleMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1467,19 +1152,10 @@ export interface PerpsV2Market extends BaseContract {
 
     currentFundingVelocity(overrides?: CallOverrides): Promise<BigNumber>;
 
-    currentLeverage(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<
-      [BigNumber, boolean] & { leverage: BigNumber; invalid: boolean }
-    >;
-
     delayedOrders(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
-    ): Promise<IPerpsV2MarketBaseTypes.DelayedOrderStructOutput>;
-
-    entryDebtCorrection(overrides?: CallOverrides): Promise<BigNumber>;
+    ): Promise<IPerpsV2MarketConsolidated.DelayedOrderStructOutput>;
 
     executeDelayedOrder(
       account: PromiseOrValue<string>,
@@ -1492,12 +1168,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
-    fillPriceWithBasePrice(
-      size: PromiseOrValue<BigNumberish>,
-      basePrice: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
-    ): Promise<[BigNumber, boolean]>;
-
     fundingLastRecomputed(overrides?: CallOverrides): Promise<number>;
 
     fundingSequence(
@@ -1507,19 +1177,12 @@ export interface PerpsV2Market extends BaseContract {
 
     fundingSequenceLength(overrides?: CallOverrides): Promise<BigNumber>;
 
-    isResolverCached(overrides?: CallOverrides): Promise<boolean>;
-
     liquidatePosition(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     liquidationFee(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
-    liquidationMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -1543,20 +1206,6 @@ export interface PerpsV2Market extends BaseContract {
 
     marketSkew(overrides?: CallOverrides): Promise<BigNumber>;
 
-    marketState(overrides?: CallOverrides): Promise<string>;
-
-    maxOrderSizes(
-      overrides?: CallOverrides
-    ): Promise<
-      [BigNumber, BigNumber, boolean] & {
-        long: BigNumber;
-        short: BigNumber;
-        invalid: boolean;
-      }
-    >;
-
-    messageSender(overrides?: CallOverrides): Promise<string>;
-
     modifyPosition(
       sizeDelta: PromiseOrValue<BigNumberish>,
       priceImpactDelta: PromiseOrValue<BigNumberish>,
@@ -1570,18 +1219,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
-    netFundingPerUnit(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
-    nominateNewOwner(
-      _owner: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<void>;
-
-    nominatedOwner(overrides?: CallOverrides): Promise<string>;
-
     notionalValue(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1589,19 +1226,19 @@ export interface PerpsV2Market extends BaseContract {
 
     orderFee(
       sizeDelta: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<[BigNumber, boolean] & { fee: BigNumber; invalid: boolean }>;
-
-    owner(overrides?: CallOverrides): Promise<string>;
 
     positions(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
-    ): Promise<IPerpsV2MarketBaseTypes.PositionStructOutput>;
+    ): Promise<IPerpsV2MarketConsolidated.PositionStructOutput>;
 
     postTradeDetails(
       sizeDelta: PromiseOrValue<BigNumberish>,
       tradePrice: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       sender: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<
@@ -1620,12 +1257,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[BigNumber, boolean] & { pnl: BigNumber; invalid: boolean }>;
 
-    proportionalSkew(overrides?: CallOverrides): Promise<BigNumber>;
-
-    proxy(overrides?: CallOverrides): Promise<string>;
-
-    rebuildCache(overrides?: CallOverrides): Promise<void>;
-
     recomputeFunding(overrides?: CallOverrides): Promise<BigNumber>;
 
     remainingMargin(
@@ -1634,20 +1265,6 @@ export interface PerpsV2Market extends BaseContract {
     ): Promise<
       [BigNumber, boolean] & { marginRemaining: BigNumber; invalid: boolean }
     >;
-
-    resolver(overrides?: CallOverrides): Promise<string>;
-
-    resolverAddressesRequired(overrides?: CallOverrides): Promise<string[]>;
-
-    setMessageSender(
-      sender: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<void>;
-
-    setProxy(
-      _proxy: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<void>;
 
     submitDelayedOrder(
       sizeDelta: PromiseOrValue<BigNumberish>,
@@ -1690,11 +1307,49 @@ export interface PerpsV2Market extends BaseContract {
   };
 
   filters: {
-    "CacheUpdated(bytes32,address)"(
-      name?: null,
-      destination?: null
-    ): CacheUpdatedEventFilter;
-    CacheUpdated(name?: null, destination?: null): CacheUpdatedEventFilter;
+    "DelayedOrderRemoved(address,bool,uint256,int256,uint256,uint256,uint256,bytes32)"(
+      account?: PromiseOrValue<string> | null,
+      isOffchain?: null,
+      currentRoundId?: null,
+      sizeDelta?: null,
+      targetRoundId?: null,
+      commitDeposit?: null,
+      keeperDeposit?: null,
+      trackingCode?: null
+    ): DelayedOrderRemovedEventFilter;
+    DelayedOrderRemoved(
+      account?: PromiseOrValue<string> | null,
+      isOffchain?: null,
+      currentRoundId?: null,
+      sizeDelta?: null,
+      targetRoundId?: null,
+      commitDeposit?: null,
+      keeperDeposit?: null,
+      trackingCode?: null
+    ): DelayedOrderRemovedEventFilter;
+
+    "DelayedOrderSubmitted(address,bool,int256,uint256,uint256,uint256,uint256,uint256,bytes32)"(
+      account?: PromiseOrValue<string> | null,
+      isOffchain?: null,
+      sizeDelta?: null,
+      targetRoundId?: null,
+      intentionTime?: null,
+      executableAtTime?: null,
+      commitDeposit?: null,
+      keeperDeposit?: null,
+      trackingCode?: null
+    ): DelayedOrderSubmittedEventFilter;
+    DelayedOrderSubmitted(
+      account?: PromiseOrValue<string> | null,
+      isOffchain?: null,
+      sizeDelta?: null,
+      targetRoundId?: null,
+      intentionTime?: null,
+      executableAtTime?: null,
+      commitDeposit?: null,
+      keeperDeposit?: null,
+      trackingCode?: null
+    ): DelayedOrderSubmittedEventFilter;
 
     "FundingRecomputed(int256,int256,uint256,uint256)"(
       funding?: null,
@@ -1709,21 +1364,6 @@ export interface PerpsV2Market extends BaseContract {
       timestamp?: null
     ): FundingRecomputedEventFilter;
 
-    "FuturesTracking(bytes32,bytes32,bytes32,int256,uint256)"(
-      trackingCode?: PromiseOrValue<BytesLike> | null,
-      baseAsset?: null,
-      marketKey?: null,
-      sizeDelta?: null,
-      fee?: null
-    ): FuturesTrackingEventFilter;
-    FuturesTracking(
-      trackingCode?: PromiseOrValue<BytesLike> | null,
-      baseAsset?: null,
-      marketKey?: null,
-      sizeDelta?: null,
-      fee?: null
-    ): FuturesTrackingEventFilter;
-
     "MarginTransferred(address,int256)"(
       account?: PromiseOrValue<string> | null,
       marginDelta?: null
@@ -1733,14 +1373,20 @@ export interface PerpsV2Market extends BaseContract {
       marginDelta?: null
     ): MarginTransferredEventFilter;
 
-    "OwnerChanged(address,address)"(
-      oldOwner?: null,
-      newOwner?: null
-    ): OwnerChangedEventFilter;
-    OwnerChanged(oldOwner?: null, newOwner?: null): OwnerChangedEventFilter;
-
-    "OwnerNominated(address)"(newOwner?: null): OwnerNominatedEventFilter;
-    OwnerNominated(newOwner?: null): OwnerNominatedEventFilter;
+    "PerpsTracking(bytes32,bytes32,bytes32,int256,uint256)"(
+      trackingCode?: PromiseOrValue<BytesLike> | null,
+      baseAsset?: null,
+      marketKey?: null,
+      sizeDelta?: null,
+      fee?: null
+    ): PerpsTrackingEventFilter;
+    PerpsTracking(
+      trackingCode?: PromiseOrValue<BytesLike> | null,
+      baseAsset?: null,
+      marketKey?: null,
+      sizeDelta?: null,
+      fee?: null
+    ): PerpsTrackingEventFilter;
 
     "PositionLiquidated(uint256,address,address,int256,uint256,uint256)"(
       id?: null,
@@ -1779,16 +1425,9 @@ export interface PerpsV2Market extends BaseContract {
       fundingIndex?: null,
       fee?: null
     ): PositionModifiedEventFilter;
-
-    "ProxyUpdated(address)"(proxyAddress?: null): ProxyUpdatedEventFilter;
-    ProxyUpdated(proxyAddress?: null): ProxyUpdatedEventFilter;
   };
 
   estimateGas: {
-    acceptOwnership(
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
     accessibleMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1833,17 +1472,10 @@ export interface PerpsV2Market extends BaseContract {
 
     currentFundingVelocity(overrides?: CallOverrides): Promise<BigNumber>;
 
-    currentLeverage(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
     delayedOrders(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
-
-    entryDebtCorrection(overrides?: CallOverrides): Promise<BigNumber>;
 
     executeDelayedOrder(
       account: PromiseOrValue<string>,
@@ -1856,12 +1488,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    fillPriceWithBasePrice(
-      size: PromiseOrValue<BigNumberish>,
-      basePrice: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
     fundingLastRecomputed(overrides?: CallOverrides): Promise<BigNumber>;
 
     fundingSequence(
@@ -1871,19 +1497,12 @@ export interface PerpsV2Market extends BaseContract {
 
     fundingSequenceLength(overrides?: CallOverrides): Promise<BigNumber>;
 
-    isResolverCached(overrides?: CallOverrides): Promise<BigNumber>;
-
     liquidatePosition(
       account: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     liquidationFee(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
-    liquidationMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -1903,12 +1522,6 @@ export interface PerpsV2Market extends BaseContract {
 
     marketSkew(overrides?: CallOverrides): Promise<BigNumber>;
 
-    marketState(overrides?: CallOverrides): Promise<BigNumber>;
-
-    maxOrderSizes(overrides?: CallOverrides): Promise<BigNumber>;
-
-    messageSender(overrides?: CallOverrides): Promise<BigNumber>;
-
     modifyPosition(
       sizeDelta: PromiseOrValue<BigNumberish>,
       priceImpactDelta: PromiseOrValue<BigNumberish>,
@@ -1922,18 +1535,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    netFundingPerUnit(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
-    nominateNewOwner(
-      _owner: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
-    nominatedOwner(overrides?: CallOverrides): Promise<BigNumber>;
-
     notionalValue(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1941,10 +1542,9 @@ export interface PerpsV2Market extends BaseContract {
 
     orderFee(
       sizeDelta: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
-
-    owner(overrides?: CallOverrides): Promise<BigNumber>;
 
     positions(
       account: PromiseOrValue<string>,
@@ -1954,6 +1554,7 @@ export interface PerpsV2Market extends BaseContract {
     postTradeDetails(
       sizeDelta: PromiseOrValue<BigNumberish>,
       tradePrice: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       sender: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -1963,14 +1564,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    proportionalSkew(overrides?: CallOverrides): Promise<BigNumber>;
-
-    proxy(overrides?: CallOverrides): Promise<BigNumber>;
-
-    rebuildCache(
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
     recomputeFunding(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -1978,20 +1571,6 @@ export interface PerpsV2Market extends BaseContract {
     remainingMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
-    ): Promise<BigNumber>;
-
-    resolver(overrides?: CallOverrides): Promise<BigNumber>;
-
-    resolverAddressesRequired(overrides?: CallOverrides): Promise<BigNumber>;
-
-    setMessageSender(
-      sender: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
-    setProxy(
-      _proxy: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     submitDelayedOrder(
@@ -2035,10 +1614,6 @@ export interface PerpsV2Market extends BaseContract {
   };
 
   populateTransaction: {
-    acceptOwnership(
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
     accessibleMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -2087,17 +1662,8 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
-    currentLeverage(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
-
     delayedOrders(
       account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
-
-    entryDebtCorrection(
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
@@ -2110,12 +1676,6 @@ export interface PerpsV2Market extends BaseContract {
       account: PromiseOrValue<string>,
       priceUpdateData: PromiseOrValue<BytesLike>[],
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
-    fillPriceWithBasePrice(
-      size: PromiseOrValue<BigNumberish>,
-      basePrice: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     fundingLastRecomputed(
@@ -2131,19 +1691,12 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
-    isResolverCached(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
     liquidatePosition(
       account: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     liquidationFee(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
-
-    liquidationMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
@@ -2163,12 +1716,6 @@ export interface PerpsV2Market extends BaseContract {
 
     marketSkew(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
-    marketState(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    maxOrderSizes(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    messageSender(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
     modifyPosition(
       sizeDelta: PromiseOrValue<BigNumberish>,
       priceImpactDelta: PromiseOrValue<BigNumberish>,
@@ -2182,18 +1729,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
-    netFundingPerUnit(
-      account: PromiseOrValue<string>,
-      overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
-
-    nominateNewOwner(
-      _owner: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
-    nominatedOwner(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
     notionalValue(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -2201,10 +1736,9 @@ export interface PerpsV2Market extends BaseContract {
 
     orderFee(
       sizeDelta: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    owner(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     positions(
       account: PromiseOrValue<string>,
@@ -2214,6 +1748,7 @@ export interface PerpsV2Market extends BaseContract {
     postTradeDetails(
       sizeDelta: PromiseOrValue<BigNumberish>,
       tradePrice: PromiseOrValue<BigNumberish>,
+      orderType: PromiseOrValue<BigNumberish>,
       sender: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
@@ -2223,14 +1758,6 @@ export interface PerpsV2Market extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
-    proportionalSkew(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    proxy(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    rebuildCache(
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
     recomputeFunding(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
@@ -2238,22 +1765,6 @@ export interface PerpsV2Market extends BaseContract {
     remainingMargin(
       account: PromiseOrValue<string>,
       overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
-
-    resolver(overrides?: CallOverrides): Promise<PopulatedTransaction>;
-
-    resolverAddressesRequired(
-      overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
-
-    setMessageSender(
-      sender: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
-    setProxy(
-      _proxy: PromiseOrValue<string>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     submitDelayedOrder(

--- a/sdk/contracts/types/PerpsV2MarketData.ts
+++ b/sdk/contracts/types/PerpsV2MarketData.ts
@@ -29,9 +29,11 @@ export declare namespace PerpsV2MarketData {
     makerFeeDelayedOrder: PromiseOrValue<BigNumberish>;
     takerFeeOffchainDelayedOrder: PromiseOrValue<BigNumberish>;
     makerFeeOffchainDelayedOrder: PromiseOrValue<BigNumberish>;
+    overrideCommitFee: PromiseOrValue<BigNumberish>;
   };
 
   export type FeeRatesStructOutput = [
+    BigNumber,
     BigNumber,
     BigNumber,
     BigNumber,
@@ -45,6 +47,7 @@ export declare namespace PerpsV2MarketData {
     makerFeeDelayedOrder: BigNumber;
     takerFeeOffchainDelayedOrder: BigNumber;
     makerFeeOffchainDelayedOrder: BigNumber;
+    overrideCommitFee: BigNumber;
   };
 
   export type MarketSummaryStruct = {
@@ -57,6 +60,7 @@ export declare namespace PerpsV2MarketData {
     marketSkew: PromiseOrValue<BigNumberish>;
     marketDebt: PromiseOrValue<BigNumberish>;
     currentFundingRate: PromiseOrValue<BigNumberish>;
+    currentFundingVelocity: PromiseOrValue<BigNumberish>;
     feeRates: PerpsV2MarketData.FeeRatesStruct;
   };
 
@@ -64,6 +68,7 @@ export declare namespace PerpsV2MarketData {
     string,
     string,
     string,
+    BigNumber,
     BigNumber,
     BigNumber,
     BigNumber,
@@ -81,6 +86,7 @@ export declare namespace PerpsV2MarketData {
     marketSkew: BigNumber;
     marketDebt: BigNumber;
     currentFundingRate: BigNumber;
+    currentFundingVelocity: BigNumber;
     feeRates: PerpsV2MarketData.FeeRatesStructOutput;
   };
 
@@ -229,6 +235,7 @@ export declare namespace IPerpsV2MarketSettings {
   export type ParametersStruct = {
     takerFee: PromiseOrValue<BigNumberish>;
     makerFee: PromiseOrValue<BigNumberish>;
+    overrideCommitFee: PromiseOrValue<BigNumberish>;
     takerFeeDelayedOrder: PromiseOrValue<BigNumberish>;
     makerFeeDelayedOrder: PromiseOrValue<BigNumberish>;
     takerFeeOffchainDelayedOrder: PromiseOrValue<BigNumberish>;
@@ -264,11 +271,13 @@ export declare namespace IPerpsV2MarketSettings {
     BigNumber,
     BigNumber,
     BigNumber,
+    BigNumber,
     string,
     BigNumber
   ] & {
     takerFee: BigNumber;
     makerFee: BigNumber;
+    overrideCommitFee: BigNumber;
     takerFeeDelayedOrder: BigNumber;
     makerFeeDelayedOrder: BigNumber;
     takerFeeOffchainDelayedOrder: BigNumber;
@@ -315,6 +324,7 @@ export declare namespace IPerpsV2MarketBaseTypes {
 export interface PerpsV2MarketDataInterface extends utils.Interface {
   functions: {
     "allMarketSummaries()": FunctionFragment;
+    "allProxiedMarketSummaries()": FunctionFragment;
     "globals()": FunctionFragment;
     "marketDetails(address)": FunctionFragment;
     "marketDetailsForKey(bytes32)": FunctionFragment;
@@ -329,6 +339,7 @@ export interface PerpsV2MarketDataInterface extends utils.Interface {
   getFunction(
     nameOrSignatureOrTopic:
       | "allMarketSummaries"
+      | "allProxiedMarketSummaries"
       | "globals"
       | "marketDetails"
       | "marketDetailsForKey"
@@ -342,6 +353,10 @@ export interface PerpsV2MarketDataInterface extends utils.Interface {
 
   encodeFunctionData(
     functionFragment: "allMarketSummaries",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "allProxiedMarketSummaries",
     values?: undefined
   ): string;
   encodeFunctionData(functionFragment: "globals", values?: undefined): string;
@@ -380,6 +395,10 @@ export interface PerpsV2MarketDataInterface extends utils.Interface {
 
   decodeFunctionResult(
     functionFragment: "allMarketSummaries",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "allProxiedMarketSummaries",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "globals", data: BytesLike): Result;
@@ -447,6 +466,10 @@ export interface PerpsV2MarketData extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[PerpsV2MarketData.MarketSummaryStructOutput[]]>;
 
+    allProxiedMarketSummaries(
+      overrides?: CallOverrides
+    ): Promise<[PerpsV2MarketData.MarketSummaryStructOutput[]]>;
+
     globals(
       overrides?: CallOverrides
     ): Promise<[PerpsV2MarketData.FuturesGlobalsStructOutput]>;
@@ -495,6 +518,10 @@ export interface PerpsV2MarketData extends BaseContract {
     overrides?: CallOverrides
   ): Promise<PerpsV2MarketData.MarketSummaryStructOutput[]>;
 
+  allProxiedMarketSummaries(
+    overrides?: CallOverrides
+  ): Promise<PerpsV2MarketData.MarketSummaryStructOutput[]>;
+
   globals(
     overrides?: CallOverrides
   ): Promise<PerpsV2MarketData.FuturesGlobalsStructOutput>;
@@ -540,6 +567,10 @@ export interface PerpsV2MarketData extends BaseContract {
 
   callStatic: {
     allMarketSummaries(
+      overrides?: CallOverrides
+    ): Promise<PerpsV2MarketData.MarketSummaryStructOutput[]>;
+
+    allProxiedMarketSummaries(
       overrides?: CallOverrides
     ): Promise<PerpsV2MarketData.MarketSummaryStructOutput[]>;
 
@@ -592,6 +623,8 @@ export interface PerpsV2MarketData extends BaseContract {
   estimateGas: {
     allMarketSummaries(overrides?: CallOverrides): Promise<BigNumber>;
 
+    allProxiedMarketSummaries(overrides?: CallOverrides): Promise<BigNumber>;
+
     globals(overrides?: CallOverrides): Promise<BigNumber>;
 
     marketDetails(
@@ -636,6 +669,10 @@ export interface PerpsV2MarketData extends BaseContract {
 
   populateTransaction: {
     allMarketSummaries(
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    allProxiedMarketSummaries(
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 

--- a/sdk/contracts/types/PerpsV2MarketSettings.ts
+++ b/sdk/contracts/types/PerpsV2MarketSettings.ts
@@ -31,6 +31,7 @@ export declare namespace IPerpsV2MarketSettings {
   export type ParametersStruct = {
     takerFee: PromiseOrValue<BigNumberish>;
     makerFee: PromiseOrValue<BigNumberish>;
+    overrideCommitFee: PromiseOrValue<BigNumberish>;
     takerFeeDelayedOrder: PromiseOrValue<BigNumberish>;
     makerFeeDelayedOrder: PromiseOrValue<BigNumberish>;
     takerFeeOffchainDelayedOrder: PromiseOrValue<BigNumberish>;
@@ -66,11 +67,13 @@ export declare namespace IPerpsV2MarketSettings {
     BigNumber,
     BigNumber,
     BigNumber,
+    BigNumber,
     string,
     BigNumber
   ] & {
     takerFee: BigNumber;
     makerFee: BigNumber;
+    overrideCommitFee: BigNumber;
     takerFeeDelayedOrder: BigNumber;
     makerFeeDelayedOrder: BigNumber;
     takerFeeOffchainDelayedOrder: BigNumber;
@@ -114,6 +117,7 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
     "offchainDelayedOrderMinAge(bytes32)": FunctionFragment;
     "offchainMarketKey(bytes32)": FunctionFragment;
     "offchainPriceDivergence(bytes32)": FunctionFragment;
+    "overrideCommitFee(bytes32)": FunctionFragment;
     "owner()": FunctionFragment;
     "parameters(bytes32)": FunctionFragment;
     "rebuildCache()": FunctionFragment;
@@ -137,7 +141,8 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
     "setOffchainDelayedOrderMinAge(bytes32,uint256)": FunctionFragment;
     "setOffchainMarketKey(bytes32,bytes32)": FunctionFragment;
     "setOffchainPriceDivergence(bytes32,uint256)": FunctionFragment;
-    "setParameters(bytes32,(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,bytes32,uint256))": FunctionFragment;
+    "setOverrideCommitFee(bytes32,uint256)": FunctionFragment;
+    "setParameters(bytes32,(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,bytes32,uint256))": FunctionFragment;
     "setSkewScale(bytes32,uint256)": FunctionFragment;
     "setTakerFee(bytes32,uint256)": FunctionFragment;
     "setTakerFeeDelayedOrder(bytes32,uint256)": FunctionFragment;
@@ -172,6 +177,7 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
       | "offchainDelayedOrderMinAge"
       | "offchainMarketKey"
       | "offchainPriceDivergence"
+      | "overrideCommitFee"
       | "owner"
       | "parameters"
       | "rebuildCache"
@@ -195,6 +201,7 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
       | "setOffchainDelayedOrderMinAge"
       | "setOffchainMarketKey"
       | "setOffchainPriceDivergence"
+      | "setOverrideCommitFee"
       | "setParameters"
       | "setSkewScale"
       | "setTakerFee"
@@ -294,6 +301,10 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
     functionFragment: "offchainPriceDivergence",
     values: [PromiseOrValue<BytesLike>]
   ): string;
+  encodeFunctionData(
+    functionFragment: "overrideCommitFee",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
   encodeFunctionData(functionFragment: "owner", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "parameters",
@@ -378,6 +389,10 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "setOffchainPriceDivergence",
+    values: [PromiseOrValue<BytesLike>, PromiseOrValue<BigNumberish>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setOverrideCommitFee",
     values: [PromiseOrValue<BytesLike>, PromiseOrValue<BigNumberish>]
   ): string;
   encodeFunctionData(
@@ -502,6 +517,10 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
     functionFragment: "offchainPriceDivergence",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(
+    functionFragment: "overrideCommitFee",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "parameters", data: BytesLike): Result;
   decodeFunctionResult(
@@ -586,6 +605,10 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "setOverrideCommitFee",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "setParameters",
     data: BytesLike
   ): Result;
@@ -625,7 +648,7 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
     "OwnerChanged(address,address)": EventFragment;
     "OwnerNominated(address)": EventFragment;
     "ParameterUpdated(bytes32,bytes32,uint256)": EventFragment;
-    "ParameterUpdated(bytes32,bytes32,bytes32)": EventFragment;
+    "ParameterUpdatedBytes32(bytes32,bytes32,bytes32)": EventFragment;
   };
 
   getEvent(nameOrSignatureOrTopic: "CacheUpdated"): EventFragment;
@@ -637,12 +660,8 @@ export interface PerpsV2MarketSettingsInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "MinKeeperFeeUpdated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerChanged"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerNominated"): EventFragment;
-  getEvent(
-    nameOrSignatureOrTopic: "ParameterUpdated(bytes32,bytes32,uint256)"
-  ): EventFragment;
-  getEvent(
-    nameOrSignatureOrTopic: "ParameterUpdated(bytes32,bytes32,bytes32)"
-  ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "ParameterUpdated"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "ParameterUpdatedBytes32"): EventFragment;
 }
 
 export interface CacheUpdatedEventObject {
@@ -721,31 +740,31 @@ export type OwnerNominatedEvent = TypedEvent<
 
 export type OwnerNominatedEventFilter = TypedEventFilter<OwnerNominatedEvent>;
 
-export interface ParameterUpdated_bytes32_bytes32_uint256_EventObject {
+export interface ParameterUpdatedEventObject {
   marketKey: string;
   parameter: string;
   value: BigNumber;
 }
-export type ParameterUpdated_bytes32_bytes32_uint256_Event = TypedEvent<
+export type ParameterUpdatedEvent = TypedEvent<
   [string, string, BigNumber],
-  ParameterUpdated_bytes32_bytes32_uint256_EventObject
+  ParameterUpdatedEventObject
 >;
 
-export type ParameterUpdated_bytes32_bytes32_uint256_EventFilter =
-  TypedEventFilter<ParameterUpdated_bytes32_bytes32_uint256_Event>;
+export type ParameterUpdatedEventFilter =
+  TypedEventFilter<ParameterUpdatedEvent>;
 
-export interface ParameterUpdated_bytes32_bytes32_bytes32_EventObject {
+export interface ParameterUpdatedBytes32EventObject {
   marketKey: string;
   parameter: string;
   value: string;
 }
-export type ParameterUpdated_bytes32_bytes32_bytes32_Event = TypedEvent<
+export type ParameterUpdatedBytes32Event = TypedEvent<
   [string, string, string],
-  ParameterUpdated_bytes32_bytes32_bytes32_EventObject
+  ParameterUpdatedBytes32EventObject
 >;
 
-export type ParameterUpdated_bytes32_bytes32_bytes32_EventFilter =
-  TypedEventFilter<ParameterUpdated_bytes32_bytes32_bytes32_Event>;
+export type ParameterUpdatedBytes32EventFilter =
+  TypedEventFilter<ParameterUpdatedBytes32Event>;
 
 export interface PerpsV2MarketSettings extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
@@ -861,6 +880,11 @@ export interface PerpsV2MarketSettings extends BaseContract {
     ): Promise<[string]>;
 
     offchainPriceDivergence(
+      _marketKey: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[BigNumber]>;
+
+    overrideCommitFee(
       _marketKey: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<[BigNumber]>;
@@ -983,6 +1007,12 @@ export interface PerpsV2MarketSettings extends BaseContract {
     setOffchainPriceDivergence(
       _marketKey: PromiseOrValue<BytesLike>,
       _offchainPriceDivergence: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setOverrideCommitFee(
+      _marketKey: PromiseOrValue<BytesLike>,
+      _overrideCommitFee: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -1128,6 +1158,11 @@ export interface PerpsV2MarketSettings extends BaseContract {
     overrides?: CallOverrides
   ): Promise<BigNumber>;
 
+  overrideCommitFee(
+    _marketKey: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<BigNumber>;
+
   owner(overrides?: CallOverrides): Promise<string>;
 
   parameters(
@@ -1244,6 +1279,12 @@ export interface PerpsV2MarketSettings extends BaseContract {
   setOffchainPriceDivergence(
     _marketKey: PromiseOrValue<BytesLike>,
     _offchainPriceDivergence: PromiseOrValue<BigNumberish>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setOverrideCommitFee(
+    _marketKey: PromiseOrValue<BytesLike>,
+    _overrideCommitFee: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -1387,6 +1428,11 @@ export interface PerpsV2MarketSettings extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    overrideCommitFee(
+      _marketKey: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     owner(overrides?: CallOverrides): Promise<string>;
 
     parameters(
@@ -1504,6 +1550,12 @@ export interface PerpsV2MarketSettings extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    setOverrideCommitFee(
+      _marketKey: PromiseOrValue<BytesLike>,
+      _overrideCommitFee: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
     setParameters(
       _marketKey: PromiseOrValue<BytesLike>,
       _parameters: IPerpsV2MarketSettings.ParametersStruct,
@@ -1599,12 +1651,23 @@ export interface PerpsV2MarketSettings extends BaseContract {
       marketKey?: PromiseOrValue<BytesLike> | null,
       parameter?: PromiseOrValue<BytesLike> | null,
       value?: null
-    ): ParameterUpdated_bytes32_bytes32_uint256_EventFilter;
-    "ParameterUpdated(bytes32,bytes32,bytes32)"(
+    ): ParameterUpdatedEventFilter;
+    ParameterUpdated(
       marketKey?: PromiseOrValue<BytesLike> | null,
       parameter?: PromiseOrValue<BytesLike> | null,
       value?: null
-    ): ParameterUpdated_bytes32_bytes32_bytes32_EventFilter;
+    ): ParameterUpdatedEventFilter;
+
+    "ParameterUpdatedBytes32(bytes32,bytes32,bytes32)"(
+      marketKey?: PromiseOrValue<BytesLike> | null,
+      parameter?: PromiseOrValue<BytesLike> | null,
+      value?: null
+    ): ParameterUpdatedBytes32EventFilter;
+    ParameterUpdatedBytes32(
+      marketKey?: PromiseOrValue<BytesLike> | null,
+      parameter?: PromiseOrValue<BytesLike> | null,
+      value?: null
+    ): ParameterUpdatedBytes32EventFilter;
   };
 
   estimateGas: {
@@ -1695,6 +1758,11 @@ export interface PerpsV2MarketSettings extends BaseContract {
     ): Promise<BigNumber>;
 
     offchainPriceDivergence(
+      _marketKey: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    overrideCommitFee(
       _marketKey: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
@@ -1815,6 +1883,12 @@ export interface PerpsV2MarketSettings extends BaseContract {
     setOffchainPriceDivergence(
       _marketKey: PromiseOrValue<BytesLike>,
       _offchainPriceDivergence: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setOverrideCommitFee(
+      _marketKey: PromiseOrValue<BytesLike>,
+      _overrideCommitFee: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -1965,6 +2039,11 @@ export interface PerpsV2MarketSettings extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
+    overrideCommitFee(
+      _marketKey: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
     owner(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     parameters(
@@ -2083,6 +2162,12 @@ export interface PerpsV2MarketSettings extends BaseContract {
     setOffchainPriceDivergence(
       _marketKey: PromiseOrValue<BytesLike>,
       _offchainPriceDivergence: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setOverrideCommitFee(
+      _marketKey: PromiseOrValue<BytesLike>,
+      _overrideCommitFee: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/sdk/contracts/types/factories/PerpsV2MarketData__factory.ts
+++ b/sdk/contracts/types/factories/PerpsV2MarketData__factory.ts
@@ -75,6 +75,11 @@ const _abi = [
             type: "int256",
           },
           {
+            internalType: "int256",
+            name: "currentFundingVelocity",
+            type: "int256",
+          },
+          {
             components: [
               {
                 internalType: "uint256",
@@ -104,6 +109,120 @@ const _abi = [
               {
                 internalType: "uint256",
                 name: "makerFeeOffchainDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "overrideCommitFee",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct PerpsV2MarketData.FeeRates",
+            name: "feeRates",
+            type: "tuple",
+          },
+        ],
+        internalType: "struct PerpsV2MarketData.MarketSummary[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "allProxiedMarketSummaries",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "market",
+            type: "address",
+          },
+          {
+            internalType: "bytes32",
+            name: "asset",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "key",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "maxLeverage",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "price",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "marketSize",
+            type: "uint256",
+          },
+          {
+            internalType: "int256",
+            name: "marketSkew",
+            type: "int256",
+          },
+          {
+            internalType: "uint256",
+            name: "marketDebt",
+            type: "uint256",
+          },
+          {
+            internalType: "int256",
+            name: "currentFundingRate",
+            type: "int256",
+          },
+          {
+            internalType: "int256",
+            name: "currentFundingVelocity",
+            type: "int256",
+          },
+          {
+            components: [
+              {
+                internalType: "uint256",
+                name: "takerFee",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "makerFee",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "takerFeeDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "makerFeeDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "takerFeeOffchainDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "makerFeeOffchainDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "overrideCommitFee",
                 type: "uint256",
               },
             ],
@@ -216,6 +335,11 @@ const _abi = [
               {
                 internalType: "uint256",
                 name: "makerFeeOffchainDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "overrideCommitFee",
                 type: "uint256",
               },
             ],
@@ -383,6 +507,11 @@ const _abi = [
                 name: "makerFeeOffchainDelayedOrder",
                 type: "uint256",
               },
+              {
+                internalType: "uint256",
+                name: "overrideCommitFee",
+                type: "uint256",
+              },
             ],
             internalType: "struct PerpsV2MarketData.FeeRates",
             name: "feeRates",
@@ -547,6 +676,11 @@ const _abi = [
             type: "int256",
           },
           {
+            internalType: "int256",
+            name: "currentFundingVelocity",
+            type: "int256",
+          },
+          {
             components: [
               {
                 internalType: "uint256",
@@ -576,6 +710,11 @@ const _abi = [
               {
                 internalType: "uint256",
                 name: "makerFeeOffchainDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "overrideCommitFee",
                 type: "uint256",
               },
             ],
@@ -652,6 +791,11 @@ const _abi = [
             type: "int256",
           },
           {
+            internalType: "int256",
+            name: "currentFundingVelocity",
+            type: "int256",
+          },
+          {
             components: [
               {
                 internalType: "uint256",
@@ -681,6 +825,11 @@ const _abi = [
               {
                 internalType: "uint256",
                 name: "makerFeeOffchainDelayedOrder",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "overrideCommitFee",
                 type: "uint256",
               },
             ],
@@ -719,6 +868,11 @@ const _abi = [
           {
             internalType: "uint256",
             name: "makerFee",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "overrideCommitFee",
             type: "uint256",
           },
           {

--- a/sdk/contracts/types/factories/PerpsV2MarketSettings__factory.ts
+++ b/sdk/contracts/types/factories/PerpsV2MarketSettings__factory.ts
@@ -177,7 +177,7 @@ const _abi = [
         type: "bytes32",
       },
     ],
-    name: "ParameterUpdated",
+    name: "ParameterUpdatedBytes32",
     type: "event",
   },
   {
@@ -590,6 +590,27 @@ const _abi = [
   },
   {
     constant: true,
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_marketKey",
+        type: "bytes32",
+      },
+    ],
+    name: "overrideCommitFee",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: true,
     inputs: [],
     name: "owner",
     outputs: [
@@ -624,6 +645,11 @@ const _abi = [
           {
             internalType: "uint256",
             name: "makerFee",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "overrideCommitFee",
             type: "uint256",
           },
           {
@@ -1104,6 +1130,26 @@ const _abi = [
         type: "bytes32",
       },
       {
+        internalType: "uint256",
+        name: "_overrideCommitFee",
+        type: "uint256",
+      },
+    ],
+    name: "setOverrideCommitFee",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_marketKey",
+        type: "bytes32",
+      },
+      {
         components: [
           {
             internalType: "uint256",
@@ -1113,6 +1159,11 @@ const _abi = [
           {
             internalType: "uint256",
             name: "makerFee",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "overrideCommitFee",
             type: "uint256",
           },
           {

--- a/sdk/contracts/types/factories/PerpsV2Market__factory.ts
+++ b/sdk/contracts/types/factories/PerpsV2Market__factory.ts
@@ -8,49 +8,119 @@ import type { PerpsV2Market, PerpsV2MarketInterface } from "../PerpsV2Market";
 
 const _abi = [
   {
+    anonymous: false,
     inputs: [
       {
-        internalType: "address payable",
-        name: "_proxy",
+        indexed: true,
+        internalType: "address",
+        name: "account",
         type: "address",
       },
       {
-        internalType: "address",
-        name: "_marketState",
-        type: "address",
+        indexed: false,
+        internalType: "bool",
+        name: "isOffchain",
+        type: "bool",
       },
       {
-        internalType: "address",
-        name: "_owner",
-        type: "address",
+        indexed: false,
+        internalType: "uint256",
+        name: "currentRoundId",
+        type: "uint256",
       },
       {
-        internalType: "address",
-        name: "_resolver",
-        type: "address",
+        indexed: false,
+        internalType: "int256",
+        name: "sizeDelta",
+        type: "int256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "targetRoundId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "commitDeposit",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "keeperDeposit",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "trackingCode",
+        type: "bytes32",
       },
     ],
-    payable: false,
-    stateMutability: "nonpayable",
-    type: "constructor",
+    name: "DelayedOrderRemoved",
+    type: "event",
   },
   {
     anonymous: false,
     inputs: [
       {
-        indexed: false,
-        internalType: "bytes32",
-        name: "name",
-        type: "bytes32",
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
       },
       {
         indexed: false,
-        internalType: "address",
-        name: "destination",
-        type: "address",
+        internalType: "bool",
+        name: "isOffchain",
+        type: "bool",
+      },
+      {
+        indexed: false,
+        internalType: "int256",
+        name: "sizeDelta",
+        type: "int256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "targetRoundId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "intentionTime",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "executableAtTime",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "commitDeposit",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "keeperDeposit",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "trackingCode",
+        type: "bytes32",
       },
     ],
-    name: "CacheUpdated",
+    name: "DelayedOrderSubmitted",
     type: "event",
   },
   {
@@ -89,6 +159,25 @@ const _abi = [
     inputs: [
       {
         indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "int256",
+        name: "marginDelta",
+        type: "int256",
+      },
+    ],
+    name: "MarginTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
         internalType: "bytes32",
         name: "trackingCode",
         type: "bytes32",
@@ -118,58 +207,7 @@ const _abi = [
         type: "uint256",
       },
     ],
-    name: "FuturesTracking",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "int256",
-        name: "marginDelta",
-        type: "int256",
-      },
-    ],
-    name: "MarginTransferred",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: "address",
-        name: "oldOwner",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnerChanged",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnerNominated",
+    name: "PerpsTracking",
     type: "event",
   },
   {
@@ -269,28 +307,6 @@ const _abi = [
     ],
     name: "PositionModified",
     type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: "address",
-        name: "proxyAddress",
-        type: "address",
-      },
-    ],
-    name: "ProxyUpdated",
-    type: "event",
-  },
-  {
-    constant: false,
-    inputs: [],
-    name: "acceptOwnership",
-    outputs: [],
-    payable: false,
-    stateMutability: "nonpayable",
-    type: "function",
   },
   {
     constant: true,
@@ -487,34 +503,8 @@ const _abi = [
     outputs: [
       {
         internalType: "int256",
-        name: "fundingRateVelocity",
+        name: "fundingVelocity",
         type: "int256",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [
-      {
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-    ],
-    name: "currentLeverage",
-    outputs: [
-      {
-        internalType: "int256",
-        name: "leverage",
-        type: "int256",
-      },
-      {
-        internalType: "bool",
-        name: "invalid",
-        type: "bool",
       },
     ],
     payable: false,
@@ -580,24 +570,9 @@ const _abi = [
             type: "bytes32",
           },
         ],
-        internalType: "struct IPerpsV2MarketBaseTypes.DelayedOrder",
+        internalType: "struct IPerpsV2MarketConsolidated.DelayedOrder",
         name: "",
         type: "tuple",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "entryDebtCorrection",
-    outputs: [
-      {
-        internalType: "int256",
-        name: "",
-        type: "int256",
       },
     ],
     payable: false,
@@ -637,37 +612,6 @@ const _abi = [
     outputs: [],
     payable: true,
     stateMutability: "payable",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [
-      {
-        internalType: "int256",
-        name: "size",
-        type: "int256",
-      },
-      {
-        internalType: "uint256",
-        name: "basePrice",
-        type: "uint256",
-      },
-    ],
-    name: "fillPriceWithBasePrice",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
-      {
-        internalType: "bool",
-        name: "",
-        type: "bool",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
     type: "function",
   },
   {
@@ -722,21 +666,6 @@ const _abi = [
     type: "function",
   },
   {
-    constant: true,
-    inputs: [],
-    name: "isResolverCached",
-    outputs: [
-      {
-        internalType: "bool",
-        name: "",
-        type: "bool",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
     constant: false,
     inputs: [
       {
@@ -765,27 +694,6 @@ const _abi = [
       {
         internalType: "uint256",
         name: "",
-        type: "uint256",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [
-      {
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-    ],
-    name: "liquidationMargin",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "lMargin",
         type: "uint256",
       },
     ],
@@ -905,61 +813,6 @@ const _abi = [
     type: "function",
   },
   {
-    constant: true,
-    inputs: [],
-    name: "marketState",
-    outputs: [
-      {
-        internalType: "contract IPerpsV2MarketState",
-        name: "",
-        type: "address",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "maxOrderSizes",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "long",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "short",
-        type: "uint256",
-      },
-      {
-        internalType: "bool",
-        name: "invalid",
-        type: "bool",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "messageSender",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
     constant: false,
     inputs: [
       {
@@ -1013,57 +866,6 @@ const _abi = [
         type: "address",
       },
     ],
-    name: "netFundingPerUnit",
-    outputs: [
-      {
-        internalType: "int256",
-        name: "",
-        type: "int256",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: false,
-    inputs: [
-      {
-        internalType: "address",
-        name: "_owner",
-        type: "address",
-      },
-    ],
-    name: "nominateNewOwner",
-    outputs: [],
-    payable: false,
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "nominatedOwner",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [
-      {
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-    ],
     name: "notionalValue",
     outputs: [
       {
@@ -1089,6 +891,11 @@ const _abi = [
         name: "sizeDelta",
         type: "int256",
       },
+      {
+        internalType: "enum IPerpsV2MarketBaseTypes.OrderType",
+        name: "orderType",
+        type: "uint8",
+      },
     ],
     name: "orderFee",
     outputs: [
@@ -1101,21 +908,6 @@ const _abi = [
         internalType: "bool",
         name: "invalid",
         type: "bool",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "owner",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
       },
     ],
     payable: false,
@@ -1161,7 +953,7 @@ const _abi = [
             type: "int128",
           },
         ],
-        internalType: "struct IPerpsV2MarketBaseTypes.Position",
+        internalType: "struct IPerpsV2MarketConsolidated.Position",
         name: "",
         type: "tuple",
       },
@@ -1182,6 +974,11 @@ const _abi = [
         internalType: "uint256",
         name: "tradePrice",
         type: "uint256",
+      },
+      {
+        internalType: "enum IPerpsV2MarketBaseTypes.OrderType",
+        name: "orderType",
+        type: "uint8",
       },
       {
         internalType: "address",
@@ -1217,7 +1014,7 @@ const _abi = [
         type: "uint256",
       },
       {
-        internalType: "enum IPerpsV2MarketBaseTypes.Status",
+        internalType: "enum IPerpsV2MarketConsolidated.Status",
         name: "status",
         type: "uint8",
       },
@@ -1250,45 +1047,6 @@ const _abi = [
     ],
     payable: false,
     stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "proportionalSkew",
-    outputs: [
-      {
-        internalType: "int256",
-        name: "",
-        type: "int256",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "proxy",
-    outputs: [
-      {
-        internalType: "contract Proxy",
-        name: "",
-        type: "address",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: false,
-    inputs: [],
-    name: "rebuildCache",
-    outputs: [],
-    payable: false,
-    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -1330,66 +1088,6 @@ const _abi = [
     ],
     payable: false,
     stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "resolver",
-    outputs: [
-      {
-        internalType: "contract AddressResolver",
-        name: "",
-        type: "address",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: "resolverAddressesRequired",
-    outputs: [
-      {
-        internalType: "bytes32[]",
-        name: "addresses",
-        type: "bytes32[]",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: false,
-    inputs: [
-      {
-        internalType: "address",
-        name: "sender",
-        type: "address",
-      },
-    ],
-    name: "setMessageSender",
-    outputs: [],
-    payable: false,
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    constant: false,
-    inputs: [
-      {
-        internalType: "address payable",
-        name: "_proxy",
-        type: "address",
-      },
-    ],
-    name: "setProxy",
-    outputs: [],
-    payable: false,
-    stateMutability: "nonpayable",
     type: "function",
   },
   {

--- a/sdk/types/futures.ts
+++ b/sdk/types/futures.ts
@@ -155,6 +155,24 @@ export enum PositionSide {
 	SHORT = 'short',
 }
 
+export enum OrderType {
+	MARKET = 0,
+	DELAYED = 1,
+	DELAYED_OFFCHAIN = 2,
+}
+
+export const OrderNameByType: Record<OrderType, string> = {
+	[OrderType.MARKET]: 'market',
+	[OrderType.DELAYED]: 'delayed',
+	[OrderType.DELAYED_OFFCHAIN]: 'delayed offchain',
+};
+
+export const OrderTypeByName: Record<string, OrderType> = {
+	market: OrderType.MARKET,
+	delayed: OrderType.DELAYED,
+	'delayed offchain': OrderType.DELAYED_OFFCHAIN,
+};
+
 export type FuturesFilledPosition<T = Wei> = {
 	canLiquidatePosition: boolean;
 	side: PositionSide;

--- a/sdk/utils/futures.ts
+++ b/sdk/utils/futures.ts
@@ -11,7 +11,7 @@ import {
 	AGGREGATE_ASSET_KEY,
 } from 'sdk/constants/futures';
 import { SECONDS_PER_DAY } from 'sdk/constants/period';
-import { IPerpsV2MarketBaseTypes } from 'sdk/contracts/types/PerpsV2Market';
+import { IPerpsV2MarketConsolidated } from 'sdk/contracts/types/PerpsV2Market';
 import {
 	DelayedOrder,
 	FundingRateUpdate,
@@ -237,7 +237,7 @@ export const unserializePotentialTrade = (
 export const formatDelayedOrder = (
 	account: string,
 	marketInfo: FuturesMarket<Wei>,
-	order: IPerpsV2MarketBaseTypes.DelayedOrderStructOutput
+	order: IPerpsV2MarketConsolidated.DelayedOrderStructOutput
 ): DelayedOrder => {
 	const {
 		isOffchain,

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -14,6 +14,7 @@ import {
 	FuturesPosition,
 	FuturesPotentialTradeDetails,
 	FuturesVolumes,
+	OrderTypeByName,
 	PositionSide,
 } from 'sdk/types/futures';
 import { calculateCrossMarginFee, serializePotentialTrade } from 'sdk/utils/futures';
@@ -281,6 +282,10 @@ export const fetchIsolatedMarginTradePreview = createAsyncThunk<
 	async (sizeDelta, { dispatch, getState, extra: { sdk } }) => {
 		const marketInfo = selectMarketInfo(getState());
 		const account = selectFuturesAccount(getState());
+		const orderType = selectOrderType(getState());
+
+		const orderTypeNum = OrderTypeByName[orderType];
+
 		if (!account) throw new Error('No account to fetch orders');
 		if (!marketInfo) throw new Error('No market info');
 		const leverageSide = selectLeverageSide(getState());
@@ -290,7 +295,8 @@ export const fetchIsolatedMarginTradePreview = createAsyncThunk<
 				sizeDelta,
 				marketInfo?.priceOracle,
 				marketInfo?.price,
-				leverageSide
+				leverageSide,
+				orderTypeNum
 			);
 			return serializePotentialTrade(preview);
 		} catch (err) {

--- a/state/futures/reducer.ts
+++ b/state/futures/reducer.ts
@@ -124,7 +124,7 @@ const initialState: FuturesState = {
 		selectedMarketAsset: FuturesMarketAsset.sETH,
 		selectedMarketKey: FuturesMarketKey.sETH,
 		leverageSide: PositionSide.LONG,
-		orderType: 'delayed',
+		orderType: 'delayed offchain',
 		tradePreview: null,
 		selectedLeverage: DEFAULT_LEVERAGE,
 		tradeInputs: ZERO_STATE_TRADE_INPUTS,


### PR DESCRIPTION
Upgrade interfaces with Perps V2 contracts to match the latest release to OP Goerli.

* Add `orderType` field to `postTradeDetails` call
* Use `allProxiedMarketSummaries` to get market data