### PR TITLE
update fleek domain

### DIFF
--- a/queries/files/constants.ts
+++ b/queries/files/constants.ts
@@ -1,3 +1,3 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket';
 
-export const FLEEK_BASE_URL = 'https://storageapi.fleek.one';
+export const FLEEK_BASE_URL = 'https://storage.kwenta.io';

--- a/queries/files/constants.ts
+++ b/queries/files/constants.ts
@@ -1,3 +1,3 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket';
 
-export const FLEEK_BASE_URL = 'https://storageapi.fleek.co';
+export const FLEEK_BASE_URL = 'https://storageapi.fleek.one';


### PR DESCRIPTION
## Description
Fleek deprecates their `.co` domain in favor of `fleek.one`: https://blog.fleek.co/posts/fleek-co-gateway-storage-url-deprecation

# DEADLINE: 30 December, 2022

Update 24-12: Changed to `storage.kwenta.io` pointing to an endpoint provided to us by fleek.


### Before release to `main`:

- [ ] Test this with various browsers and hope not to see any big red fishing warning on deploys
- [ ] Make sure this is also pushed to `perps-v2` otherwise Staking page there will break
