### PR TITLE
Skipping the distribution epoch 10

### DIFF
--- a/sdk/services/kwentaToken.ts
+++ b/sdk/services/kwentaToken.ts
@@ -183,7 +183,7 @@ export default class KwentaTokenService {
 			vKwentaBalance: wei(vKwentaBalance),
 			vKwentaAllowance: wei(vKwentaAllowance),
 			kwentaAllowance: wei(kwentaAllowance),
-			epochPeriod: Number(epochPeriod) - 1,
+			epochPeriod: Number(epochPeriod) - 2,
 			veKwentaBalance: wei(veKwentaBalance),
 			veKwentaAllowance: wei(veKwentaAllowance),
 		};
@@ -379,7 +379,7 @@ export default class KwentaTokenService {
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName, index) => {
 				const response = await client.get(fileName);
-				const period = index >= 5 ? index + 1 : index;
+				const period = index >= 5 ? (index >= 10 ? index + 2 : index + 1) : index;
 				return { ...response.data, period };
 			})
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Taking #1789 and #1800 as examples. In this PR, we fix the following issues:

1. Enable the estimated rewards for the current epoch
- Solution: we reduce the distribution epoch by 2 to align the epoch dates and reward supply with the original design
2. Make sure the `claimMultiple` function works properly by skipping epoch 10.
Solution: Starting from epoch-10.json, we add the index number by 2 before passing it (as the epoch number) to the parameters of the function call

## Related issue
#1789 
#1800 

## Motivation and Context
Fixing the issue by minimizing the code change

## How Has This Been Tested?
1. Switch to the current epoch on the trading rewards tab. The estimated rewards can be seen
2. Switch to the optimism goerli. Then check the epoch number of the `epoch-9.json` and the `epoch-10.json`
- epoch-9.json: epoch number is 10
- epoch-10.json: epoch number is 12

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/214458901-701fa35b-d511-4c0c-815c-00e7015b0f65.png)
