### PR TITLE
Disable sentry v1 app

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -55,6 +55,7 @@ Sentry.init({
 	autoSessionTracking: true,
 	integrations: [new BrowserTracing()],
 	tracesSampleRate: 0.3,
+	enabled: false, // Disabling on V1 as dropping support
 });
 
 const InnerApp: FC<AppProps> = ({ Component, pageProps }: AppPropsWithLayout) => {


### PR DESCRIPTION
## Description
Disable Sentry on v1 to reduce noise of errors as we'll no longer be maintaining this version.