### PR TITLE
Fetch open orders using multicall

### DIFF
--- a/sdk/contracts/index.ts
+++ b/sdk/contracts/index.ts
@@ -11,6 +11,7 @@ import ExchangeRatesABI from './abis/ExchangeRates.json';
 import FuturesMarketDataABI from './abis/FuturesMarketData.json';
 import FuturesMarketSettingsABI from './abis/FuturesMarketSettings.json';
 import KwentaStakingRewardsABI from './abis/KwentaStakingRewards.json';
+import PerpsV2MarketABI from './abis/PerpsV2Market.json';
 import PerpsV2MarketDataABI from './abis/PerpsV2MarketData.json';
 import PerpsV2MarketSettingsABI from './abis/PerpsV2MarketSettings.json';
 import StakingRewardsABI from './abis/StakingRewards.json';
@@ -50,6 +51,9 @@ export type AllContractsMap = Record<
 	ContractName,
 	{ addresses: Partial<Record<NetworkId, string>>; Factory: ContractFactory }
 >;
+
+export const getPerpsV2MarketMulticall = (marketAddress: string) =>
+	new EthCallContract(marketAddress, PerpsV2MarketABI);
 
 export const getContractsByNetwork = (
 	networkId: NetworkId,

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -316,10 +316,9 @@ export const fetchOpenOrders = createAsyncThunk<
 	if (markets.length === 0) {
 		throw new Error('No markets available');
 	}
-	// TODO: Make this multicall
-	const orders: DelayedOrder[] = await Promise.all(
-		markets.map((market) => sdk.futures.getDelayedOrder(account, market.market))
-	);
+	const marketAddresses = markets.map((market) => market.market);
+
+	const orders: DelayedOrder[] = await sdk.futures.getDelayedOrders(account, marketAddresses);
 	const nonzeroOrders = orders
 		.filter((o) => o.size.abs().gt(0))
 		.map((o) => {


### PR DESCRIPTION
Add an SDK function which takes a list of addresses and fetches orders in a single request using multicall

## Description
* Add SDK function to create perps market multicall contracts
* Add `getDelayedOrders` function to SDK which returns orders for a list of markets, using multicall
* Update state to fetch using `getDelayedOrders`

## Related issue
- #1878 