### PR TITLE
enable market orders

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -43,7 +43,7 @@ export const MAX_TIMESTAMP: number = 8640000000000000;
 export const DEFAULT_NUMBER_OF_FUTURES_FEE: number = 9999;
 
 // leverage adjustment
-export const DEFAULT_NP_LEVERAGE_ADJUSTMENT: number = 0.9975;
+export const DEFAULT_NP_LEVERAGE_ADJUSTMENT: number = 1;
 
 // for mobile leaderboard
 export const DEFAULT_LEADERBOARD_ROWS = 20;

--- a/constants/futures.ts
+++ b/constants/futures.ts
@@ -2,11 +2,7 @@ import { wei } from '@synthetixio/wei';
 
 import { FuturesOrderType } from 'queries/futures/types';
 
-export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = [
-	'delayed offchain',
-	'delayed',
-	'market',
-];
+export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['delayed offchain', 'market'];
 export const CROSS_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'limit', 'stop market'];
 export const ORDER_KEEPER_ETH_DEPOSIT = wei(0.01);
 export const DEFAULT_MAX_LEVERAGE = wei(10);

--- a/constants/futures.ts
+++ b/constants/futures.ts
@@ -6,5 +6,6 @@ export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['delayed offchai
 export const CROSS_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'limit', 'stop market'];
 export const ORDER_KEEPER_ETH_DEPOSIT = wei(0.01);
 export const DEFAULT_MAX_LEVERAGE = wei(10);
+export const DEFAULT_DELAYED_LEVERAGE_CAP = wei(100);
 export const MAX_POSITION_BUFFER = 0.01;
 export const MIN_MARGIN_AMOUNT = wei(50);

--- a/sections/futures/Trade/OrderWarning.tsx
+++ b/sections/futures/Trade/OrderWarning.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-const DelayedOrderWarning: React.FC = () => {
+import { selectOrderType } from 'state/futures/selectors';
+import { useAppSelector } from 'state/hooks';
+
+const OrderWarning: React.FC = () => {
 	const { t } = useTranslation();
+	const orderType = useAppSelector(selectOrderType);
 
 	return (
 		<Container>
 			<p className="description">
-				{t('futures.market.trade.delayed-order.description')} {/* TODO: Add link to blog */}
-				{/* <a href={EXTERNAL_LINKS.Trade.NextPriceBlogPost} rel="noreferrer" target="_blank">
-					{t('futures.market.trade.next-price.learn-more')} ↗
-				</a> */}
+				{orderType === 'delayed offchain'
+					? t('futures.market.trade.delayed-order.description')
+					: t('futures.market.trade.market-order.description')}
 			</p>
 		</Container>
 	);
@@ -30,4 +33,4 @@ const Container = styled.div`
 	}
 `;
 
-export default DelayedOrderWarning;
+export default OrderWarning;

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import Error from 'components/Error';
 import SegmentedControl from 'components/SegmentedControl';
-import { ISOLATED_MARGIN_ORDER_TYPES } from 'constants/futures';
+import { DEFAULT_DELAYED_LEVERAGE_CAP, ISOLATED_MARGIN_ORDER_TYPES } from 'constants/futures';
 import { setOpenModal } from 'state/app/reducer';
 import { selectOpenModal } from 'state/app/selectors';
 import { changeLeverageSide } from 'state/futures/actions';
@@ -18,8 +18,8 @@ import LeverageInput from '../LeverageInput';
 import MarketInfoBox from '../MarketInfoBox';
 import OrderSizing from '../OrderSizing';
 import PositionButtons from '../PositionButtons';
-import DelayedOrderWarning from './DelayedOrderWarning';
 import ManagePosition from './ManagePosition';
+import OrderWarning from './OrderWarning';
 import TradePanelHeader from './TradePanelHeader';
 import TransferIsolatedMarginModal from './TransferIsolatedMarginModal';
 
@@ -53,17 +53,19 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 
 			{!isMobile && <MarketInfoBox />}
 
-			<StyledSegmentedControl
-				styleType="check"
-				values={ISOLATED_MARGIN_ORDER_TYPES}
-				selectedIndex={ISOLATED_MARGIN_ORDER_TYPES.indexOf(orderType)}
-				onChange={(oType: number) => {
-					const newOrderType = oType === 1 ? 'market' : 'delayed offchain';
-					dispatch(setOrderType(newOrderType));
-				}}
-			/>
+			{position?.position && position.position.leverage.gte(DEFAULT_DELAYED_LEVERAGE_CAP) && (
+				<StyledSegmentedControl
+					styleType="check"
+					values={ISOLATED_MARGIN_ORDER_TYPES}
+					selectedIndex={ISOLATED_MARGIN_ORDER_TYPES.indexOf(orderType)}
+					onChange={(oType: number) => {
+						const newOrderType = oType === 1 ? 'market' : 'delayed offchain';
+						dispatch(setOrderType(newOrderType));
+					}}
+				/>
+			)}
 
-			<DelayedOrderWarning />
+			<OrderWarning />
 
 			<PositionButtons
 				selected={leverageSide}

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -1,10 +1,14 @@
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import Error from 'components/Error';
+import SegmentedControl from 'components/SegmentedControl';
+import { ISOLATED_MARGIN_ORDER_TYPES } from 'constants/futures';
 import { setOpenModal } from 'state/app/reducer';
 import { selectOpenModal } from 'state/app/selectors';
 import { changeLeverageSide } from 'state/futures/actions';
-import { selectLeverageSide, selectPosition } from 'state/futures/selectors';
+import { setOrderType } from 'state/futures/reducer';
+import { selectLeverageSide, selectOrderType, selectPosition } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { selectPricesConnectionError } from 'state/prices/selectors';
 import { zeroBN } from 'utils/formatters/number';
@@ -29,6 +33,7 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 
 	const leverageSide = useAppSelector(selectLeverageSide);
 	const position = useAppSelector(selectPosition);
+	const orderType = useAppSelector(selectOrderType);
 	const openModal = useAppSelector(selectOpenModal);
 	const pricesConnectionError = useAppSelector(selectPricesConnectionError);
 	const totalMargin = position?.remainingMargin ?? zeroBN;
@@ -47,6 +52,16 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 			<Error messageType="warn" message={t('futures.market.trade.perpsv2-disclaimer')} />
 
 			{!isMobile && <MarketInfoBox />}
+
+			<StyledSegmentedControl
+				styleType="check"
+				values={ISOLATED_MARGIN_ORDER_TYPES}
+				selectedIndex={ISOLATED_MARGIN_ORDER_TYPES.indexOf(orderType)}
+				onChange={(oType: number) => {
+					const newOrderType = oType === 1 ? 'market' : 'delayed offchain';
+					dispatch(setOrderType(newOrderType));
+				}}
+			/>
 
 			<DelayedOrderWarning />
 
@@ -75,3 +90,7 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 };
 
 export default TradeIsolatedMargin;
+
+const StyledSegmentedControl = styled(SegmentedControl)`
+	margin-bottom: 16px;
+`;

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -64,6 +64,7 @@ import {
 	setIsolatedMarginTradeInputs,
 	setIsolatedTradePreview,
 	setLeverageSide,
+	setOrderType,
 	setTransaction,
 	setTransactionEstimate,
 	updateTransactionHash,
@@ -799,6 +800,7 @@ export const modifyIsolatedPosition = createAsyncThunk<
 			dispatch(updateTransactionHash(tx.hash));
 			await tx.wait();
 			dispatch(refetchPosition('isolated_margin'));
+			dispatch(setOrderType('delayed offchain'));
 			dispatch(setOpenModal(null));
 			dispatch(clearTradeInputs());
 			dispatch(fetchBalances());

--- a/translations/en.json
+++ b/translations/en.json
@@ -789,6 +789,9 @@
 					"description": "Delayed orders are subject to a time delay before execution by a keeper. The fill price is subject to volatility as the order is executed at a future price.",
 					"learn-more": "Learn more"
 				},
+				"market-order": {
+					"description": "Market order fees are significantly higher than delayed orders. Reducing your position size below max leverage will reenable closing your position using delayed orders."
+				},
 				"next-price": {
 					"description": "Next Price orders are subject to volatility and execute at the very next on-chain price.",
 					"learn-more": "Learn more"

--- a/translations/en.json
+++ b/translations/en.json
@@ -786,7 +786,7 @@
 					}
 				},
 				"delayed-order": {
-					"description": "All orders are subject to a delay before execution. The fill price is subject to volatility as the order is executed at future price.",
+					"description": "Delayed orders are subject to a time delay before execution by a keeper. The fill price is subject to volatility as the order is executed at a future price.",
 					"learn-more": "Learn more"
 				},
 				"next-price": {


### PR DESCRIPTION
Reenable market orders. When users have a position above max leverage, they are unable to close using delayed orders. Therefore, we need a market order option available for users to reduce positions below max leverage.

## Description
* Add back market orders
* Default to delayed offchain orders
* Always display delayed order disclaimer