### PR TITLE
Fix undefined market error

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -72,7 +72,9 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 			})
 			.filter(
 				(position) =>
-					position.position && (position?.market?.asset !== currentMarket || showCurrentMarket)
+					position.position &&
+					position.market &&
+					(position?.market?.asset !== currentMarket || showCurrentMarket)
 			);
 	}, [
 		isolatedPositions,


### PR DESCRIPTION
Fixes and issue where market can be undefined in mapping position data. This filters out a position if we don't have the market. It likely only occurs if the position query and markets query is out of sync.