### PR TITLE
Perps V1: Switch to testnet subgraph

### DIFF
--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -11,7 +11,7 @@ import {
 
 import { requestCandlesticks } from 'queries/rates/useCandlesticksQuery';
 import { combineDataToPair } from 'sections/exchange/TradeCard/Charts/hooks/useCombinedCandleSticksChartData';
-import { MarketAssetByKey, getDisplayAsset } from 'utils/futures';
+import { getDisplayAsset } from 'utils/futures';
 import logError from 'utils/logError';
 
 import { resolutionToSeconds } from './utils';

--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -11,7 +11,7 @@ import {
 
 import { requestCandlesticks } from 'queries/rates/useCandlesticksQuery';
 import { combineDataToPair } from 'sections/exchange/TradeCard/Charts/hooks/useCombinedCandleSticksChartData';
-import { getDisplayAsset } from 'utils/futures';
+import { MarketAssetByKey, getDisplayAsset } from 'utils/futures';
 import logError from 'utils/logError';
 
 import { resolutionToSeconds } from './utils';
@@ -57,7 +57,7 @@ const fetchCombinedCandles = async (
 	const baseCurrencyIsSUSD = base === 'sUSD';
 	const quoteCurrencyIsSUSD = quote === 'sUSD';
 	const baseDataPromise = requestCandlesticks(
-		base,
+		getDisplayAsset(base),
 		from,
 		to,
 		resolutionToSeconds(resolution),

--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -88,7 +88,7 @@ const fetchLastCandle = async (
 	const from = 0;
 
 	const baseDataPromise = requestCandlesticks(
-		base,
+		getDisplayAsset(base),
 		from,
 		to,
 		resolutionToSeconds(resolution),

--- a/queries/rates/constants.ts
+++ b/queries/rates/constants.ts
@@ -3,7 +3,7 @@ import { chain } from 'wagmi';
 export const RATES_ENDPOINT_MAIN = 'https://api.thegraph.com/subgraphs/name/kwenta/mainnet-main';
 
 export const RATES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';
 
 export const RATES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';

--- a/queries/rates/types.ts
+++ b/queries/rates/types.ts
@@ -54,7 +54,7 @@ export type Candle = {
 export type Candles = Candle[];
 
 export type LatestRate = {
-	id: string;
+	synth: string;
 	rate: Wei;
 };
 

--- a/queries/rates/useLaggedDailyPrice.ts
+++ b/queries/rates/useLaggedDailyPrice.ts
@@ -1,5 +1,4 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
-import EthDater from 'ethereum-block-by-date';
 import request, { gql } from 'graphql-request';
 import { values } from 'lodash';
 import { useQuery, UseQueryOptions } from 'react-query';
@@ -8,21 +7,22 @@ import { useSetRecoilState } from 'recoil';
 import QUERY_KEYS from 'constants/queryKeys';
 import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import { selectMarketAssets } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { pastRatesState } from 'store/futures';
 import logError from 'utils/logError';
 
 import { RATES_ENDPOINT_OP_MAINNET } from './constants';
-import { Price } from './types';
+import { LatestRate, Price } from './types';
 import { getRatesEndpoint, mapLaggedDailyPrices } from './utils';
 
 const useLaggedDailyPrice = (options?: UseQueryOptions<Price[] | null>) => {
-	const { provider, network, synthsMap } = Connector.useContainer();
+	const { network, synthsMap } = Connector.useContainer();
 	const marketAssets = useAppSelector(selectMarketAssets);
 	const setPastRates = useSetRecoilState(pastRatesState);
 
-	const minTimestamp = Math.floor(Date.now()) - 60 * 60 * 24 * 1000;
+	const minTimestamp = Math.floor((Date.now() - 60 * 60 * 24 * 1000) / 1000);
 	const synths = [...marketAssets, ...values(synthsMap).map(({ name }) => name)];
 
 	const ratesEndpoint =
@@ -33,32 +33,36 @@ const useLaggedDailyPrice = (options?: UseQueryOptions<Price[] | null>) => {
 	return useQuery<Price[] | null>(
 		QUERY_KEYS.Rates.PastRates(network?.id as NetworkId, synths),
 		async () => {
-			if (!provider) return null;
-			const dater = new EthDater(provider);
-
-			const block = await dater.getDate(minTimestamp, true, false);
-
 			try {
+				const rateUpdateQueries = synths.map((synth) => {
+					return gql`
+					# last before timestamp
+					${synth}: rateUpdates(
+						first: 1
+						where: { synth: "${getDisplayAsset(synth) ?? synth}", timestamp_gte: $minTimestamp }
+						orderBy: timestamp
+						orderDirection: asc
+					) {
+						synth
+						rate
+					}
+				`;
+				});
+
 				const response = await request(
 					ratesEndpoint,
 					gql`
-						query latestRates($synths: [String!]!) {
-							latestRates(
-								where: {
-									id_in: $synths
-								}
-								block: { number: ${block.block} }
-							) {
-								id
-								rate
-							}
-						}
-					`,
+						query rateUpdates($minTimestamp: BigInt!) {
+							${rateUpdateQueries.reduce((acc: string, curr: string) => {
+								return acc + curr;
+							})}
+					}`,
 					{
-						synths: synths,
+						minTimestamp: minTimestamp,
 					}
 				);
-				const pastRates = response ? mapLaggedDailyPrices(response.latestRates) : [];
+				const latestRates = (response ? Object.values(response).flat() : []) as LatestRate[];
+				const pastRates = mapLaggedDailyPrices(latestRates);
 
 				setPastRates(pastRates);
 				return pastRates;

--- a/queries/rates/utils.ts
+++ b/queries/rates/utils.ts
@@ -17,9 +17,9 @@ export const getRatesEndpoint = (networkId: NetworkId): string => {
 export const mapLaggedDailyPrices = (rates: LatestRate[]): Prices => {
 	return rates.map((rate) => {
 		return {
-			synth: rate.id,
+			synth: rate.synth,
 			price:
-				rate.id === 'DebtRatio'
+				rate.synth === 'DebtRatio'
 					? wei(rate.rate).div(DEBT_RATIO_UNIT).toNumber()
 					: wei(rate.rate).toNumber(),
 		};

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -15,6 +15,7 @@ import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
 import { FundingRateResponse } from 'sdk/types/futures';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import {
 	selectAverageFundingRates,
 	selectFuturesType,
@@ -40,7 +41,7 @@ const FuturesMarketsTable: FC = () => {
 		return futuresMarkets.map((market) => {
 			const description = getSynthDescription(market.asset, synthsMap, t);
 			const volume = futuresVolumes[market.assetHex]?.volume;
-			const pastPrice = pastRates.find((price) => price.synth === market.asset);
+			const pastPrice = pastRates.find((price) => price.synth === getDisplayAsset(market.asset));
 			const fundingRate = fundingRates.find(
 				(funding) => (funding as FundingRateResponse)?.asset === MarketKeyByAsset[market.asset]
 			);

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -7,6 +7,7 @@ import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { NO_VALUE } from 'constants/placeholder';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import useExternalPriceQuery from 'queries/rates/useExternalPriceQuery';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import {
 	selectFundingRate,
 	selectMarketAsset,
@@ -44,7 +45,7 @@ const useGetMarketData = (mobile?: boolean) => {
 			? DEFAULT_CRYPTO_DECIMALS
 			: undefined;
 
-	const pastPrice = pastRates.find((price) => price.synth === marketAsset);
+	const pastPrice = pastRates.find((price) => price.synth === getDisplayAsset(marketAsset));
 
 	const fundingTitle = useMemo(
 		() => `${fundingRate?.fundingTitle ?? t('futures.market.info.hourly-funding')}`,


### PR DESCRIPTION
Update the rates subgraph to use the testnet subgraph. This is a temporary fix while the mainnet subgraph lags behind blocks.

Description
* Update rates subgraph to OP Goerli
* Update the candles query to use the display asset name. This solves an issue where the sLINK candles return the ETH price