### PR TITLE
Fee Display

### DIFF
--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -6,19 +6,21 @@ import styled from 'styled-components';
 import EligibleIcon from 'assets/svg/app/eligible.svg';
 import LinkArrowIcon from 'assets/svg/app/link-arrow.svg';
 import NotEligibleIcon from 'assets/svg/app/not-eligible.svg';
+import HelpIcon from 'assets/svg/app/question-mark.svg';
 import InfoBox, { DetailedInfo } from 'components/InfoBox/InfoBox';
 import { Body } from 'components/Text';
+import Tooltip from 'components/Tooltip/Tooltip';
 import { NO_VALUE } from 'constants/placeholder';
 import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
 import {
 	selectCrossMarginSettings,
 	selectCrossMarginTradeFees,
-	selectDelayedOrderFee,
 	selectFuturesType,
 	selectIsolatedMarginFee,
 	selectMarketInfo,
 	selectOrderType,
+	selectTradePreview,
 	selectTradeSizeInputs,
 } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
@@ -43,10 +45,12 @@ const FeeInfoBox: React.FC = () => {
 		selectCrossMarginSettings
 	);
 	const marketInfo = useAppSelector(selectMarketInfo);
-	const { commitDeposit } = useAppSelector(selectDelayedOrderFee);
+	const tradePreview = useAppSelector(selectTradePreview);
+
+	const commitDeposit = useMemo(() => tradePreview?.fee ?? zeroBN, [tradePreview?.fee]);
 
 	const totalDeposit = useMemo(() => {
-		return (commitDeposit ?? zeroBN).add(marketInfo?.keeperDeposit ?? zeroBN);
+		return commitDeposit.add(marketInfo?.keeperDeposit ?? zeroBN);
 	}, [commitDeposit, marketInfo?.keeperDeposit]);
 
 	const { orderFee, makerFee, takerFee } = useMemo(
@@ -62,13 +66,20 @@ const FeeInfoBox: React.FC = () => {
 
 	const marketCostTooltip = useMemo(
 		() => (
-			<>
-				{nativeSizeDelta.abs().gt(0)
-					? formatPercent(orderFee ?? zeroBN)
-					: `${formatPercent(makerFee ?? zeroBN)} / ${formatPercent(takerFee ?? zeroBN)}`}
-			</>
+			<CostContainer>
+				<>{`${formatPercent(makerFee ?? zeroBN)} / ${formatPercent(takerFee ?? zeroBN)}`}</>
+				<Tooltip
+					height={'auto'}
+					preset="top"
+					width="300px"
+					content={t('futures.market.trade.fees.tooltip')}
+					style={{ textTransform: 'none' }}
+				>
+					<StyledHelpIcon />
+				</Tooltip>
+			</CostContainer>
 		),
-		[orderFee, makerFee, takerFee, nativeSizeDelta]
+		[t, orderFee, makerFee, takerFee, nativeSizeDelta]
 	);
 
 	const isRewardEligible = useMemo(
@@ -163,7 +174,6 @@ const FeeInfoBox: React.FC = () => {
 					value: !!commitDeposit
 						? formatDollars(commitDeposit, { minDecimals: commitDeposit.lt(0.01) ? 4 : 2 })
 						: NO_VALUE,
-					keyNode: marketCostTooltip,
 				},
 				'Total Deposit': {
 					value: formatDollars(totalDeposit),
@@ -173,6 +183,7 @@ const FeeInfoBox: React.FC = () => {
 					value: !!commitDeposit
 						? formatDollars(commitDeposit, { minDecimals: commitDeposit.lt(0.01) ? 4 : 2 })
 						: NO_VALUE,
+					keyNode: marketCostTooltip,
 				},
 			};
 		}
@@ -206,6 +217,16 @@ const FeeInfoBox: React.FC = () => {
 
 const StyledInfoBox = styled(InfoBox)`
 	margin-bottom: 16px;
+`;
+
+const CostContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+`;
+
+const StyledHelpIcon = styled(HelpIcon)`
+	margin-left: 4px;
 `;
 
 const StyledLinkArrowIcon = styled(LinkArrowIcon)`

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -14,7 +14,6 @@ import { getDisplayAsset, OrderNameByType } from 'sdk/utils/futures';
 import { setOpenModal } from 'state/app/reducer';
 import { modifyIsolatedPosition } from 'state/futures/actions';
 import {
-	selectDelayedOrderFee,
 	selectIsModifyingIsolatedPosition,
 	selectLeverageSide,
 	selectMarketAsset,
@@ -57,7 +56,6 @@ const DelayedOrderConfirmationModal: FC = () => {
 	const potentialTradeDetails = useAppSelector(selectTradePreview);
 	const previewStatus = useAppSelector(selectTradePreviewStatus);
 	const orderType = useAppSelector(selectOrderType);
-	const { commitDeposit } = useAppSelector(selectDelayedOrderFee);
 
 	const positionSize = useMemo(() => {
 		const positionDetails = position?.position;
@@ -74,10 +72,9 @@ const DelayedOrderConfirmationModal: FC = () => {
 		return orderDetails.size.eq(zeroBN);
 	}, [orderDetails]);
 
-	// TODO: check this deposit
 	const totalDeposit = useMemo(() => {
-		return (commitDeposit ?? zeroBN).add(marketInfo?.keeperDeposit ?? zeroBN);
-	}, [commitDeposit, marketInfo?.keeperDeposit]);
+		return (potentialTradeDetails?.fee ?? zeroBN).add(marketInfo?.keeperDeposit ?? zeroBN);
+	}, [potentialTradeDetails?.fee, marketInfo?.keeperDeposit]);
 
 	const dataRows = useMemo(
 		() => [
@@ -122,7 +119,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 			},
 			{
 				label: t('futures.market.user.position.modal.fee-estimated'),
-				value: formatCurrency(selectedPriceCurrency.name, commitDeposit ?? zeroBN, {
+				value: formatCurrency(selectedPriceCurrency.name, potentialTradeDetails?.fee ?? zeroBN, {
 					minDecimals: 2,
 					sign: selectedPriceCurrency.sign,
 				}),
@@ -143,7 +140,6 @@ const DelayedOrderConfirmationModal: FC = () => {
 			t,
 			orderDetails,
 			orderType,
-			commitDeposit,
 			potentialTradeDetails,
 			marketAsset,
 			leverageSide,

--- a/translations/en.json
+++ b/translations/en.json
@@ -846,7 +846,7 @@
 					"error": "Error generating preview"
 				},
 				"fees": {
-					"tooltip": "Fees are displayed as maker/taker. Maker fees apply to orders that reduce the market skew. Maker fees apply to orders that increase the market skew."
+					"tooltip": "Fees are displayed as maker/taker. Maker fees apply to orders that reduce the market skew. Taker fees apply to orders that increase the market skew."
 				},
 				"orders": {
 					"manage-keeper-deposit": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -845,6 +845,9 @@
 					"insufficient-margin": "Insufficient free margin",
 					"error": "Error generating preview"
 				},
+				"fees": {
+					"tooltip": "Fees are displayed as maker/taker. Maker fees apply to orders that reduce the market skew. Maker fees apply to orders that increase the market skew."
+				},
 				"orders": {
 					"manage-keeper-deposit": {
 						"title": "Manage Account ETH Balance",


### PR DESCRIPTION
Improve fee displays by passing the trade preview fee. This fixes a bug where orders that change the skew display an incorrect amount for the fee and commit deposit.

## Description
* Replace "estimated fees" with the value from trade preview
* Replace "commit deposit" with the value from trade preview
* Move the fee percentage to "estimated fees" and add a tooltip that explains maker/taker

Old:
![image](https://user-images.githubusercontent.com/10401554/215908268-7157f432-de45-4372-ad75-1db14b8da7f5.png)

New:
![image](https://user-images.githubusercontent.com/10401554/215908301-fc0392bf-3765-4567-ab8a-c5ef31bbe73d.png)
