### PR TITLE
bump version and decode-uri-component to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kwenta",
-	"version": "6.0.1-alpha",
+	"version": "6.0.2-alpha",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kwenta",
-			"version": "6.0.1-alpha",
+			"version": "6.0.2-alpha",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@artsy/fresnel": "1.7.0",
@@ -30650,8 +30650,8 @@
 			"dev": true
 		},
 		"node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
 			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
 			"engines": {
 				"node": ">=0.10"
@@ -82490,8 +82490,8 @@
 			"dev": true
 		},
 		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
 			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
 		},
 		"decompress": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kwenta",
-	"version": "6.0.1-alpha",
+	"version": "6.0.2-alpha",
 	"scripts": {
 		"dev": "next",
 		"build": "next build",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- bump alpha version to `v6.0.2-alpha`
- update vulnerable package `decode-uri-component` to `v0.2.2` where applicable (see #1863)
