### PR TITLE
Fix gray label contrast on dark theme

### DIFF
--- a/components/InfoBox/InfoBox.tsx
+++ b/components/InfoBox/InfoBox.tsx
@@ -84,7 +84,7 @@ const InfoBoxContainer = styled.div`
 `;
 
 const InfoBoxKey = styled(Text.Body)`
-	color: ${(props) => props.theme.colors.selectedTheme.text.title};
+	color: ${(props) => props.theme.colors.selectedTheme.text.label};
 	font-size: 13px;
 	text-transform: capitalize;
 	cursor: default;

--- a/components/Input/InputTitle.tsx
+++ b/components/Input/InputTitle.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const InputTitle = styled.div<{ margin?: string }>`
-	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	color: ${(props) => props.theme.colors.selectedTheme.text.label};
 	font-size: 13px;
 	margin: ${(props) => props.margin || '0'};
 	span {

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -290,13 +290,13 @@ const ReactTable = styled.div<{ palette: TablePalette }>`
 				max-height: calc(100% - ${CARD_HEIGHT});
 			}
 			${TableCell} {
-				color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+				color: ${(props) => props.theme.colors.selectedTheme.text.value};
 				font-size: 12px;
 				height: ${CARD_HEIGHT};
 				font-family: ${(props) => props.theme.fonts.mono};
 			}
 			${TableCellHead} {
-				color: ${(props) => props.theme.colors.selectedTheme.gray};
+				color: ${(props) => props.theme.colors.selectedTheme.text.label};
 				font-family: ${(props) => props.theme.fonts.regular};
 				border-bottom: ${(props) => props.theme.colors.selectedTheme.border};
 			}
@@ -317,7 +317,7 @@ const StyledSortUpIcon = styled(SortUpIcon)`
 
 export const TableHeader = styled(Body)<{ $small?: boolean }>`
 	text-transform: capitalize;
-	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	color: ${(props) => props.theme.colors.selectedTheme.text.label};
 
 	${(props) =>
 		props.$small &&

--- a/sections/dashboard/Stake/EscrowTable.tsx
+++ b/sections/dashboard/Stake/EscrowTable.tsx
@@ -287,7 +287,7 @@ const EscrowStats = styled.div`
 
 	.stat-title {
 		font-size: 10px;
-		color: ${(props) => props.theme.colors.selectedTheme.text.title};
+		color: ${(props) => props.theme.colors.selectedTheme.text.label};
 	}
 
 	.stat-value {

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -213,7 +213,7 @@ const StyledLinkArrowIcon = styled(LinkArrowIcon)`
 `;
 
 const RewardCopy = styled(Body)`
-	color: ${(props) => props.theme.colors.selectedTheme.text.title};
+	color: ${(props) => props.theme.colors.selectedTheme.text.label};
 `;
 
 const CompactBox = styled.div<{ $isEligible: boolean }>`

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import Button from 'components/Button';
 import CustomNumericInput from 'components/Input/CustomNumericInput';
+import InputTitle from 'components/Input/InputTitle';
 import { FlexDivCol, FlexDivRow } from 'components/layout/flex';
 import { DEFAULT_FIAT_DECIMALS } from 'constants/defaults';
 import { editIsolatedMarginSize } from 'state/futures/actions';
@@ -135,14 +136,8 @@ const LeverageRow = styled(FlexDivRow)`
 	margin-bottom: 8px;
 `;
 
-const LeverageTitle = styled.div`
-	font-size: 13px;
-	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+const LeverageTitle = styled(InputTitle)`
 	text-transform: capitalize;
-
-	span {
-		color: ${(props) => props.theme.colors.selectedTheme.gray};
-	}
 `;
 
 const SliderRow = styled(FlexDivRow)`

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -101,7 +101,7 @@ const MarketDetailsContainer = styled.div<{ mobile?: boolean }>`
 
 	.heading {
 		font-size: 13px;
-		color: ${(props) => props.theme.colors.selectedTheme.text.title};
+		color: ${(props) => props.theme.colors.selectedTheme.text.label};
 	}
 
 	.value {

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -443,7 +443,7 @@ const InfoRow = styled.div`
 
 const Subtitle = styled(Body)`
 	font-size: 13px;
-	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	color: ${(props) => props.theme.colors.selectedTheme.text.label};
 	text-transform: capitalize;
 `;
 

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import Button from 'components/Button';
 import Error from 'components/ErrorView';
+import InputTitle from 'components/Input/InputTitle';
 import { useFuturesContext } from 'contexts/FuturesContext';
 import { previewErrorI18n } from 'queries/futures/constants';
 import { PositionSide } from 'sdk/types/futures';
@@ -233,14 +234,8 @@ const CloseOrderButton = styled(Button)`
 	}
 `;
 
-const ManageOrderTitle = styled.p`
-	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
-	font-size: 13px;
+const ManageOrderTitle = styled(InputTitle)`
 	margin-bottom: 8px;
-
-	span {
-		color: ${(props) => props.theme.colors.selectedTheme.gray};
-	}
 `;
 
 export default ManagePosition;

--- a/styles/theme/colors/common.ts
+++ b/styles/theme/colors/common.ts
@@ -7,6 +7,7 @@ const common = {
 	primaryGreen: '#7FD482',
 	primaryGray: '#B1B1B1',
 	secondaryGray: '#515151',
+	neautralGray: '#A9A8A6',
 	tertiaryGray: '#999999',
 	secondaryGold: '#E4B378',
 	primaryYellow: '#FFB800',

--- a/styles/theme/colors/dark.ts
+++ b/styles/theme/colors/dark.ts
@@ -109,9 +109,8 @@ const darkTheme = {
 	},
 	text: {
 		header: '#B1B1B1',
-		title: common.secondaryGray,
 		value: common.primaryWhite,
-		label: common.secondaryGray,
+		label: common.neautralGray,
 		body: common.dark.gray,
 	},
 	icon: {

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -106,7 +106,6 @@ const lightTheme = {
 	},
 	text: {
 		header: '#171002',
-		title: common.secondaryGray,
 		value: '#000000',
 		label: common.secondaryGray,
 		body: common.light.gray,


### PR DESCRIPTION
## Motivation and Context
There were some inconsistencies in the gray colors used in the labels and some places in the UI where the labels had really poor contrast.

This PR removes the use of the low contrast gray and introduces a brighter gray from the latest designs.

## Screenshots (if appropriate):

Old style:

<img width="1894" alt="Screenshot 2023-02-01 at 11 28 44" src="https://user-images.githubusercontent.com/3802342/216030725-7f2e525f-5508-4f29-b7fa-a3e4b272aeda.png">

Updated style:
<img width="1906" alt="Screenshot 2023-02-01 at 11 28 51" src="https://user-images.githubusercontent.com/3802342/216030812-b43bb3d2-471f-438d-b3d6-c585dfb5622e.png">
