### PR TITLE
Add navigation back to mobile exchange page

### DIFF
--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -10,6 +10,7 @@ import Header from 'sections/shared/Layout/AppLayout/Header';
 import { resetCurrencies } from 'state/exchange/actions';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { FullScreenContainer, MobileScreenContainer } from 'styles/common';
+import AppLayout from 'sections/shared/Layout/AppLayout';
 
 type ExchangeComponent = FC & { getLayout: (page: HTMLElement) => JSX.Element };
 
@@ -47,6 +48,6 @@ const Exchange: ExchangeComponent = () => {
 	);
 };
 
-Exchange.getLayout = (page) => <>{page}</>;
+Exchange.getLayout = (page) => <AppLayout>{page}</AppLayout>;
 
 export default Exchange;

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -6,11 +6,11 @@ import NotificationContainer from 'constants/NotificationContainer';
 import Connector from 'containers/Connector';
 import ExchangeContent from 'sections/exchange/ExchangeContent';
 import ExchangeHead from 'sections/exchange/ExchangeHead';
+import AppLayout from 'sections/shared/Layout/AppLayout';
 import Header from 'sections/shared/Layout/AppLayout/Header';
 import { resetCurrencies } from 'state/exchange/actions';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { FullScreenContainer, MobileScreenContainer } from 'styles/common';
-import AppLayout from 'sections/shared/Layout/AppLayout';
 
 type ExchangeComponent = FC & { getLayout: (page: HTMLElement) => JSX.Element };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The navigation bar is supposed to be visible when visiting the Exchange page on mobile, 

## Related issue
#1780 

Revert the change of #1444 
![image](https://user-images.githubusercontent.com/4819006/208705248-4673efd0-4d32-475c-a4b6-4bf17869acf8.png)


## Motivation and Context
It's easy for the user to navigate the dapp.

## How Has This Been Tested?
1. Open the exchange page on mobile and see the navigation bar

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/208704973-263b093a-6ef6-4a8a-af46-aa089a4d41c8.png)
