### PR TITLE
Improve Order Types

### DIFF
--- a/constants/futures.ts
+++ b/constants/futures.ts
@@ -2,8 +2,8 @@ import { wei } from '@synthetixio/wei';
 
 import { FuturesOrderType } from 'queries/futures/types';
 
-export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['delayed offchain', 'market'];
-export const CROSS_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'limit', 'stop market'];
+export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['delayedOffchain', 'market'];
+export const CROSS_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market', 'limit', 'stopMarket'];
 export const ORDER_KEEPER_ETH_DEPOSIT = wei(0.01);
 export const DEFAULT_MAX_LEVERAGE = wei(10);
 export const DEFAULT_DELAYED_LEVERAGE_CAP = wei(100);

--- a/hooks/useFuturesData.ts
+++ b/hooks/useFuturesData.ts
@@ -168,7 +168,7 @@ const useFuturesData = () => {
 		switch (orderType) {
 			case 'limit':
 				return limitOrderFee;
-			case 'stop market':
+			case 'stopMarket':
 				return stopOrderFee;
 			default:
 				return zeroBN;

--- a/queries/futures/types.ts
+++ b/queries/futures/types.ts
@@ -197,13 +197,7 @@ export type FuturesTradeInputs = {
 	orderPrice?: Wei | undefined;
 };
 
-export type FuturesOrderType =
-	| 'market'
-	| 'next price'
-	| 'stop market'
-	| 'limit'
-	| 'delayed'
-	| 'delayed offchain';
+export type FuturesOrderType = 'market' | 'stopMarket' | 'limit' | 'delayed' | 'delayedOffchain';
 
 export type SpotsFee = {
 	timestamp: string;

--- a/sdk/types/futures.ts
+++ b/sdk/types/futures.ts
@@ -169,13 +169,13 @@ export enum OrderType {
 export const OrderNameByType: Record<OrderType, string> = {
 	[OrderType.MARKET]: 'market',
 	[OrderType.DELAYED]: 'delayed',
-	[OrderType.DELAYED_OFFCHAIN]: 'delayed offchain',
+	[OrderType.DELAYED_OFFCHAIN]: 'delayedOffchain',
 };
 
 export const OrderTypeByName: Record<string, OrderType> = {
 	market: OrderType.MARKET,
 	delayed: OrderType.DELAYED,
-	'delayed offchain': OrderType.DELAYED_OFFCHAIN,
+	delayedOffchain: OrderType.DELAYED_OFFCHAIN,
 };
 
 export type FuturesFilledPosition<T = Wei> = {

--- a/sdk/utils/futures.ts
+++ b/sdk/utils/futures.ts
@@ -443,7 +443,7 @@ export const calculateCrossMarginFee = (
 	susdSize: Wei,
 	feeRates: CrossMarginSettings
 ) => {
-	if (orderType !== 'limit' && orderType !== 'stop market') return zeroBN;
+	if (orderType !== 'limit' && orderType !== 'stopMarket') return zeroBN;
 	const advancedOrderFeeRate =
 		orderType === 'limit' ? feeRates.limitOrderFee : feeRates.stopOrderFee;
 	return susdSize.mul(advancedOrderFeeRate);

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -58,7 +58,7 @@ const FeeInfoBox: React.FC = () => {
 
 	const orderFeeRate = useMemo(
 		() =>
-			orderType === 'limit' ? limitOrderFee : orderType === 'stop market' ? stopOrderFee : null,
+			orderType === 'limit' ? limitOrderFee : orderType === 'stopMarket' ? stopOrderFee : null,
 		[orderType, stopOrderFee, limitOrderFee]
 	);
 
@@ -152,7 +152,7 @@ const FeeInfoBox: React.FC = () => {
 				}),
 			},
 		};
-		if (orderType === 'limit' || orderType === 'stop market') {
+		if (orderType === 'limit' || orderType === 'stopMarket') {
 			return {
 				...crossMarginFeeInfo,
 				'Keeper Deposit': {
@@ -162,7 +162,7 @@ const FeeInfoBox: React.FC = () => {
 				},
 			};
 		}
-		if (orderType === 'delayed' || orderType === 'delayed offchain') {
+		if (orderType === 'delayed' || orderType === 'delayedOffchain') {
 			return {
 				'Keeper Deposit': {
 					value: !!marketInfo?.keeperDeposit ? formatDollars(marketInfo.keeperDeposit) : NO_VALUE,

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -84,7 +84,7 @@ const LeverageInput: FC = memo(() => {
 				</LeverageTitle>
 				{modeButton}
 			</LeverageRow>
-			{(orderType === 'delayed' || orderType === 'delayed offchain') && isDisclaimerDisplayed && (
+			{(orderType === 'delayed' || orderType === 'delayedOffchain') && isDisclaimerDisplayed && (
 				<LeverageDisclaimer>
 					{t('futures.market.trade.input.leverage.disclaimer')}
 				</LeverageDisclaimer>

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -87,7 +87,7 @@ const OrderSizing: React.FC<OrderSizingProps> = memo(({ disabled, isMobile }) =>
 
 	const showPosSizeHelper =
 		position?.position?.size &&
-		(orderType === 'limit' || orderType === 'stop market') &&
+		(orderType === 'limit' || orderType === 'stopMarket') &&
 		position?.position.side !== selectedLeverageSide;
 
 	const invalid =

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -64,7 +64,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 			modifyIsolatedPositionEstimateGas({
 				sizeDelta: nativeSizeDelta,
 				delayed: true,
-				offchain: orderType === 'delayed offchain',
+				offchain: orderType === 'delayedOffchain',
 			})
 		);
 	}, [nativeSizeDelta, orderType, dispatch]);
@@ -174,7 +174,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 			modifyIsolatedPosition({
 				sizeDelta: nativeSizeDelta,
 				delayed: true,
-				offchain: orderType === 'delayed offchain',
+				offchain: orderType === 'delayedOffchain',
 			})
 		);
 	};

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -101,7 +101,7 @@ const ManagePosition: React.FC = () => {
 			orderType
 		);
 
-		if ((orderType === 'limit' || orderType === 'stop market') && !!invalidReason)
+		if ((orderType === 'limit' || orderType === 'stopMarket') && !!invalidReason)
 			return invalidReason;
 		if (susdSize.gt(maxUsdInputAmount)) return 'max_size_exceeded';
 		if (placeOrderTranslationKey === 'futures.market.trade.button.deposit-margin-minimum')
@@ -111,7 +111,7 @@ const ManagePosition: React.FC = () => {
 				return 'awaiting_preview';
 			if (orderType !== 'market' && isZero(orderPrice)) return 'pricerequired';
 		} else if (selectedAccountType === 'isolated_margin') {
-			if ((orderType === 'delayed' || orderType === 'delayed offchain') && !!openOrder)
+			if ((orderType === 'delayed' || orderType === 'delayedOffchain') && !!openOrder)
 				return 'order_open';
 		} else if (isZero(susdSize)) {
 			return 'size_required';
@@ -162,7 +162,7 @@ const ManagePosition: React.FC = () => {
 						variant="danger"
 						onClick={() => {
 							if (
-								(orderType === 'delayed' || orderType === 'delayed offchain') &&
+								(orderType === 'delayed' || orderType === 'delayedOffchain') &&
 								position?.position?.size
 							) {
 								const newTradeSize = position.position.size;
@@ -198,7 +198,7 @@ const ManagePosition: React.FC = () => {
 			{isConfirmationModalOpen &&
 				(selectedAccountType === 'cross_margin' ? (
 					<TradeConfirmationModalCrossMargin />
-				) : orderType === 'delayed' || orderType === 'delayed offchain' ? (
+				) : orderType === 'delayed' || orderType === 'delayedOffchain' ? (
 					<DelayedOrderConfirmationModal />
 				) : (
 					<TradeConfirmationModalIsolatedMargin />

--- a/sections/futures/Trade/OrderWarning.tsx
+++ b/sections/futures/Trade/OrderWarning.tsx
@@ -12,7 +12,7 @@ const OrderWarning: React.FC = () => {
 	return (
 		<Container>
 			<p className="description">
-				{orderType === 'delayed offchain'
+				{orderType === 'delayedOffchain'
 					? t('futures.market.trade.delayed-order.description')
 					: t('futures.market.trade.market-order.description')}
 			</p>

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -102,7 +102,7 @@ export default function TradeConfirmationModal({
 				label: 'resulting leverage',
 				value: `${formatNumber(positionDetails?.leverage ?? zeroBN)}x`,
 			},
-			orderType === 'limit' || orderType === 'stop market'
+			orderType === 'limit' || orderType === 'stopMarket'
 				? {
 						label: orderType + ' order price',
 						value: formatDollars(orderPrice, { isAssetPrice: true }),

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -54,7 +54,7 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 					values={ISOLATED_MARGIN_ORDER_TYPES}
 					selectedIndex={ISOLATED_MARGIN_ORDER_TYPES.indexOf(orderType)}
 					onChange={(oType: number) => {
-						const newOrderType = oType === 1 ? 'market' : 'delayed offchain';
+						const newOrderType = oType === 1 ? 'market' : 'delayedOffchain';
 						dispatch(setOrderType(newOrderType));
 					}}
 				/>

--- a/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
+++ b/sections/futures/TradeCrossMargin/CrossMarginInfoBox.tsx
@@ -110,9 +110,9 @@ function MarginInfoBox({ editingLeverage }: Props) {
 
 		return {
 			showPreview:
-				((orderType === 'market' || orderType === 'delayed' || orderType === 'delayed offchain') &&
+				((orderType === 'market' || orderType === 'delayed' || orderType === 'delayedOffchain') &&
 					(!size.eq(0) || !marginDelta.eq(0))) ||
-				((orderType === 'limit' || orderType === 'stop market') && !!orderPrice && !size.eq(0)),
+				((orderType === 'limit' || orderType === 'stopMarket') && !!orderPrice && !size.eq(0)),
 			totalMargin: potentialTrade?.margin.sub(crossMarginFee) || zeroBN,
 			freeAccountMargin: crossMarginFreeMargin.sub(marginDelta),
 			availableMargin: previewAvailableMargin.gt(0) ? previewAvailableMargin : zeroBN,

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -612,7 +612,7 @@ export const calculateCrossMarginFees = (): AppThunk => (dispatch, getState) => 
 	const tradeFee = susdSize.mul(staticRate).add(susdSize.mul(dynamicFeeRate));
 
 	const currentDeposit =
-		orderType === 'limit' || orderType === 'stop market' ? keeperBalance : wei(0);
+		orderType === 'limit' || orderType === 'stopMarket' ? keeperBalance : wei(0);
 	const requiredDeposit = currentDeposit.lt(ORDER_KEEPER_ETH_DEPOSIT)
 		? ORDER_KEEPER_ETH_DEPOSIT.sub(currentDeposit)
 		: wei(0);
@@ -800,7 +800,7 @@ export const modifyIsolatedPosition = createAsyncThunk<
 			dispatch(updateTransactionHash(tx.hash));
 			await tx.wait();
 			dispatch(refetchPosition('isolated_margin'));
-			dispatch(setOrderType('delayed offchain'));
+			dispatch(setOrderType('delayedOffchain'));
 			dispatch(setOpenModal(null));
 			dispatch(clearTradeInputs());
 			dispatch(fetchBalances());

--- a/state/futures/reducer.ts
+++ b/state/futures/reducer.ts
@@ -124,7 +124,7 @@ const initialState: FuturesState = {
 		selectedMarketAsset: FuturesMarketAsset.sETH,
 		selectedMarketKey: FuturesMarketKey.sETH,
 		leverageSide: PositionSide.LONG,
-		orderType: 'delayed offchain',
+		orderType: 'delayedOffchain',
 		tradePreview: null,
 		tradeInputs: ZERO_STATE_TRADE_INPUTS,
 		priceImpact: DEFAULT_PRICE_IMPACT_DELTA,

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -344,7 +344,7 @@ export const selectMaxLeverage = createSelector(
 		const positionSide = position?.position?.side;
 		const marketMaxLeverage = market?.maxLeverage ?? DEFAULT_MAX_LEVERAGE;
 		const adjustedMaxLeverage =
-			orderType === 'delayed' || orderType === 'delayed offchain'
+			orderType === 'delayed' || orderType === 'delayedOffchain'
 				? marketMaxLeverage.mul(DEFAULT_NP_LEVERAGE_ADJUSTMENT)
 				: marketMaxLeverage;
 
@@ -478,10 +478,10 @@ export const selectPlaceOrderTranslationKey = createSelector(
 			remainingMargin = positionMargin.add(freeMargin);
 		}
 
-		if (orderType === 'delayed' || orderType === 'delayed offchain')
+		if (orderType === 'delayed' || orderType === 'delayedOffchain')
 			return 'futures.market.trade.button.place-delayed-order';
 		if (orderType === 'limit') return 'futures.market.trade.button.place-limit-order';
-		if (orderType === 'stop market') return 'futures.market.trade.button.place-stop-order';
+		if (orderType === 'stopMarket') return 'futures.market.trade.button.place-stop-order';
 		if (!!position?.position) return 'futures.market.trade.button.modify-position';
 		return remainingMargin.lt('50')
 			? 'futures.market.trade.button.deposit-margin-minimum'
@@ -610,7 +610,7 @@ export const selectCrossMarginSettings = createSelector(
 
 export const selectIsAdvancedOrder = createSelector(
 	(state: RootState) => state.futures.crossMargin.orderType,
-	(type) => type === 'limit' || type === 'stop market'
+	(type) => type === 'limit' || type === 'stopMarket'
 );
 
 export const selectModifyIsolatedGasEstimate = createSelector(
@@ -642,11 +642,11 @@ export const selectDelayedOrderFee = createSelector(
 		const notionalDiff = nativeSizeDelta.mul(price);
 
 		const makerFee =
-			orderType === 'delayed offchain'
+			orderType === 'delayedOffchain'
 				? market.feeRates.makerFeeOffchainDelayedOrder
 				: market.feeRates.makerFeeDelayedOrder;
 		const takerFee =
-			orderType === 'delayed offchain'
+			orderType === 'delayedOffchain'
 				? market.feeRates.takerFeeOffchainDelayedOrder
 				: market.feeRates.takerFeeDelayedOrder;
 

--- a/state/futures/types.ts
+++ b/state/futures/types.ts
@@ -14,8 +14,8 @@ import { PositionSide } from 'sections/futures/types';
 import { QueryStatus } from 'state/types';
 import { FuturesMarketAsset, FuturesMarketKey } from 'utils/futures';
 
-export type IsolatedMarginOrderType = 'delayed' | 'delayed offchain' | 'market';
-export type CrossMarginOrderType = 'market' | 'stop market' | 'limit';
+export type IsolatedMarginOrderType = 'delayed' | 'delayedOffchain' | 'market';
+export type CrossMarginOrderType = 'market' | 'stopMarket' | 'limit';
 
 export type TradeSizeInputs<T = Wei> = {
 	nativeSize: T;

--- a/utils/costCalculations.ts
+++ b/utils/costCalculations.ts
@@ -57,13 +57,13 @@ export const computeOrderFee = (
 	}
 
 	const makerFee =
-		orderType === 'delayed offchain'
+		orderType === 'delayedOffchain'
 			? market.feeRates.makerFeeOffchainDelayedOrder
 			: orderType === 'delayed'
 			? market.feeRates.makerFeeDelayedOrder
 			: market.feeRates.makerFee;
 	const takerFee =
-		orderType === 'delayed offchain'
+		orderType === 'delayedOffchain'
 			? market.feeRates.takerFeeOffchainDelayedOrder
 			: orderType === 'delayed'
 			? market.feeRates.takerFeeDelayedOrder

--- a/utils/futures.ts
+++ b/utils/futures.ts
@@ -184,12 +184,12 @@ export const orderPriceInvalidLabel = (
 	if (!orderPrice || Number(orderPrice) <= 0) return null;
 	const isLong = leverageSide === 'long';
 	if (
-		((isLong && orderType === 'limit') || (!isLong && orderType === 'stop market')) &&
+		((isLong && orderType === 'limit') || (!isLong && orderType === 'stopMarket')) &&
 		wei(orderPrice).gt(currentPrice)
 	)
 		return 'max ' + formatNumber(currentPrice);
 	if (
-		((!isLong && orderType === 'limit') || (isLong && orderType === 'stop market')) &&
+		((!isLong && orderType === 'limit') || (isLong && orderType === 'stopMarket')) &&
 		wei(orderPrice).lt(currentPrice)
 	)
 		return 'min ' + formatNumber(currentPrice);


### PR DESCRIPTION
Improve our `orderType` typing by removing spacing and replacing all references with a camelcase version. No major changes, this is just addressing a comment from a previous PR.