### PR TITLE
Display large deposit CTA when user has no margin balance

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -9,7 +9,8 @@ export type ButtonVariant =
 	| 'success'
 	| 'danger'
 	| 'text'
-	| 'select';
+	| 'select'
+	| 'yellow';
 
 type ButtonProps = {
 	size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -84,6 +85,22 @@ const Button = styled.button<ButtonProps>`
 			box-shadow: none;
 			&:hover {
 				background: ${(props) => props.theme.colors.selectedTheme.button.fillHover};
+			}
+			&::before {
+				display: none;
+			}
+		`};
+
+	${(props) =>
+		props.variant === 'yellow' &&
+		css`
+			background: ${(props) => props.theme.colors.selectedTheme.button.yellow.fill};
+			border: 1px solid ${(props) => props.theme.colors.selectedTheme.button.yellow.border};
+			color: ${(props) => props.theme.colors.selectedTheme.button.yellow.text};
+
+			box-shadow: none;
+			&:hover {
+				background: ${(props) => props.theme.colors.selectedTheme.button.yellow.fillHover};
 			}
 			&::before {
 				display: none;

--- a/sections/futures/Trade/TradePanelHeader.tsx
+++ b/sections/futures/Trade/TradePanelHeader.tsx
@@ -4,10 +4,13 @@ import styled from 'styled-components';
 
 import HelpIcon from 'assets/svg/app/question-mark.svg';
 import SwitchAssetArrows from 'assets/svg/futures/deposit-withdraw-arrows.svg';
+import Button from 'components/Button';
 import FuturesIcon from 'components/Nav/FuturesIcon';
 import { NumberDiv } from 'components/Text/NumberLabel';
 import { EXTERNAL_LINKS } from 'constants/links';
 import { FuturesAccountType } from 'queries/futures/subgraph';
+import { setOpenModal } from 'state/app/reducer';
+import { useAppDispatch } from 'state/hooks';
 import { BorderedPanel, YellowIconButton } from 'styles/common';
 import { formatDollars } from 'utils/formatters/number';
 
@@ -19,6 +22,28 @@ type Props = {
 
 export default function TradePanelHeader({ accountType, onManageBalance, balance }: Props) {
 	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+
+	if (balance.eq(0)) {
+		return (
+			<DepositButton
+				variant="yellow"
+				onClick={() =>
+					dispatch(
+						setOpenModal(
+							accountType === 'isolated_margin'
+								? 'futures_isolated_transfer'
+								: 'futures_cross_deposit'
+						)
+					)
+				}
+			>
+				<ButtonContent>
+					Deposit Margin <SwitchAssetArrows />
+				</ButtonContent>
+			</DepositButton>
+		);
+	}
 
 	return (
 		<Container>
@@ -44,6 +69,12 @@ export default function TradePanelHeader({ accountType, onManageBalance, balance
 		</Container>
 	);
 }
+
+const DepositButton = styled(Button)`
+	height: 55px;
+	width: 100%;
+	margin-bottom: 16px;
+`;
 
 const Container = styled(BorderedPanel)`
 	display: flex;
@@ -86,4 +117,12 @@ const FAQLink = styled.div`
 	}
 	cursor: pointer;
 	margin-left: 5px;
+`;
+
+const ButtonContent = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
 `;

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -55,6 +55,12 @@ const darkTheme = {
 			disabled: { border: '1px solid #353333', text: '#353333' },
 		},
 		pill: { background: common.dark.yellow, text: common.dark.yellow, hover: common.black },
+		yellow: {
+			fill: '#3E2D00',
+			fillHover: '#513C05',
+			border: '#514219',
+			text: common.dark.yellow,
+		},
 	},
 	input: {
 		background: '#151515',

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -52,6 +52,12 @@ const lightTheme = {
 			disabled: { border: '1px solid #353333', text: '#B3B3B3' },
 		},
 		pill: { background: common.light.yellow, text: common.light.yellow, hover: common.light.white },
+		yellow: {
+			fill: '#FFF4D7',
+			fillHover: '#FFF8E5',
+			border: '#F2E1B6',
+			text: '#C18C00',
+		},
 	},
 	input: {
 		background: '#dbdbdb',


### PR DESCRIPTION
## Description
Displays a large deposit button when the user has margin in their cross margin account or isolated margin market

## Related issue
closes: #1794

## Motivation and Context
It wasn't obvious how to deposit margin when users first arrive on the futures pages

## Screenshots (if appropriate):
<img width="574" alt="Screenshot 2022-12-22 at 10 53 13" src="https://user-images.githubusercontent.com/3802342/209119065-a79a261d-0a46-46aa-9b6b-c734bf0937f3.png">

Awaiting light mode design