### PR TITLE
Fix deposit approval transaction

### DIFF
--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -477,7 +477,10 @@ export default class FuturesService {
 		amount: BigNumber = ethers.constants.MaxUint256
 	) {
 		if (!this.sdk.context.contracts.SUSD) throw new Error(UNSUPPORTED_NETWORK);
-		return this.sdk.context.contracts.SUSD.approve(crossMarginAddress, amount);
+		return this.sdk.transactions.createContractTxn(this.sdk.context.contracts.SUSD, 'approve', [
+			crossMarginAddress,
+			amount,
+		]);
 	}
 
 	public async depositCrossMargin(crossMarginAddress: string, amount: Wei) {


### PR DESCRIPTION
The approval call needs to be updated to use signer instead of provider, which is now the contract default. 