### PR TITLE
Enable the estimated rewards for the current epoch

### DIFF
--- a/sdk/services/kwentaToken.ts
+++ b/sdk/services/kwentaToken.ts
@@ -375,9 +375,11 @@ export default class KwentaTokenService {
 						this.sdk.context.networkId === 420 ? `goerli-` : ''
 					}epoch-${i}.json`
 			);
+
 		const responses: EpochData[] = await Promise.all(
-			fileNames.map(async (fileName, period) => {
+			fileNames.map(async (fileName, index) => {
 				const response = await client.get(fileName);
+				const period = index >= 5 ? index + 1 : index;
 				return { ...response.data, period };
 			})
 		);

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -80,8 +80,7 @@ const TradingRewardsTab: FC<TradingRewardProps> = ({
 		return wei(weeklyRewards).gt(0) ? wei(estimatedReward).div(wei(weeklyRewards)) : zeroBN;
 	}, [estimatedReward, weeklyRewards]);
 
-	// TODO this is a quick fix to disable the estimated rewards
-	const showEstimatedValue = false;
+	const showEstimatedValue = useMemo(() => wei(period).eq(epochPeriod), [epochPeriod, period]);
 
 	return (
 		<TradingRewardsContainer>

--- a/translations/en.json
+++ b/translations/en.json
@@ -532,7 +532,7 @@
 					"claimable-rewards-all": "Claimable Trading Rewards",
 					"claim-epoch": "Claim: Epoch {{EpochPeriod}}",
 					"claim": "Claim",
-					"estimated-info": "* Estimated values do not reflect the final reward value and are subject to change as a result of Futures fees paid and staked amounts by other participants."
+					"estimated-info": "* Estimated values do not reflect the final reward value and are subject to change as a result of future fees paid and staked amounts by other participants."
 				},
 				"escrow": {
 					"title": "Escrow",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After applying the fix of #1789, the estimated rewards for the current epoch are disabled. 

So in this PR, we fix the following issues:
1. Enable the estimated rewards for the current epoch
- Solution: same as the change made in the `reward-estimator.ts` script, we reduce the distribution epoch by 1 to align the epoch dates and reward supply with the original design
2. Make sure the `claimMultiple` function works properly by skipping epoch 5.
- Solution: Starting from `epoch-5.json`, the index of the files is not the same as the epoch number. We add the index number by 1 before passing it (as the epoch number) to the parameters of the function call

## Related issue
#1789 

## Motivation and Context
Fixing the issue by minimizing the code change

## How Has This Been Tested?
1. Switch to the current epoch on the trading rewards tab. The estimated rewards can be seen
2. Switch to the optimism goerli. Then check the epoch number of the `epoch-4.json` and the `epoch-5.json`
- epoch-4.json: epoch number is 4
- epoch-5.json: epoch number is 6

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/208990768-f5da3f09-8a0f-4a8f-9e9c-4b30afde30e0.png)
