### PR TITLE
Perps V2: Update mainnet rates subgraph

### DIFF
--- a/queries/rates/constants.ts
+++ b/queries/rates/constants.ts
@@ -3,7 +3,7 @@ import { chain } from 'wagmi';
 export const RATES_ENDPOINT_MAIN = 'https://api.thegraph.com/subgraphs/name/kwenta/mainnet-main';
 
 export const RATES_ENDPOINT_OP_MAINNET =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';
+	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-latest-rates';
 
 export const RATES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';


### PR DESCRIPTION
Update rates subgraph on OP mainnet to the `latest-rates` subgraph