### PR TITLE
Check if approved and valid before estimating exchange tx fee

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -35,6 +35,7 @@ import '@reach/dialog/styles.css';
 import '@rainbow-me/rainbowkit/styles.css';
 import '../i18n';
 import { getDesignTokens } from 'utils/theme';
+import { IGNORE_ERRORS } from 'utils/logError';
 
 type NextPageWithLayout = NextPage & {
 	getLayout?: (page: ReactElement) => ReactNode;
@@ -54,6 +55,7 @@ Sentry.init({
 	autoSessionTracking: true,
 	integrations: [new BrowserTracing()],
 	tracesSampleRate: 0.3,
+	ignoreErrors: IGNORE_ERRORS,
 });
 
 const InnerApp: FC<AppProps> = ({ Component, pageProps }: AppPropsWithLayout) => {

--- a/state/exchange/actions.ts
+++ b/state/exchange/actions.ts
@@ -10,7 +10,12 @@ import { AppThunk } from 'state/store';
 import { FetchStatus, ThunkConfig } from 'state/types';
 import { toWei, truncateNumbers } from 'utils/formatters/number';
 
-import { selectBaseBalanceWei, selectQuoteBalanceWei } from './selectors';
+import {
+	selectBaseBalanceWei,
+	selectInsufficientBalance,
+	selectIsApproved,
+	selectQuoteBalanceWei,
+} from './selectors';
 import { SwapRatio } from './types';
 
 export const fetchRedeemableBalances = createAsyncThunk<any, void, ThunkConfig>(
@@ -43,6 +48,15 @@ export const fetchTransactionFee = createAsyncThunk<
 	const {
 		exchange: { quoteCurrencyKey, baseCurrencyKey, quoteAmount, baseAmount },
 	} = getState();
+
+	const isApproved = selectIsApproved(getState());
+	const insufficientBalance = selectInsufficientBalance(getState());
+	if (!isApproved || insufficientBalance) {
+		return {
+			transactionFee: '0',
+			feeCost: '0',
+		};
+	}
 
 	if (baseCurrencyKey && quoteCurrencyKey) {
 		const [transactionFee, feeCost] = await Promise.all([

--- a/utils/logError.ts
+++ b/utils/logError.ts
@@ -3,5 +3,15 @@ import * as Sentry from '@sentry/browser';
 export default function logError(err: Error): void {
 	// eslint-disable-next-line no-console
 	console.error(err);
-	Sentry.captureException(err);
+	if (!sentrySkipFilter(err)) {
+		Sentry.captureException(err);
+	}
 }
+
+const sentrySkipFilter = (e: Error) => {
+	return IGNORE_ERRORS.some((text) => {
+		return e.message?.toLowerCase().includes(text.toLowerCase());
+	});
+};
+
+export const IGNORE_ERRORS = ['Insufficient margin', 'Network request failed', 'timeout exceeded'];


### PR DESCRIPTION
## Motivation and Context
There are errors when inputting exchange values if the user hasn't approved the token spend or if the amount is more than balance.

This PR ensures the fee estimate will only be called when in a valid state, preventing the errors.
