### PR TITLE
Removed the duplicated headers on exchange desktop

### DIFF
--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -7,7 +7,6 @@ import Connector from 'containers/Connector';
 import ExchangeContent from 'sections/exchange/ExchangeContent';
 import ExchangeHead from 'sections/exchange/ExchangeHead';
 import AppLayout from 'sections/shared/Layout/AppLayout';
-import Header from 'sections/shared/Layout/AppLayout/Header';
 import { resetCurrencies } from 'state/exchange/actions';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { FullScreenContainer, MobileScreenContainer } from 'styles/common';

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -34,7 +34,6 @@ const Exchange: ExchangeComponent = () => {
 			<ExchangeHead />
 			<DesktopOnlyView>
 				<FullScreenContainer>
-					<Header />
 					<ExchangeContent />
 					<NotificationContainer />
 				</FullScreenContainer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The exchange page on the desktop show duplicated headers after implementing the fix of #1783.
After further analysis, the root cause of #1783 is that the desktop view has its own `Header` component, which is not visible on the mobile view. So only adding the `AppLayout` back without removing this extra `Header` will cause the duplicated header issue.

The duplicated headers are removed in this PR.

## Related issue
#1783 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the exchange page on mobile and see the header correctly
2. Open the exchange page on desktop and see the header correctly

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/208872037-23871a8d-9846-4db0-80f0-8179ff726114.png)
![image](https://user-images.githubusercontent.com/4819006/208872587-04a71183-e2c3-4794-b716-84dc2e399b9c.png)
