### PR TITLE
Update fee info box and remove v2 warning

### DIFF
--- a/components/Tooltip/BaseTooltip.tsx
+++ b/components/Tooltip/BaseTooltip.tsx
@@ -32,6 +32,7 @@ export const BaseTooltip = styled.div<BaseTooltipProps>`
 	z-index: 2;
 
 	p, span {
+		margin: 0;
 		font-size: 13px;
 		font-family: ${(props) => props.theme.fonts.regular};
 		color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
@@ -43,7 +44,6 @@ export const BaseTooltip = styled.div<BaseTooltipProps>`
 			top: 0;
 			left: 50%;
 			transform: translate(-50%, -150%);
-			text-align: center;
 			display: inline-block;
 		`}
 

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -225,7 +225,7 @@ const PeriodLabel = styled.div`
 `;
 
 const CustomStyledTooltip = styled(Tooltip)`
-	padding: 0px 10px 0px;
+	padding: 10px;
 	${media.lessThan('md')`
 		width: 310px;
 		left: -5px;

--- a/sections/futures/FeeInfoBox/FeeInfoBox.tsx
+++ b/sections/futures/FeeInfoBox/FeeInfoBox.tsx
@@ -191,7 +191,7 @@ const FeeInfoBox: React.FC = () => {
 								: NO_VALUE,
 							keyNode: executionFeeTooltip,
 						},
-						[`Est Trade Fee (${formatPercent(makerFee ?? zeroBN)} / ${formatPercent(
+						[`Est. Trade Fee (${formatPercent(makerFee ?? zeroBN)} / ${formatPercent(
 							takerFee ?? zeroBN
 						)})`]: {
 							value: !!commitDeposit

--- a/sections/futures/OrderPriceInput/OrderPriceInput.tsx
+++ b/sections/futures/OrderPriceInput/OrderPriceInput.tsx
@@ -110,7 +110,7 @@ export default function OrderPriceInput({
 				<Tooltip
 					width={'310px'}
 					height="auto"
-					style={{ padding: '0 15px', textTransform: 'none' }}
+					style={{ padding: '15px', textTransform: 'none' }}
 					content={t('futures.market.trade.orders.fee-rejection-tooltip')}
 				>
 					<FeeRejectionLabel>

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -453,7 +453,7 @@ const SubtitleWithCursor = styled(Subtitle)`
 
 const PositionCardTooltip = styled(Tooltip).attrs({ preset: 'fixed', height: 'auto' })`
 	z-index: 2;
-	padding: 0px 10px 0px 10px;
+	padding: 10px;
 `;
 
 const StyledValue = styled(Body).attrs({ mono: true })`

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -2,12 +2,14 @@ import { FC, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import HelpIcon from 'assets/svg/app/question-mark.svg';
 import BaseModal from 'components/BaseModal';
 import Button from 'components/Button';
 import Error from 'components/ErrorView';
 import { FlexDivCentered } from 'components/layout/flex';
 import { ButtonLoader } from 'components/Loader/Loader';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import Tooltip from 'components/Tooltip/Tooltip';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { PositionSide } from 'sdk/types/futures';
 import { getDisplayAsset, OrderNameByType } from 'sdk/utils/futures';
@@ -98,6 +100,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 			},
 			{
 				label: t('futures.market.user.position.modal.estimated-fill'),
+				tooltipContent: t('futures.market.trade.delayed-order.description'),
 				value: formatDollars(potentialTradeDetails?.price ?? zeroBN, { isAssetPrice: true }),
 			},
 			{
@@ -179,7 +182,21 @@ const DelayedOrderConfirmationModal: FC = () => {
 				>
 					{dataRows.map((row, i) => (
 						<Row key={`datarow-${i}`}>
-							<Label>{row.label}</Label>
+							{row.tooltipContent ? (
+								<Tooltip
+									height="auto"
+									width="240px"
+									content={row.tooltipContent}
+									style={{ textTransform: 'none' }}
+								>
+									<Label>
+										{row.label}
+										<StyledHelpIcon />
+									</Label>
+								</Tooltip>
+							) : (
+								<Label>{row.label}</Label>
+							)}
 							<Value>
 								<span className={`value ${row.color ?? ''}`}>{row.value}</span>
 							</Value>
@@ -285,6 +302,10 @@ const Disclaimer = styled.div`
 	color: ${(props) => props.theme.colors.selectedTheme.gray};
 	margin-top: 12px;
 	margin-bottom: 12px;
+`;
+
+const StyledHelpIcon = styled(HelpIcon)`
+	margin-left: 8px;
 `;
 
 export default DelayedOrderConfirmationModal;

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -136,6 +136,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 			},
 			{
 				label: t('futures.market.user.position.modal.deposit'),
+				tooltipContent: t('futures.market.trade.confirmation.modal.delayed-disclaimer'),
 				value: formatDollars(totalDeposit),
 			},
 		],
@@ -185,7 +186,7 @@ const DelayedOrderConfirmationModal: FC = () => {
 							{row.tooltipContent ? (
 								<Tooltip
 									height="auto"
-									width="240px"
+									width="250px"
 									content={row.tooltipContent}
 									style={{ textTransform: 'none' }}
 								>
@@ -216,7 +217,6 @@ const DelayedOrderConfirmationModal: FC = () => {
 							t('futures.market.trade.confirmation.modal.confirm-order')
 						)}
 					</ConfirmTradeButton>
-					<Disclaimer>{t('futures.market.trade.confirmation.modal.delayed-disclaimer')}</Disclaimer>
 					{txError && <Error message={getKnownError(txError)} formatter="revert" />}
 				</StyledBaseModal>
 			</DesktopOnlyView>
@@ -249,9 +249,6 @@ const DelayedOrderConfirmationModal: FC = () => {
 const StyledBaseModal = styled(BaseModal)`
 	[data-reach-dialog-content] {
 		width: 400px;
-	}
-	.card-body {
-		padding: 28px;
 	}
 `;
 
@@ -290,7 +287,6 @@ const Value = styled.div`
 
 const ConfirmTradeButton = styled(Button)`
 	margin-top: 24px;
-	margin-bottom: 12px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
@@ -305,6 +301,7 @@ const Disclaimer = styled.div`
 `;
 
 const StyledHelpIcon = styled(HelpIcon)`
+	margin-bottom: -1px;
 	margin-left: 8px;
 `;
 

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -12,6 +12,7 @@ import Connector from 'containers/Connector';
 import useFuturesMarketClosed, { FuturesClosureReason } from 'hooks/useFuturesMarketClosed';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
 import { Rates } from 'queries/rates/types';
+import { getDisplayAsset } from 'sdk/utils/futures';
 import {
 	selectMarketAsset,
 	selectMarkets,
@@ -105,7 +106,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	);
 
 	const getPastPrice = React.useCallback(
-		(asset: string) => pastRates.find((price) => price.synth === asset),
+		(asset: string) => pastRates.find((price) => price.synth === getDisplayAsset(asset)),
 		[pastRates]
 	);
 

--- a/sections/futures/Trade/MarketsDropdownOption.tsx
+++ b/sections/futures/Trade/MarketsDropdownOption.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components';
 import MarketBadge from 'components/Badge/MarketBadge';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { FlexDivCentered } from 'components/layout/flex';
+import { Body } from 'components/Text';
 
 import { MarketsCurrencyOption } from './MarketsDropdown';
 import { CurrencyLabel, SingleValueContainer } from './MarketsDropdownSingleValue';
@@ -11,42 +12,43 @@ import { CurrencyLabel, SingleValueContainer } from './MarketsDropdownSingleValu
 const MarketsDropdownOption: React.FC<OptionProps<MarketsCurrencyOption>> = (props) => (
 	<components.Option {...props}>
 		<OptionDetailsContainer $isSelected={props.isSelected}>
-			<CurrencyIcon
-				currencyKey={(props.data.value[0] !== 's' ? 's' : '') + props.data.value}
-				width="31px"
-				height="31px"
-			/>
 			<CurrencyMeta $isSelected={props.isSelected}>
-				<div>
-					<StyledCurrencyLabel>
-						{props.data.label}
-						<MarketBadge
-							currencyKey={props.data.value}
-							isFuturesMarketClosed={props.data.isFuturesMarketClosed}
-							futuresClosureReason={props.data.futuresClosureReason}
-						/>
-					</StyledCurrencyLabel>
-					<p className="name">{props.data.description}</p>
-				</div>
+				<CurrencyIcon
+					currencyKey={(props.data.value[0] !== 's' ? 's' : '') + props.data.value}
+					width="24px"
+					height="24px"
+				/>
+				<StyledCurrencyLabel>
+					{props.data.label}
+					<MarketBadge
+						currencyKey={props.data.value}
+						isFuturesMarketClosed={props.data.isFuturesMarketClosed}
+						futuresClosureReason={props.data.futuresClosureReason}
+					/>
+				</StyledCurrencyLabel>
 			</CurrencyMeta>
-			<div>
-				<p className={props.data.negativeChange ? 'price red' : 'price green'}>
+			<PriceLabel>
+				<Body className={props.data.negativeChange ? 'price red' : 'price green'}>
 					{props.data.price}
-				</p>
-				<p className={props.data.negativeChange ? `change red` : 'change green'}>
+				</Body>
+			</PriceLabel>
+			<div>
+				{' '}
+				<Body className={props.data.negativeChange ? `change red` : 'change green'}>
 					{props.data.change}
-				</p>
+				</Body>
 			</div>
 		</OptionDetailsContainer>
 	</components.Option>
 );
 
 const StyledCurrencyLabel = styled(CurrencyLabel)`
-	color: ${(props) => props.theme.colors.selectedTheme.gray};
+	color: ${(props) => props.theme.colors.selectedTheme.white};
+	font-size: 13px;
 `;
 const CurrencyMeta = styled(FlexDivCentered)<{ $isSelected: boolean }>`
-	flex: 1;
-	margin-left: 12px;
+	gap: 7px;
+	width: 125px;
 
 	${(props) =>
 		props.$isSelected &&
@@ -58,8 +60,14 @@ const CurrencyMeta = styled(FlexDivCentered)<{ $isSelected: boolean }>`
 		`}
 `;
 
+const PriceLabel = styled.div`
+	flex: 1;
+`;
+
 const OptionDetailsContainer = styled(SingleValueContainer)<{ $isSelected: boolean }>`
-	padding: 6px;
+	padding: 7px;
+	justify-content: space-between;
+	gap: 5px;
 
 	p {
 		margin: 0;
@@ -68,12 +76,12 @@ const OptionDetailsContainer = styled(SingleValueContainer)<{ $isSelected: boole
 	.price {
 		font-family: ${(props) => props.theme.fonts.mono};
 		color: ${(props) => props.theme.colors.selectedTheme.gray};
-		font-size: 15px;
+		font-size: 13px;
 	}
 
 	.change {
 		font-family: ${(props) => props.theme.fonts.mono};
-		font-size: 11.5px;
+		font-size: 13px;
 		text-align: right;
 	}
 

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -4,12 +4,14 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import HelpIcon from 'assets/svg/app/question-mark.svg';
 import BaseModal from 'components/BaseModal';
 import Button from 'components/Button';
 import ErrorView from 'components/ErrorView';
 import { FlexDivCentered } from 'components/layout/flex';
 import { ButtonLoader } from 'components/Loader/Loader';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import Tooltip from 'components/Tooltip/Tooltip';
 import { MIN_MARGIN_AMOUNT } from 'constants/futures';
 import { PositionSide } from 'sdk/types/futures';
 import {
@@ -113,6 +115,7 @@ export default function TradeConfirmationModal({
 				  },
 			{
 				label: 'price impact',
+				tooltipContent: t('futures.market.trade.delayed-order.description'),
 				value: `${formatPercent(potentialTradeDetails?.priceImpact ?? zeroBN)}`,
 				color: potentialTradeDetails?.priceImpact.abs().gt(0.45) // TODO: Make this configurable
 					? 'red'
@@ -144,6 +147,7 @@ export default function TradeConfirmationModal({
 				: null,
 		],
 		[
+			t,
 			positionDetails,
 			marketAsset,
 			keeperFee,
@@ -173,7 +177,23 @@ export default function TradeConfirmationModal({
 						if (!row) return null;
 						return (
 							<Row key={`datarow-${i}`}>
-								<Label>{row.label}</Label>
+								{row.tooltipContent ? (
+									<Tooltip
+										height="auto"
+										preset="bottom"
+										width="300px"
+										content={row.tooltipContent}
+										style={{ padding: 10, textTransform: 'none' }}
+									>
+										<Label>
+											{row.label}
+											<StyledHelpIcon />
+										</Label>
+									</Tooltip>
+								) : (
+									<Label>{row.label}</Label>
+								)}
+
 								<Value>
 									<span className={row.color ? `value ${row.color}` : ''}>{row.value}</span>
 								</Value>
@@ -286,4 +306,8 @@ export const MobileConfirmTradeButton = styled(Button)`
 
 const ErrorContainer = styled.div`
 	margin-top: 20px;
+`;
+
+const StyledHelpIcon = styled(HelpIcon)`
+	margin-left: 8px;
 `;

--- a/sections/futures/Trade/TradeIsolatedMargin.tsx
+++ b/sections/futures/Trade/TradeIsolatedMargin.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from 'react-i18next';
-
 import Error from 'components/ErrorView';
 import SegmentedControl from 'components/SegmentedControl';
 import { DEFAULT_DELAYED_LEVERAGE_CAP, ISOLATED_MARGIN_ORDER_TYPES } from 'constants/futures';
@@ -16,7 +14,6 @@ import MarketInfoBox from '../MarketInfoBox';
 import OrderSizing from '../OrderSizing';
 import PositionButtons from '../PositionButtons';
 import ManagePosition from './ManagePosition';
-import OrderWarning from './OrderWarning';
 import TradePanelHeader from './TradePanelHeader';
 
 type Props = {
@@ -24,7 +21,6 @@ type Props = {
 };
 
 const TradeIsolatedMargin = ({ isMobile }: Props) => {
-	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
 	const leverageSide = useAppSelector(selectLeverageSide);
@@ -43,8 +39,6 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 				<Error message="Failed to connect to price feed. Please try disabling any add blockers and refresh." />
 			)}
 
-			<Error messageType="warn" message={t('futures.market.trade.perpsv2-disclaimer')} />
-
 			{!isMobile && <MarketInfoBox />}
 
 			{position?.position && position.position.leverage.gte(DEFAULT_DELAYED_LEVERAGE_CAP) && (
@@ -58,8 +52,6 @@ const TradeIsolatedMargin = ({ isMobile }: Props) => {
 					}}
 				/>
 			)}
-
-			<OrderWarning />
 
 			<PositionButtons
 				selected={leverageSide}

--- a/sections/shared/components/FeeRateSummary.tsx
+++ b/sections/shared/components/FeeRateSummary.tsx
@@ -54,7 +54,7 @@ export const DynamicFeeLabel = styled.span`
 
 const CustomStyledTooltip = styled(Tooltip)`
 	width: 300px;
-	padding: 0px 4px;
+	padding: 4px;
 	text-align: center;
 `;
 

--- a/sections/shared/modals/TxConfirmationModal.tsx
+++ b/sections/shared/modals/TxConfirmationModal.tsx
@@ -322,13 +322,13 @@ const CustomStyledTooltip = styled(Tooltip)`
 
 const ExchangeFeeHintTooltip = styled(Tooltip)`
 	width: 240px;
-	padding: 0px 10px;
+	padding: 10px;
 	margin: 0px 0px 0px 40px;
 `;
 
 const PriceAdjustmentTooltip = styled(Tooltip)`
 	width: 240px;
-	padding: 0px 10px;
+	padding: 10px;
 	margin: 0px;
 `;
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -851,7 +851,7 @@
 				},
 				"fees": {
 					"tooltip": "Fees are displayed as maker / taker. Maker fees apply to orders that reduce the market skew. Taker fees apply to orders that increase the market skew.",
-					"keeper-tooltip": "This is a fixed fee to pay for automated order execution"
+					"keeper-tooltip": "Fixed fee to cover automated order execution"
 
 				},
 				"orders": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -822,7 +822,7 @@
 						"close-order": "Close position",
 						"max-leverage-disclaimer": "Note: A next price update could cause your order to exceed maximum leverage resulting in the order being dropped by the keeper.",
 						"disabled-min-margin": "Minimum market margin of $50 required",
-						"delayed-disclaimer": "* The deposit is applied to trading fees and keeper fees on order execution. If an order is either cancelled or not executed, the deposit will be forfeit to the Synthetix debt pool."
+						"delayed-disclaimer": "The fee amount will be deposited to cover trade and automated execution fees. If an order is cancelled or not executed, the deposit will be forfeited to the Synthetix debt pool."
 					}
 				},
 				"leverage": {
@@ -908,16 +908,16 @@
 						"fee-total": "Total Fees",
 						"estimated-fill": "Estimated Fill Price",
 						"estimated-price-impact": "Estimated Price Impact",
-						"fee-estimated": "Estimated Fees",
+						"fee-estimated": "Estimated Trade Fee",
 						"liquidation-price": "Liquidation Price",
 						"time-delay": "Delay Until Executable",
-						"keeper-deposit": "Keeper Deposit",
+						"keeper-deposit": "Execution Fee",
 						"gas-fee": "Network Gas Fee",
 						"order-type": "Order Type",
 						"market-order": "Market",
 						"next-price-order": "Next Price",
 						"delayed-order": "Delayed",
-						"deposit": "Total Deposit*",
+						"deposit": "Total Fees",
 						"np-discount": "Next Price Discount"
 					}
 				},

--- a/translations/en.json
+++ b/translations/en.json
@@ -850,7 +850,9 @@
 					"error": "Error generating preview"
 				},
 				"fees": {
-					"tooltip": "Fees are displayed as maker/taker. Maker fees apply to orders that reduce the market skew. Taker fees apply to orders that increase the market skew."
+					"tooltip": "Fees are displayed as maker / taker. Maker fees apply to orders that reduce the market skew. Taker fees apply to orders that increase the market skew.",
+					"keeper-tooltip": "This is a fixed fee to pay for automated order execution"
+
 				},
 				"orders": {
 					"manage-keeper-deposit": {


### PR DESCRIPTION
### Fee info box updates
- The fee box is collapsed to a single row to show the total with an expand option to show the breakdown

<img width="416" alt="Screenshot 2023-02-06 at 11 41 45" src="https://user-images.githubusercontent.com/3802342/216976472-0f2daabf-2c0a-453c-83de-7b70c276394e.png">

<img width="419" alt="Screenshot 2023-02-06 at 12 08 55" src="https://user-images.githubusercontent.com/3802342/216976496-f4cdc7e4-3702-4168-9e78-f0550a882452.png">

- Added a tooltip for explaining the keeper fee

<img width="463" alt="Screenshot 2023-02-06 at 12 07 02" src="https://user-images.githubusercontent.com/3802342/216976620-60c2f52e-2aba-4cc6-86d1-81646a637f88.png">

### Trade panel clean up

- Remove the v2 warning
- Moved the trade price estimation blurb to a tooltip in the estimation row on confirmation modal

OLD: 
<img width="421" alt="Screenshot 2023-02-06 at 12 57 43" src="https://user-images.githubusercontent.com/3802342/216977472-fa756d57-5ddc-4ef2-8062-d5430917735f.png">

NEW:
<img width="423" alt="Screenshot 2023-02-06 at 12 57 54" src="https://user-images.githubusercontent.com/3802342/216977543-7226140a-1613-41e8-9bbb-1581451965ed.png">

### Market drop down

- Fixed price change not working
- Updated styling

<img width="344" alt="Screenshot 2023-02-06 at 18 56 00" src="https://user-images.githubusercontent.com/3802342/217062219-ead3b9fd-5034-4c74-9bec-2fe77350c688.png">

### Trade confirmation

- Moved disclaimer to a tooltip next to fees
- Fixed container padding
- Updated fees copy

<img width="437" alt="Screenshot 2023-02-07 at 07 52 32" src="https://user-images.githubusercontent.com/3802342/217186235-ef4d6167-1426-420a-9ff5-1fa18a2edadc.png">
<img width="448" alt="Screenshot 2023-02-07 at 07 49 18" src="https://user-images.githubusercontent.com/3802342/217186240-51d4ae25-db02-463c-8631-88cf96bac58b.png">


### Related issue
closes #1839 
