### PR TITLE
Fixed the vekwenta redeemer contract

### DIFF
--- a/sdk/contracts/index.ts
+++ b/sdk/contracts/index.ts
@@ -39,6 +39,7 @@ import {
 	KwentaStakingRewards__factory,
 	VKwentaRedeemer__factory,
 	StakingRewards__factory,
+	VeKwentaRedeemer__factory,
 } from './types';
 
 type ContractFactory = {
@@ -138,7 +139,7 @@ export const getContractsByNetwork = (
 			? VKwentaRedeemer__factory.connect(ADDRESSES.vKwentaRedeemer[networkId], provider)
 			: undefined,
 		veKwentaRedeemer: ADDRESSES.veKwentaRedeemer[networkId]
-			? VKwentaRedeemer__factory.connect(ADDRESSES.veKwentaRedeemer[networkId], provider)
+			? VeKwentaRedeemer__factory.connect(ADDRESSES.veKwentaRedeemer[networkId], provider)
 			: undefined,
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user reported that the `veKwenta` couldn't be redeemed.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Make the redemption process smoothly.

## How Has This Been Tested?
Test the redemption of veKwenta on optimism goerli.
https://goerli-optimism.etherscan.io/tx/0xba8f3aedb48769126184b3dd48cc6fad78d475293ef798abe8abd78ee57674e4

## Screenshots (if appropriate):
