### PR TITLE
Fixed the wrong reward badge after the market page refresh

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -91,7 +91,6 @@ const useFuturesData = () => {
 	const { tradeFee: crossMarginTradeFee, stopOrderFee, limitOrderFee } = useAppSelector(
 		selectCrossMarginSettings
 	);
-
 	const isAdvancedOrder = useAppSelector(selectIsAdvancedOrder);
 	const marketAssetRate = useAppSelector(selectMarketAssetRate);
 	const orderPrice = useAppSelector(selectCrossMarginOrderPrice);

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -41,7 +41,6 @@ import {
 } from 'state/futures/selectors';
 import { selectMarketAsset, selectMarketInfo } from 'state/futures/selectors';
 import { useAppSelector, useAppDispatch } from 'state/hooks';
-import { fetchStakingData } from 'state/staking/actions';
 import { futuresAccountState, orderFeeCapState } from 'store/futures';
 import { computeMarketFee } from 'utils/costCalculations';
 import { zeroBN } from 'utils/formatters/number';
@@ -295,7 +294,6 @@ const useFuturesData = () => {
 
 	useEffect(() => {
 		resetTradeState();
-		dispatch(fetchStakingData());
 		// Clear trade state when switching address
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [crossMarginAddress]);

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -41,6 +41,7 @@ import {
 } from 'state/futures/selectors';
 import { selectMarketAsset, selectMarketInfo } from 'state/futures/selectors';
 import { useAppSelector, useAppDispatch } from 'state/hooks';
+import { fetchStakingData } from 'state/staking/actions';
 import { futuresAccountState, orderFeeCapState } from 'store/futures';
 import { computeMarketFee } from 'utils/costCalculations';
 import { zeroBN } from 'utils/formatters/number';
@@ -91,6 +92,7 @@ const useFuturesData = () => {
 	const { tradeFee: crossMarginTradeFee, stopOrderFee, limitOrderFee } = useAppSelector(
 		selectCrossMarginSettings
 	);
+
 	const isAdvancedOrder = useAppSelector(selectIsAdvancedOrder);
 	const marketAssetRate = useAppSelector(selectMarketAssetRate);
 	const orderPrice = useAppSelector(selectCrossMarginOrderPrice);
@@ -293,6 +295,7 @@ const useFuturesData = () => {
 
 	useEffect(() => {
 		resetTradeState();
+		dispatch(fetchStakingData());
 		// Clear trade state when switching address
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [crossMarginAddress]);

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -1,5 +1,5 @@
 import router from 'next/router';
-import React, { FC, useMemo, useEffect } from 'react';
+import React, { FC, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -22,8 +22,7 @@ import {
 	selectOrderType,
 	selectTradeSizeInputs,
 } from 'state/futures/selectors';
-import { useAppDispatch, useAppSelector } from 'state/hooks';
-import { fetchStakingData } from 'state/staking/actions';
+import { useAppSelector } from 'state/hooks';
 import {
 	selectStakedEscrowedKwentaBalance,
 	selectStakedKwentaBalance,
@@ -35,7 +34,6 @@ import { formatCurrency, formatDollars, formatPercent, zeroBN } from 'utils/form
 const FeeInfoBox: React.FC = () => {
 	const { t } = useTranslation();
 	const { walletAddress } = Connector.useContainer();
-	const dispatch = useAppDispatch();
 	const orderType = useAppSelector(selectOrderType);
 	const stakedEscrowedKwentaBalance = useAppSelector(selectStakedEscrowedKwentaBalance);
 	const stakedKwentaBalance = useAppSelector(selectStakedKwentaBalance);
@@ -81,12 +79,6 @@ const FeeInfoBox: React.FC = () => {
 		() => !!walletAddress && stakedKwentaBalance.add(stakedEscrowedKwentaBalance).gt(0),
 		[walletAddress, stakedKwentaBalance, stakedEscrowedKwentaBalance]
 	);
-
-	useEffect(() => {
-		if (!!walletAddress) {
-			dispatch(fetchStakingData());
-		}
-	}, [dispatch, walletAddress]);
 
 	const feesInfo = useMemo<Record<string, DetailedInfo | null | undefined>>(() => {
 		const crossMarginFeeInfo = {

--- a/state/futures/hooks.ts
+++ b/state/futures/hooks.ts
@@ -1,4 +1,5 @@
 import { useAppSelector, useFetchAction, usePollAction } from 'state/hooks';
+import { fetchStakingData } from 'state/staking/actions';
 import { selectNetwork, selectWallet } from 'state/wallet/selectors';
 
 import {
@@ -21,6 +22,7 @@ export const usePollMarketFuturesData = () => {
 	const selectedAccountType = useAppSelector(selectFuturesType);
 
 	useFetchAction(fetchCrossMarginSettings, { changeKeys: [networkId] });
+	useFetchAction(fetchStakingData, { changeKeys: [networkId, wallet] });
 	usePollAction('fetchSharedFuturesData', fetchSharedFuturesData, {
 		dependencies: [networkId],
 		intervalTime: 60000,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The 'Eligible' text switches to 'Not Eligible' after refreshing the market page even though the user has staked Kwenta.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Case 1: Disconnected the wallet
1. Show `Not Eligible` badge
2. Same text after page refresh

Case 2: Connected the wallet with staked Kwenta
1. Show `Eligible` badge
2. Same text after page refresh

Case 3: Connected the wallet with no staked Kwenta: 
1. Showing `Not Eligible` badge
2. Same text after page refresh

## Screenshots (if appropriate):
