### PR TITLE
Perps V2: Fix price feeds

### DIFF
--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -176,7 +176,7 @@ const useFuturesData = () => {
 	}, [orderType, limitOrderFee, stopOrderFee]);
 
 	const totalFeeRate = useCallback(
-		async (usdSizeDelta: Wei) => {
+		(usdSizeDelta: Wei) => {
 			const staticRate = computeMarketFee(market, usdSizeDelta);
 
 			let total = crossMarginTradeFee.add(dynamicFeeRate).add(staticRate).add(advancedOrderFeeRate);

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -3,10 +3,10 @@ import { gql } from 'graphql-request';
 import { chain } from 'wagmi';
 
 export const FUTURES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/tburm/optimism-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-perps';
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
-	'https://api.thegraph.com/subgraphs/name/tburm/optimism-goerli-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-goerli-perps';
 
 export const FUTURES_ENDPOINTS = {
 	[chain.optimism.id]: FUTURES_ENDPOINT_OP_MAINNET,

--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-request';
 import { chain } from 'wagmi';
 
 export const FUTURES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-futures';
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/tburm/optimism-goerli-futures';

--- a/queries/rates/constants.ts
+++ b/queries/rates/constants.ts
@@ -3,7 +3,7 @@ import { chain } from 'wagmi';
 export const RATES_ENDPOINT_MAIN = 'https://api.thegraph.com/subgraphs/name/kwenta/mainnet-main';
 
 export const RATES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';
 
 export const RATES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';

--- a/queries/rates/types.ts
+++ b/queries/rates/types.ts
@@ -54,7 +54,7 @@ export type Candle = {
 export type Candles = Candle[];
 
 export type LatestRate = {
-	id: string;
+	synth: string;
 	rate: Wei;
 };
 

--- a/queries/rates/useLaggedDailyPrice.ts
+++ b/queries/rates/useLaggedDailyPrice.ts
@@ -1,5 +1,4 @@
 import { NetworkId } from '@synthetixio/contracts-interface';
-import EthDater from 'ethereum-block-by-date';
 import request, { gql } from 'graphql-request';
 import { values } from 'lodash';
 import { useQuery, UseQueryOptions } from 'react-query';
@@ -8,21 +7,22 @@ import { useSetRecoilState } from 'recoil';
 import QUERY_KEYS from 'constants/queryKeys';
 import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import { selectMarketAssets } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { pastRatesState } from 'store/futures';
 import logError from 'utils/logError';
 
 import { RATES_ENDPOINT_OP_MAINNET } from './constants';
-import { Price } from './types';
+import { LatestRate, Price } from './types';
 import { getRatesEndpoint, mapLaggedDailyPrices } from './utils';
 
 const useLaggedDailyPrice = (options?: UseQueryOptions<Price[] | null>) => {
-	const { provider, network, synthsMap } = Connector.useContainer();
+	const { network, synthsMap } = Connector.useContainer();
 	const marketAssets = useAppSelector(selectMarketAssets);
 	const setPastRates = useSetRecoilState(pastRatesState);
 
-	const minTimestamp = Math.floor(Date.now()) - 60 * 60 * 24 * 1000;
+	const minTimestamp = Math.floor((Date.now() - 60 * 60 * 24 * 1000) / 1000);
 	const synths = [...marketAssets, ...values(synthsMap).map(({ name }) => name)];
 
 	const ratesEndpoint =
@@ -33,32 +33,36 @@ const useLaggedDailyPrice = (options?: UseQueryOptions<Price[] | null>) => {
 	return useQuery<Price[] | null>(
 		QUERY_KEYS.Rates.PastRates(network?.id as NetworkId, synths),
 		async () => {
-			if (!provider) return null;
-			const dater = new EthDater(provider);
-
-			const block = await dater.getDate(minTimestamp, true, false);
-
 			try {
+				const rateUpdateQueries = synths.map((synth) => {
+					return gql`
+					# last before timestamp
+					${synth}: rateUpdates(
+						first: 1
+						where: { synth: "${getDisplayAsset(synth) ?? synth}", timestamp_gte: $minTimestamp }
+						orderBy: timestamp
+						orderDirection: asc
+					) {
+						synth
+						rate
+					}
+				`;
+				});
+
 				const response = await request(
 					ratesEndpoint,
 					gql`
-						query latestRates($synths: [String!]!) {
-							latestRates(
-								where: {
-									id_in: $synths
-								}
-								block: { number: ${block.block} }
-							) {
-								id
-								rate
-							}
-						}
-					`,
+						query rateUpdates($minTimestamp: BigInt!) {
+							${rateUpdateQueries.reduce((acc: string, curr: string) => {
+								return acc + curr;
+							})}
+					}`,
 					{
-						synths: synths,
+						minTimestamp: minTimestamp,
 					}
 				);
-				const pastRates = response ? mapLaggedDailyPrices(response.latestRates) : [];
+				const latestRates = (response ? Object.values(response).flat() : []) as LatestRate[];
+				const pastRates = mapLaggedDailyPrices(latestRates);
 
 				setPastRates(pastRates);
 				return pastRates;

--- a/queries/rates/utils.ts
+++ b/queries/rates/utils.ts
@@ -17,9 +17,9 @@ export const getRatesEndpoint = (networkId: NetworkId): string => {
 export const mapLaggedDailyPrices = (rates: LatestRate[]): Prices => {
 	return rates.map((rate) => {
 		return {
-			synth: rate.id,
+			synth: rate.synth,
 			price:
-				rate.id === 'DebtRatio'
+				rate.synth === 'DebtRatio'
 					? wei(rate.rate).div(DEBT_RATIO_UNIT).toNumber()
 					: wei(rate.rate).toNumber(),
 		};

--- a/sdk/constants/futures.ts
+++ b/sdk/constants/futures.ts
@@ -1,10 +1,10 @@
 import { FuturesMarketAsset, FuturesMarketConfig, FuturesMarketKey } from 'sdk/types/futures';
 
 export const FUTURES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/tburm/optimism-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-perps';
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
-	'https://api.thegraph.com/subgraphs/name/tburm/optimism-goerli-futures';
+	'https://api.thegraph.com/subgraphs/name/tburm/optimism-goerli-perps';
 
 export const FUTURES_ENDPOINTS: Record<number, string> = {
 	10: FUTURES_ENDPOINT_OP_MAINNET,

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -14,6 +14,7 @@ import Table from 'components/Table';
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import { selectFuturesType, selectMarkets, selectMarketVolumes } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { selectPrices } from 'state/prices/selectors';
@@ -35,7 +36,7 @@ const FuturesMarketsTable: FC = () => {
 		return futuresMarkets.map((market) => {
 			const description = getSynthDescription(market.asset, synthsMap, t);
 			const volume = futuresVolumes[market.marketKey]?.volume;
-			const pastPrice = pastRates.find((price) => price.synth === market.asset);
+			const pastPrice = pastRates.find((price) => price.synth === getDisplayAsset(market.asset));
 			const marketPrice = prices[market.asset]?.offChain ?? prices[market.asset]?.onChain ?? wei(0);
 
 			return {

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -6,6 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { NO_VALUE } from 'constants/placeholder';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import {
 	selectMarketAsset,
 	selectMarketInfo,
@@ -43,7 +44,7 @@ const useGetMarketData = (mobile?: boolean) => {
 			? DEFAULT_CRYPTO_DECIMALS
 			: undefined;
 
-	const pastPrice = pastRates.find((price) => price.synth === marketAsset);
+	const pastPrice = pastRates.find((price) => price.synth === getDisplayAsset(marketAsset));
 
 	const oraclePrice = marketPrices.onChain ?? wei(0);
 


### PR DESCRIPTION
Point perps v2 at the OP Goerli price feed to avoid the lagging price feeds. Additionally updates some other subgraph-related configurations.

## Description
* Update lagged prices to match V1 implementation
* Change rates subgraph to point at testnet
* Update futures subgraph to point at the correct perps version
* Update an async function which was throwing errors

