### PR TITLE
Deposit button logic

### DIFF
--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -247,14 +247,12 @@ export default class FuturesService {
 		)) as boolean[];
 
 		// map the positions using the results
-		const positions = positionDetails
-			.map((position, ind) => {
-				const canLiquidate = canLiquidateState[ind];
-				const marketKey = futuresMarkets[ind].marketKey;
-				const asset = futuresMarkets[ind].asset;
-				return mapFuturesPosition(position, canLiquidate, asset, marketKey);
-			})
-			.filter(({ remainingMargin }) => remainingMargin.gt(0));
+		const positions = positionDetails.map((position, ind) => {
+			const canLiquidate = canLiquidateState[ind];
+			const marketKey = futuresMarkets[ind].marketKey;
+			const asset = futuresMarkets[ind].asset;
+			return mapFuturesPosition(position, canLiquidate, asset, marketKey);
+		});
 
 		return positions;
 	}

--- a/sections/futures/Trade/TradePanelHeader.tsx
+++ b/sections/futures/Trade/TradePanelHeader.tsx
@@ -10,9 +10,8 @@ import { NumberDiv } from 'components/Text/NumberLabel';
 import { EXTERNAL_LINKS } from 'constants/links';
 import { FuturesAccountType } from 'queries/futures/subgraph';
 import { setOpenModal } from 'state/app/reducer';
-import { selectPosition, selectPositionStatus } from 'state/futures/selectors';
+import { selectPosition } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
-import { FetchStatus } from 'state/types';
 import { selectWallet } from 'state/wallet/selectors';
 import { BorderedPanel, YellowIconButton } from 'styles/common';
 import { formatDollars, zeroBN } from 'utils/formatters/number';
@@ -30,7 +29,6 @@ export default function TradePanelHeader({ accountType, onManageBalance }: Props
 	const wallet = useAppSelector(selectWallet);
 	const { openConnectModal } = useConnectModal();
 	const position = useAppSelector(selectPosition);
-	const positionStatus = useAppSelector(selectPositionStatus);
 	const balance = position ? position.remainingMargin : null;
 
 	if (!wallet) {
@@ -41,7 +39,7 @@ export default function TradePanelHeader({ accountType, onManageBalance }: Props
 		);
 	}
 
-	if (!balance && positionStatus.status === FetchStatus.Success) {
+	if (!!balance && balance.eq(0)) {
 		return (
 			<DepositButton
 				variant="yellow"


### PR DESCRIPTION
There is some flickering with the "Deposit Margin" button which can be improved. The current logic only displays the yellow `Deposit Margin` button when the position query has succeeded. This causes flickering when the query is in progress.

## Description:
* Update futures position query to return values where margin is zero. This will help distinguish when the query has _not been run_ versus when it has _succeeded_
* Update logic to ONLY display `Deposit Margin` button when we have confirmed the user has $0 margin

Note that the "startup" behavior for a connected wallet with no margin can still look strange: Display "Connect wallet" -> Display $0 -> Display "Deposit Margin"
