### PR TITLE
Display an error message when pyth price feed fails to connect

### DIFF
--- a/sdk/services/prices.ts
+++ b/sdk/services/prices.ts
@@ -45,6 +45,10 @@ export default class PricesService {
 			this.pyth.onWsError = (error) => {
 				// TODO: Feedback connection issue and display
 				// prompt to try disabling add blocker
+				this.sdk.context.events.emit('prices_connection_update', {
+					connected: false,
+					error: error || new Error('pyth prices ws connection failed'),
+				});
 				logError(error);
 			};
 			this.subscribeToPythPriceUpdates();
@@ -89,6 +93,16 @@ export default class PricesService {
 
 	public removePricesListeners() {
 		this.sdk.context.events.removeAllListeners('prices_updated');
+	}
+
+	public onPricesConnectionUpdated(
+		listener: (status: { connected: boolean; error?: Error | undefined }) => void
+	) {
+		return this.sdk.context.events.on('prices_connection_update', listener);
+	}
+
+	public removeConnectionListeners() {
+		this.sdk.context.events.removeAllListeners('prices_connection_update');
 	}
 
 	public async getOnChainPrices() {

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -6,6 +6,7 @@ import { selectOpenModal } from 'state/app/selectors';
 import { changeLeverageSide } from 'state/futures/actions';
 import { selectLeverageSide, selectPosition } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
+import { selectPricesConnectionError } from 'state/prices/selectors';
 import { zeroBN } from 'utils/formatters/number';
 
 import FeeInfoBox from '../FeeInfoBox';
@@ -29,6 +30,7 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 	const leverageSide = useAppSelector(selectLeverageSide);
 	const position = useAppSelector(selectPosition);
 	const openModal = useAppSelector(selectOpenModal);
+	const pricesConnectionError = useAppSelector(selectPricesConnectionError);
 	const totalMargin = position?.remainingMargin ?? zeroBN;
 
 	return (
@@ -38,6 +40,9 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 				balance={totalMargin}
 				accountType={'isolated_margin'}
 			/>
+			{pricesConnectionError && (
+				<Error message="Failed to connect to price feed. Please try disabling any add blockers and refresh." />
+			)}
 
 			<Error messageType="warn" message={t('futures.market.trade.perpsv2-disclaimer')} />
 

--- a/state/app/hooks.ts
+++ b/state/app/hooks.ts
@@ -4,6 +4,7 @@ import { fetchBalances } from 'state/balances/actions';
 import { sdk } from 'state/config';
 import { useAppDispatch, useAppSelector, usePollAction } from 'state/hooks';
 import { updatePrices } from 'state/prices/actions';
+import { setConnectionError } from 'state/prices/reducer';
 import { selectWallet } from 'state/wallet/selectors';
 import { serializePrices } from 'utils/futures';
 
@@ -22,10 +23,19 @@ export function useAppData(ready: boolean) {
 	useEffect(() => {
 		sdk.prices.onPricesUpdated(({ prices, type }) => {
 			dispatch(updatePrices(serializePrices(prices), type));
+			if (type === 'off_chain') {
+				// must be connected again, remove any error
+				dispatch(setConnectionError(null));
+			}
+		});
+
+		sdk.prices.onPricesConnectionUpdated(({ error }) => {
+			dispatch(setConnectionError(error?.message));
 		});
 
 		return () => {
 			sdk.prices.removePricesListeners();
+			sdk.prices.removeConnectionListeners();
 		};
 	}, [dispatch]);
 }

--- a/state/prices/reducer.ts
+++ b/state/prices/reducer.ts
@@ -7,6 +7,7 @@ import { PricesState } from './types';
 const initialState: PricesState = {
 	onChainPrices: {},
 	offChainPrices: {},
+	connectionError: null,
 };
 
 const pricesSlice = createSlice({
@@ -19,9 +20,12 @@ const pricesSlice = createSlice({
 		setOnChainPrices: (state, action) => {
 			state.onChainPrices = action.payload;
 		},
+		setConnectionError: (state, action) => {
+			state.connectionError = action.payload;
+		},
 	},
 });
 
-export const { setOffChainPrices, setOnChainPrices } = pricesSlice.actions;
+export const { setOffChainPrices, setOnChainPrices, setConnectionError } = pricesSlice.actions;
 
 export default pricesSlice.reducer;

--- a/state/prices/selectors.ts
+++ b/state/prices/selectors.ts
@@ -31,3 +31,5 @@ export const selectLatestEthPrice = createSelector(selectPrices, (prices) => {
 	const price = getPricesForCurrencies(prices, 'sETH', 'sUSD');
 	return price.offChain ?? price.onChain ?? wei(0);
 });
+
+export const selectPricesConnectionError = (state: RootState) => state.prices.connectionError;

--- a/state/prices/types.ts
+++ b/state/prices/types.ts
@@ -3,4 +3,5 @@ import { PricesMap } from 'sdk/types/prices';
 export type PricesState = {
 	onChainPrices: PricesMap<string>;
 	offChainPrices: PricesMap<string>;
+	connectionError: string | null | undefined;
 };


### PR DESCRIPTION
Sometimes the price feed can fail to connect and fails consistently if the user is using AdBlock extension. This listens on the error and displays a message with a hint to disable add blocker. 