### PR TITLE
Query open orders from contract instead of subgraph

### DIFF
--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -4,15 +4,16 @@ import { Contract as EthCallContract } from 'ethcall';
 import { BigNumber, ContractTransaction, ethers } from 'ethers';
 import { formatBytes32String, parseBytes32String } from 'ethers/lib/utils';
 import request, { gql } from 'graphql-request';
+import { orderBy } from 'lodash';
 import KwentaSDK from 'sdk';
 
 import { DAY_PERIOD, KWENTA_TRACKING_CODE } from 'queries/futures/constants';
 import { getFuturesAggregateStats } from 'queries/futures/subgraph';
-import { mapFuturesOrders } from 'queries/futures/utils';
 import { UNSUPPORTED_NETWORK } from 'sdk/common/errors';
 import { BPS_CONVERSION } from 'sdk/constants/futures';
 import { Period, PERIOD_IN_SECONDS } from 'sdk/constants/period';
 import { getContractsByNetwork } from 'sdk/contracts';
+import CrossMarginBaseABI from 'sdk/contracts/abis/CrossMarginBase.json';
 import FuturesMarketABI from 'sdk/contracts/abis/FuturesMarket.json';
 import FuturesMarketInternal from 'sdk/contracts/FuturesMarketInternal';
 import {
@@ -28,7 +29,6 @@ import {
 	FuturesMarket,
 	FuturesMarketAsset,
 	FuturesMarketKey,
-	FuturesOrder,
 	FuturesVolumes,
 	MarketClosureReason,
 	PositionDetail,
@@ -41,6 +41,7 @@ import {
 	getFuturesEndpoint,
 	getMarketName,
 	getReasonFromCode,
+	mapFuturesOrderFromEvent,
 	mapFuturesPosition,
 	marketsForNetwork,
 } from 'sdk/utils/futures';
@@ -384,33 +385,36 @@ export default class FuturesService {
 	}
 
 	public async getOpenOrders(account: string) {
-		const response = await request(
-			this.futuresGqlEndpoint,
-			gql`
-				query OpenOrders($account: String!) {
-					futuresOrders(where: { abstractAccount: $account, status: Pending }) {
-						id
-						account
-						size
-						market
-						asset
-						targetRoundId
-						marginDelta
-						targetPrice
-						timestamp
-						orderType
+		if (!this.sdk.context.signer) return [];
+
+		const crossMarginBaseMultiCall = new EthCallContract(account, CrossMarginBaseABI);
+		const crossMarginBaseContract = CrossMarginBase__factory.connect(
+			account,
+			this.sdk.context.signer
+		);
+		const accountFilter = crossMarginBaseContract.filters.OrderPlaced(account);
+		const orders = [];
+
+		if (accountFilter) {
+			const logs = await crossMarginBaseContract.queryFilter(accountFilter);
+			if (logs.length) {
+				const orderCalls = logs.map((l) => crossMarginBaseMultiCall.orders(l.args.orderId));
+				const contractOrders = (await this.sdk.context.multicallProvider.all(orderCalls)) as any;
+				for (let i = 0; i < logs.length; i++) {
+					const log = logs[i];
+					const contractOrder = contractOrders[i];
+					// Checks if the order is still pending
+					// Orders are never removed but all values set to zero so we check a zero value on price to filter pending
+					if (contractOrder && contractOrder.targetPrice.gt(0)) {
+						const block = await log.getBlock();
+						const order = mapFuturesOrderFromEvent(log, account, wei(block.timestamp));
+						orders.push(order);
 					}
 				}
-			`,
-			{ account: account }
-		);
+			}
+		}
 
-		const openOrders: FuturesOrder[] = response
-			? response.futuresOrders.map((o: any) => {
-					return mapFuturesOrders(o);
-			  })
-			: [];
-		return openOrders;
+		return orderBy(orders, ['timestamp'], 'desc');
 	}
 
 	public async getCrossMarginSettings() {


### PR DESCRIPTION
## Issue
When the subgraph has sync issues users can't see open orders and there is no way to cancel orders.

## Solution
This removes the dependency on the subgraph and queries the orders direct from the contract instead.

## How Has This Been Tested?
Opening and closing advanced orders on cross margin