### PR TITLE
`TransferPanelHeader` Display

### DIFF
--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -11,7 +11,6 @@ import { setOrderType } from 'state/futures/reducer';
 import { selectLeverageSide, selectOrderType, selectPosition } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { selectPricesConnectionError } from 'state/prices/selectors';
-import { zeroBN } from 'utils/formatters/number';
 
 import FeeInfoBox from '../FeeInfoBox';
 import LeverageInput from '../LeverageInput';
@@ -36,13 +35,11 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 	const orderType = useAppSelector(selectOrderType);
 	const openModal = useAppSelector(selectOpenModal);
 	const pricesConnectionError = useAppSelector(selectPricesConnectionError);
-	const totalMargin = position?.remainingMargin ?? zeroBN;
 
 	return (
 		<div>
 			<TradePanelHeader
 				onManageBalance={() => dispatch(setOpenModal('futures_isolated_transfer'))}
-				balance={totalMargin}
 				accountType={'isolated_margin'}
 			/>
 			{pricesConnectionError && (

--- a/sections/futures/Trade/TradePanelHeader.tsx
+++ b/sections/futures/Trade/TradePanelHeader.tsx
@@ -9,8 +9,9 @@ import { NumberDiv } from 'components/Text/NumberLabel';
 import { EXTERNAL_LINKS } from 'constants/links';
 import { FuturesAccountType } from 'queries/futures/subgraph';
 import { setOpenModal } from 'state/app/reducer';
-import { selectPosition } from 'state/futures/selectors';
+import { selectPosition, selectPositionStatus } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
+import { FetchStatus } from 'state/types';
 import { BorderedPanel, YellowIconButton } from 'styles/common';
 import { formatDollars, zeroBN } from 'utils/formatters/number';
 
@@ -24,9 +25,10 @@ export default function TradePanelHeader({ accountType, onManageBalance }: Props
 	const dispatch = useAppDispatch();
 	const theme = useTheme();
 	const position = useAppSelector(selectPosition);
-	const balance = position?.remainingMargin ?? null;
+	const positionStatus = useAppSelector(selectPositionStatus);
+	const balance = position ? position.remainingMargin : null;
 
-	if (!!balance && balance.eq(0)) {
+	if (!balance && positionStatus.status === FetchStatus.Success) {
 		return (
 			<DepositButton
 				variant="yellow"

--- a/sections/futures/Trade/TradePanelHeader.tsx
+++ b/sections/futures/Trade/TradePanelHeader.tsx
@@ -1,4 +1,3 @@
-import Wei from '@synthetixio/wei';
 import { useTranslation } from 'react-i18next';
 import styled, { useTheme } from 'styled-components';
 
@@ -10,22 +9,24 @@ import { NumberDiv } from 'components/Text/NumberLabel';
 import { EXTERNAL_LINKS } from 'constants/links';
 import { FuturesAccountType } from 'queries/futures/subgraph';
 import { setOpenModal } from 'state/app/reducer';
-import { useAppDispatch } from 'state/hooks';
+import { selectPosition } from 'state/futures/selectors';
+import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { BorderedPanel, YellowIconButton } from 'styles/common';
-import { formatDollars } from 'utils/formatters/number';
+import { formatDollars, zeroBN } from 'utils/formatters/number';
 
 type Props = {
 	accountType: FuturesAccountType;
-	balance: Wei;
 	onManageBalance: () => void;
 };
 
-export default function TradePanelHeader({ accountType, onManageBalance, balance }: Props) {
+export default function TradePanelHeader({ accountType, onManageBalance }: Props) {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 	const theme = useTheme();
+	const position = useAppSelector(selectPosition);
+	const balance = position?.remainingMargin ?? null;
 
-	if (balance.eq(0)) {
+	if (!!balance && balance.eq(0)) {
 		return (
 			<DepositButton
 				variant="yellow"
@@ -62,7 +63,7 @@ export default function TradePanelHeader({ accountType, onManageBalance, balance
 				)}
 			</Title>
 			<BalanceRow onClick={onManageBalance}>
-				<NumberDiv contrast="strong">{formatDollars(balance)}</NumberDiv>
+				<NumberDiv contrast="strong">{formatDollars(balance ?? zeroBN)}</NumberDiv>
 				<BalanceButton>
 					<SwitchAssetArrows />
 				</BalanceButton>

--- a/sections/futures/TradeCrossMargin/TradeCrossMargin.tsx
+++ b/sections/futures/TradeCrossMargin/TradeCrossMargin.tsx
@@ -68,7 +68,6 @@ export default function TradeCrossMargin({ isMobile }: Props) {
 			) : (
 				<>
 					<TradePanelHeader
-						balance={freeMargin}
 						accountType={selectedAccountType}
 						onManageBalance={() => dispatch(setOpenModal('futures_cross_deposit'))}
 					/>

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -569,8 +569,18 @@ export const selectTradePreviewStatus = createSelector(
 	(state: RootState) => state.futures,
 	(type, futures) => {
 		return type === 'cross_margin'
-			? futures.queryStatuses.crossMarginTradePreview
-			: futures.queryStatuses.isolatedTradePreview;
+			? futures.queryStatuses.crossMarginPositions
+			: futures.queryStatuses.isolatedPositions;
+	}
+);
+
+export const selectPositionStatus = createSelector(
+	selectFuturesType,
+	(state: RootState) => state.futures,
+	(type, futures) => {
+		return type === 'cross_margin'
+			? futures.queryStatuses.crossMarginPositions
+			: futures.queryStatuses.isolatedPositions;
 	}
 );
 


### PR DESCRIPTION
Update the logic for displaying the options for the `TradePanelHeader`. Only display the yellow "Deposit Margin" button if we have checked the balance to avoid flashing before contracts are loaded.