### PR TITLE
Replace V1 graph endpoints

### DIFF
--- a/queries/futures/constants.ts
+++ b/queries/futures/constants.ts
@@ -2,7 +2,7 @@ import { utils as ethersUtils } from 'ethers';
 import { gql } from 'graphql-request';
 import { chain } from 'wagmi';
 
-export const FUTURES_ENDPOINT_OP_MAINNET = `https://subgraph.satsuma-prod.com/${process.env.NEXT_PUBLIC_SATSUMA_API_KEY}/kwenta/optimism-futures/api`;
+export const FUTURES_ENDPOINT_OP_MAINNET = `https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures`;
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-futures';

--- a/queries/rates/constants.ts
+++ b/queries/rates/constants.ts
@@ -2,7 +2,7 @@ import { chain } from 'wagmi';
 
 export const RATES_ENDPOINT_MAIN = 'https://api.thegraph.com/subgraphs/name/kwenta/mainnet-main';
 
-export const RATES_ENDPOINT_OP_MAINNET = `https://subgraph.satsuma-prod.com/${process.env.NEXT_PUBLIC_SATSUMA_API_KEY}/kwenta/optimism-latest-rates/api`;
+export const RATES_ENDPOINT_OP_MAINNET = `https://api.thegraph.com/subgraphs/name/kwenta/optimism-latest-rates`;
 
 export const RATES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-main';

--- a/sdk/constants/futures.ts
+++ b/sdk/constants/futures.ts
@@ -1,6 +1,6 @@
 import { FuturesMarketAsset, FuturesMarketConfig, FuturesMarketKey } from 'sdk/types/futures';
 
-export const FUTURES_ENDPOINT_OP_MAINNET = `https://subgraph.satsuma-prod.com/${process.env.NEXT_PUBLIC_SATSUMA_API_KEY}/kwenta/optimism-futures/api`;
+export const FUTURES_ENDPOINT_OP_MAINNET = `https://api.thegraph.com/subgraphs/name/kwenta/optimism-futures`;
 
 export const FUTURES_ENDPOINT_OP_GOERLI =
 	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-futures';


### PR DESCRIPTION
Replace Satsuma endpoints on V1 with The Graph. This will reduce traffic to Satsuma while we deprecate the V1 markets.