### PR TITLE
Separate isolated margin account data by network

### DIFF
--- a/sections/futures/CrossMarginOnboard/CrossMarginOnboard.tsx
+++ b/sections/futures/CrossMarginOnboard/CrossMarginOnboard.tsx
@@ -26,7 +26,7 @@ import {
 	selectCMBalance,
 	selectCMDepositApproved,
 	selectCrossMarginAccount,
-	selectCrossMarginSupportedNetwork,
+	selectFuturesSupportedNetwork,
 	selectSubmittingFuturesTx,
 } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
@@ -48,7 +48,7 @@ export default function CrossMarginOnboard({ onClose, isOpen }: Props) {
 	const { provider } = Connector.useContainer();
 	const dispatch = useAppDispatch();
 	const balances = useAppSelector(selectBalances);
-	const crossMarginAvailable = useAppSelector(selectCrossMarginSupportedNetwork);
+	const crossMarginAvailable = useAppSelector(selectFuturesSupportedNetwork);
 	const crossMarginAccount = useAppSelector(selectCrossMarginAccount);
 	const queryStatus = useAppSelector(selectCMAccountQueryStatus);
 	const depositApproved = useAppSelector(selectCMDepositApproved);

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -39,7 +39,7 @@ const FeeInfoBox: React.FC = () => {
 	const stakedKwentaBalance = useAppSelector(selectStakedKwentaBalance);
 	const crossMarginFees = useAppSelector(selectCrossMarginTradeFees);
 	const isolatedMarginFee = useAppSelector(selectIsolatedMarginFee);
-	const { nativeSizeDelta, susdSizeDelta } = useAppSelector(selectTradeSizeInputs);
+	const { susdSizeDelta } = useAppSelector(selectTradeSizeInputs);
 	const accountType = useAppSelector(selectFuturesType);
 	const { tradeFee: crossMarginTradeFeeRate, limitOrderFee, stopOrderFee } = useAppSelector(
 		selectCrossMarginSettings
@@ -79,7 +79,7 @@ const FeeInfoBox: React.FC = () => {
 				</Tooltip>
 			</CostContainer>
 		),
-		[t, orderFee, makerFee, takerFee, nativeSizeDelta]
+		[t, makerFee, takerFee]
 	);
 
 	const isRewardEligible = useMemo(

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -53,7 +53,7 @@ const FeeInfoBox: React.FC = () => {
 		return commitDeposit.add(marketInfo?.keeperDeposit ?? zeroBN);
 	}, [commitDeposit, marketInfo?.keeperDeposit]);
 
-	const { orderFee, makerFee, takerFee } = useMemo(
+	const { makerFee, takerFee } = useMemo(
 		() => computeOrderFee(marketInfo, susdSizeDelta, orderType),
 		[marketInfo, susdSizeDelta, orderType]
 	);

--- a/sections/futures/TradeCrossMargin/TradeCrossMargin.tsx
+++ b/sections/futures/TradeCrossMargin/TradeCrossMargin.tsx
@@ -13,7 +13,7 @@ import {
 	selectCrossMarginAccount,
 	selectCrossMarginBalanceInfo,
 	selectCrossMarginOrderPrice,
-	selectCrossMarginSupportedNetwork,
+	selectFuturesSupportedNetwork,
 	selectCrossMarginTransferOpen,
 	selectFuturesType,
 	selectLeverageSide,
@@ -48,7 +48,7 @@ export default function TradeCrossMargin({ isMobile }: Props) {
 	const orderType = useAppSelector(selectOrderType);
 	const orderPrice = useAppSelector(selectCrossMarginOrderPrice);
 	const openTransferModal = useAppSelector(selectCrossMarginTransferOpen);
-	const crossMarginAvailable = useAppSelector(selectCrossMarginSupportedNetwork);
+	const crossMarginAvailable = useAppSelector(selectFuturesSupportedNetwork);
 	const crossMarginAddress = useAppSelector(selectCrossMarginAccount);
 	const queryStatus = useAppSelector(selectCMAccountQueryStatus);
 	const showOnboard = useAppSelector(selectShowCrossMarginOnboard);

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -89,7 +89,6 @@ import {
 	selectCrossMarginOrderPrice,
 	selectCrossMarginSelectedLeverage,
 	selectCrossMarginSettings,
-	selectCrossMarginSupportedNetwork,
 	selectCrossMarginTradeFees,
 	selectCrossMarginTradeInputs,
 	selectFuturesAccount,
@@ -161,7 +160,7 @@ export const fetchCrossMarginBalanceInfo = createAsyncThunk<
 		const account = selectCrossMarginAccount(getState());
 		const network = selectNetwork(getState());
 		const wallet = selectWallet(getState());
-		const crossMarginSupported = selectCrossMarginSupportedNetwork(getState());
+		const crossMarginSupported = selectFuturesSupportedNetwork(getState());
 		if (!account || !wallet || !crossMarginSupported) return;
 		try {
 			const balanceInfo = await sdk.futures.getCrossMarginBalanceInfo(wallet, account);
@@ -180,7 +179,7 @@ export const fetchCrossMarginSettings = createAsyncThunk<
 	void,
 	ThunkConfig
 >('futures/fetchCrossMarginSettings', async (_, { getState, extra: { sdk } }) => {
-	const supportedNetwork = selectCrossMarginSupportedNetwork(getState());
+	const supportedNetwork = selectFuturesSupportedNetwork(getState());
 	if (!supportedNetwork) return;
 	try {
 		const settings = await sdk.futures.getCrossMarginSettings();
@@ -211,7 +210,7 @@ export const fetchCrossMarginPositions = createAsyncThunk<
 >('futures/fetchCrossMarginPositions', async (_, { getState, extra: { sdk } }) => {
 	const { futures } = getState();
 	const account = selectCrossMarginAccount(getState());
-	const supportedNetwork = selectCrossMarginSupportedNetwork(getState());
+	const supportedNetwork = selectFuturesSupportedNetwork(getState());
 	const network = selectNetwork(getState());
 
 	if (!account || !supportedNetwork) return;
@@ -232,12 +231,14 @@ export const fetchCrossMarginPositions = createAsyncThunk<
 });
 
 export const fetchIsolatedMarginPositions = createAsyncThunk<
-	{ positions: FuturesPosition<string>[]; wallet: string } | undefined,
+	{ positions: FuturesPosition<string>[]; wallet: string; network: NetworkId } | undefined,
 	void,
 	ThunkConfig
 >('futures/fetchIsolatedMarginPositions', async (_, { getState, extra: { sdk } }) => {
 	const { wallet, futures } = getState();
 	const supportedNetwork = selectFuturesSupportedNetwork(getState());
+	const network = selectNetwork(getState());
+
 	if (!wallet.walletAddress || !supportedNetwork) return;
 	try {
 		const positions = await sdk.futures.getFuturesPositions(
@@ -247,6 +248,7 @@ export const fetchIsolatedMarginPositions = createAsyncThunk<
 		return {
 			positions: positions.map((p) => serializeWeiObject(p) as FuturesPosition<string>),
 			wallet: wallet.walletAddress,
+			network: network,
 		};
 	} catch (err) {
 		logError(err);
@@ -256,13 +258,19 @@ export const fetchIsolatedMarginPositions = createAsyncThunk<
 });
 
 export const refetchPosition = createAsyncThunk<
-	{ position: FuturesPosition<string>; wallet: string; futuresType: FuturesAccountType } | null,
+	{
+		position: FuturesPosition<string>;
+		wallet: string;
+		futuresType: FuturesAccountType;
+		networkId: NetworkId;
+	} | null,
 	FuturesAccountType,
 	ThunkConfig
 >('futures/refetchPosition', async (type, { getState, extra: { sdk } }) => {
 	const account = selectFuturesAccount(getState());
 	if (!account) throw new Error('No wallet connected');
 	const marketInfo = selectMarketInfo(getState());
+	const networkId = selectNetwork(getState());
 	const position = selectPosition(getState());
 	if (!marketInfo || !position) throw new Error('Market or position not found');
 
@@ -281,7 +289,7 @@ export const refetchPosition = createAsyncThunk<
 		const serialized = serializeWeiObject(result.data[0] as FuturesPosition) as FuturesPosition<
 			string
 		>;
-		return { position: serialized, wallet: account, futuresType: type };
+		return { position: serialized, wallet: account, futuresType: type, networkId };
 	}
 	return null;
 });
@@ -292,7 +300,7 @@ export const fetchCrossMarginAccount = createAsyncThunk<
 	ThunkConfig
 >('futures/fetchCrossMarginAccount', async (_, { getState, extra: { sdk }, rejectWithValue }) => {
 	const wallet = selectWallet(getState());
-	const supportedNetwork = selectCrossMarginSupportedNetwork(getState());
+	const supportedNetwork = selectFuturesSupportedNetwork(getState());
 	const network = selectNetwork(getState());
 	if (!wallet || !supportedNetwork) return undefined;
 	const accounts = getState().futures.crossMargin.accounts;
@@ -352,7 +360,7 @@ export const fetchSharedFuturesData = createAsyncThunk<void, void, ThunkConfig>(
 );
 
 export const fetchIsolatedOpenOrders = createAsyncThunk<
-	{ orders: DelayedOrderWithDetails<string>[]; wallet: string; network: NetworkId } | undefined,
+	{ orders: DelayedOrderWithDetails<string>[]; wallet: string; networkId: NetworkId } | undefined,
 	void,
 	ThunkConfig
 >('futures/fetchIsolatedOpenOrders', async (_, { getState, extra: { sdk } }) => {
@@ -387,7 +395,7 @@ export const fetchIsolatedOpenOrders = createAsyncThunk<
 			return acc;
 		}, [] as DelayedOrderWithDetails[]);
 	return {
-		network,
+		networkId: network,
 		orders: serializeDelayedOrders(nonzeroOrders),
 		wallet: wallet,
 	};

--- a/state/futures/hooks.ts
+++ b/state/futures/hooks.ts
@@ -15,7 +15,6 @@ import {
 } from './actions';
 import {
 	selectCrossMarginAccount,
-	selectCrossMarginSupportedNetwork,
 	selectFuturesSupportedNetwork,
 	selectFuturesType,
 	selectMarkets,
@@ -29,7 +28,7 @@ export const usePollMarketFuturesData = () => {
 	const wallet = useAppSelector(selectWallet);
 	const crossMarginAddress = useAppSelector(selectCrossMarginAccount);
 	const selectedAccountType = useAppSelector(selectFuturesType);
-	const networkSupportsCrossMargin = useAppSelector(selectCrossMarginSupportedNetwork);
+	const networkSupportsCrossMargin = useAppSelector(selectFuturesSupportedNetwork);
 	const networkSupportsFutures = useAppSelector(selectFuturesSupportedNetwork);
 
 	useFetchAction(fetchCrossMarginAccount, {
@@ -82,7 +81,7 @@ export const usePollDashboardFuturesData = () => {
 	const markets = useAppSelector(selectMarkets);
 	const wallet = useAppSelector(selectWallet);
 	const crossMarginAddress = useAppSelector(selectCrossMarginAccount);
-	const networkSupportsCrossMargin = useAppSelector(selectCrossMarginSupportedNetwork);
+	const networkSupportsCrossMargin = useAppSelector(selectFuturesSupportedNetwork);
 
 	useFetchAction(fetchCrossMarginAccount, {
 		dependencies: [networkId, wallet],

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -56,9 +56,6 @@ export const selectIsolatedLeverageInput = (state: RootState) =>
 export const selectCrossMarginMarginDelta = (state: RootState) =>
 	wei(state.futures.crossMargin.marginDelta || 0);
 
-export const selectCrossMarginSupportedNetwork = (state: RootState) =>
-	state.wallet.networkId === 10 || state.wallet.networkId === 420;
-
 export const selectFuturesSupportedNetwork = (state: RootState) =>
 	state.wallet.networkId === 10 || state.wallet.networkId === 420;
 
@@ -76,10 +73,20 @@ export const selectSelectedTrader = (state: RootState) => state.futures.leaderbo
 export const selectCrossMarginAccountData = createSelector(
 	selectWallet,
 	selectNetwork,
-	selectCrossMarginSupportedNetwork,
+	selectFuturesSupportedNetwork,
 	(state: RootState) => state.futures.crossMargin,
 	(wallet, network, supportedNetwork, crossMargin) => {
 		return wallet && supportedNetwork ? crossMargin.accounts[network][wallet] : null;
+	}
+);
+
+export const selectIsolatedAccountData = createSelector(
+	selectWallet,
+	selectNetwork,
+	selectFuturesSupportedNetwork,
+	(state: RootState) => state.futures.isolatedMargin,
+	(wallet, network, supportedNetwork, isolatedMargin) => {
+		return wallet && supportedNetwork ? isolatedMargin.accounts[network][wallet] : null;
 	}
 );
 
@@ -193,24 +200,20 @@ export const selectFuturesAccount = createSelector(
 export const selectCrossMarginPositions = createSelector(
 	selectCrossMarginAccountData,
 	(account) => {
-		return account
-			? account.positions.map(
-					// TODO: Maybe change to explicit serializing functions to avoid casting
-					(p) => deserializeWeiObject(p, futuresPositionKeys) as FuturesPosition
-			  )
-			: [];
+		return (
+			account?.positions?.map(
+				// TODO: Maybe change to explicit serializing functions to avoid casting
+				(p) => deserializeWeiObject(p, futuresPositionKeys) as FuturesPosition
+			) ?? []
+		);
 	}
 );
 
 export const selectIsolatedMarginPositions = createSelector(
-	selectWallet,
 	selectPrices,
-	(state: RootState) => state.futures,
-	(wallet, prices, futures) => {
-		if (!wallet) return [];
-		return futures.isolatedMargin.positions[wallet]
-			? futures.isolatedMargin.positions[wallet].map((p) => updatePositionUpnl(p, prices))
-			: [];
+	selectIsolatedAccountData,
+	(prices, account) => {
+		return account?.positions?.map((p) => updatePositionUpnl(p, prices)) ?? [];
 	}
 );
 
@@ -567,14 +570,8 @@ export const selectCrossMarginOpenOrders = createSelector(
 	}
 );
 
-export const selectIsolatedMarginOpenOrders = createSelector(
-	selectWallet,
-	(state: RootState) => state.futures,
-	(wallet, futures) => {
-		return wallet && futures.isolatedMargin.openOrders[wallet]
-			? unserializeDelayedOrders(futures.isolatedMargin.openOrders[wallet])
-			: [];
-	}
+export const selectIsolatedMarginOpenOrders = createSelector(selectIsolatedAccountData, (account) =>
+	unserializeDelayedOrders(account?.openOrders ?? [])
 );
 
 export const selectTradePreview = createSelector(
@@ -711,16 +708,14 @@ export const selectOpenInterest = createSelector(selectMarkets, (futuresMarkets)
 );
 export const selectPositionHistory = createSelector(
 	selectFuturesType,
-	selectFuturesAccount,
 	selectCrossMarginAccountData,
-	(state: RootState) => state.futures,
-	(type, account, accountData, futures) => {
+	selectIsolatedAccountData,
+	(type, crossAccountData, isolatedAccountData) => {
 		if (type === 'cross_margin') {
-			return unserializePositionHistory(accountData?.positionHistory ?? []);
-		} else if (account) {
-			return unserializePositionHistory(futures.isolatedMargin.positionHistory[account] ?? []);
+			return unserializePositionHistory(crossAccountData?.positionHistory ?? []);
+		} else {
+			return unserializePositionHistory(isolatedAccountData?.positionHistory ?? []);
 		}
-		return [];
 	}
 );
 
@@ -749,13 +744,13 @@ export const selectUsersTradesForMarket = createSelector(
 	selectFuturesAccount,
 	selectMarketAsset,
 	selectCrossMarginAccountData,
-	(state: RootState) => state.futures,
-	(type, account, asset, accountData, futures) => {
+	selectIsolatedAccountData,
+	(type, account, asset, crossAccountData, isolatedAccountData) => {
 		let trades;
 		if (type === 'cross_margin') {
-			trades = unserializeTrades(accountData?.trades ?? []);
+			trades = unserializeTrades(crossAccountData?.trades ?? []);
 		} else if (account) {
-			trades = unserializeTrades(futures.isolatedMargin.trades?.[account] ?? []);
+			trades = unserializeTrades(isolatedAccountData?.trades ?? []);
 		}
 		return trades?.filter((t) => t.asset === formatBytes32String(asset)) ?? [];
 	}
@@ -763,16 +758,14 @@ export const selectUsersTradesForMarket = createSelector(
 
 export const selectAllUsersTrades = createSelector(
 	selectFuturesType,
-	selectFuturesAccount,
 	selectCrossMarginAccountData,
-	(state: RootState) => state.futures,
-	(type, account, accountData, futures) => {
+	selectIsolatedAccountData,
+	(type, crossAccountData, isolatedAccountData) => {
 		if (type === 'cross_margin') {
-			return unserializeTrades(accountData?.trades ?? []);
-		} else if (account) {
-			return unserializeTrades(futures.isolatedMargin.trades?.[account] ?? []);
+			return unserializeTrades(crossAccountData?.trades ?? []);
+		} else {
+			return unserializeTrades(isolatedAccountData?.trades ?? []);
 		}
-		return [];
 	}
 );
 

--- a/state/futures/types.ts
+++ b/state/futures/types.ts
@@ -14,7 +14,7 @@ import {
 	FuturesVolumes,
 	IsolatedMarginOrderType,
 	PositionSide,
-	FuturesOrder,
+	FuturesOrder as CrossMarginOrder,
 } from 'sdk/types/futures';
 import { QueryStatus } from 'state/types';
 import { FuturesMarketAsset, FuturesMarketKey } from 'utils/futures';
@@ -124,18 +124,25 @@ type FuturesErrors = {
 	tradePreview?: string | undefined | null;
 };
 
-type CrossMarginNetwork = number;
+type FuturesNetwork = number;
 
 export type InputCurrencyDenomination = 'usd' | 'native';
 
-export type CrossMarginAccount = {
-	account: string;
+export type FuturesAccountData = {
 	position?: FuturesPosition<string>;
+	positions?: FuturesPosition<string>[];
+	positionHistory?: FuturesPositionHistory<string>[];
+	trades?: FuturesTrade<string>[];
+};
+
+export type IsolatedAccountData = FuturesAccountData & {
+	openOrders?: DelayedOrderWithDetails<string>[];
+};
+
+export type CrossMarginAccountData = FuturesAccountData & {
+	account: string;
 	balanceInfo: CrossMarginBalanceInfo<string>;
-	positions: FuturesPosition<string>[];
-	openOrders: FuturesOrder<string>[];
-	positionHistory: FuturesPositionHistory<string>[];
-	trades: FuturesTrade<string>[];
+	openOrders: CrossMarginOrder<string>[];
 };
 
 // TODO: Separate in some way by network and wallet
@@ -157,7 +164,7 @@ export type FuturesState = {
 	leaderboard: {
 		selectedTrader: string | undefined;
 		selectedTraderPositionHistory: Record<
-			CrossMarginNetwork,
+			FuturesNetwork,
 			{
 				[wallet: string]: FuturesPositionHistory<string>[];
 			}
@@ -187,9 +194,9 @@ export type CrossMarginState = {
 	cancellingOrder: string | undefined;
 	showOnboard: boolean;
 	accounts: Record<
-		CrossMarginNetwork,
+		FuturesNetwork,
 		{
-			[wallet: string]: CrossMarginAccount;
+			[wallet: string]: CrossMarginAccountData;
 		}
 	>;
 
@@ -210,19 +217,12 @@ export type IsolatedMarginState = {
 	leverageInput: string;
 	priceImpact: string;
 	tradeFee: string;
-	// TODO: Update to map by network similar to cross margin
-	positions: {
-		[account: string]: FuturesPosition<string>[];
-	};
-	positionHistory: {
-		[account: string]: FuturesPositionHistory<string>[];
-	};
-	openOrders: {
-		[account: string]: DelayedOrderWithDetails<string>[];
-	};
-	trades: {
-		[account: string]: FuturesTrade<string>[];
-	};
+	accounts: Record<
+		FuturesNetwork,
+		{
+			[wallet: string]: IsolatedAccountData;
+		}
+	>;
 };
 
 export type ModifyIsolatedPositionInputs = {

--- a/state/futures/types.ts
+++ b/state/futures/types.ts
@@ -213,7 +213,6 @@ export type IsolatedMarginState = {
 	leverageSide: PositionSide;
 	selectedMarketKey: FuturesMarketKey;
 	selectedMarketAsset: FuturesMarketAsset;
-	position?: FuturesPosition<string>;
 	leverageInput: string;
 	priceImpact: string;
 	tradeFee: string;

--- a/state/migrations.ts
+++ b/state/migrations.ts
@@ -7,6 +7,12 @@ export const migrations = {
 			futures: INITIAL_STATE,
 		};
 	},
+	4: (state: any) => {
+		return {
+			...state,
+			futures: INITIAL_STATE,
+		};
+	},
 };
 
 export default migrations;

--- a/state/store.ts
+++ b/state/store.ts
@@ -34,7 +34,7 @@ const LOG_REDUX = process.env.NODE_ENV !== 'production';
 const persistConfig = {
 	key: 'root1',
 	storage,
-	version: 3,
+	version: 4,
 	blacklist: ['app', 'wallet'],
 	migrate: createMigrate(migrations, { debug: true }),
 };


### PR DESCRIPTION
### Motivation and Context
Incorrect data is displayed from the previous chain when switching to a non supported chain and toggling chain feels laggy in updating to the correct data.

### Implementation
Storing isolated margin account data state by network allows us to persist data between networks switches ensuring things feel snappy and that correct data is displayed on the selected chain.

