### PR TITLE
chore: display liquadation price

### DIFF
--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -114,6 +114,10 @@ const DelayedOrderConfirmationModal: FC = () => {
 				value: formatDollars(potentialTradeDetails?.price ?? zeroBN, { isAssetPrice: true }),
 			},
 			{
+				label: 'liquidation price',
+				value: formatDollars(potentialTradeDetails?.liqPrice ?? zeroBN, { isAssetPrice: true }),
+			},
+			{
 				label: t('futures.market.user.position.modal.time-delay'),
 				value: `${formatNumber(marketInfo?.settings.offchainDelayedOrderMinAge ?? zeroBN, {
 					maxDecimals: 0,

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -114,7 +114,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 				value: formatDollars(potentialTradeDetails?.price ?? zeroBN, { isAssetPrice: true }),
 			},
 			{
-				label: 'liquidation price',
+				label: t('futures.market.user.position.modal.liquidation-price'),
 				value: formatDollars(potentialTradeDetails?.liqPrice ?? zeroBN, { isAssetPrice: true }),
 			},
 			{

--- a/translations/en.json
+++ b/translations/en.json
@@ -893,6 +893,7 @@
 						"estimated-fill": "Estimated Fill Price",
 						"estimated-price-impact": "Estimated Price Impact",
 						"fee-estimated": "Estimated Fees",
+						"liquidation-price": "Liquidation Price",
 						"time-delay": "Delay Until Executable",
 						"keeper-deposit": "Keeper Deposit",
 						"gas-fee": "Network Gas Fee",


### PR DESCRIPTION
Liquidation price displayed in the trade confirmation modal the same as v1.
