### PR TITLE
chore: update v2 nav item

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/constants.tsx
+++ b/sections/shared/Layout/AppLayout/Header/constants.tsx
@@ -105,12 +105,6 @@ export const getMenuLinks = (isMobile: boolean): MenuLinks => [
 						link: EXTERNAL_LINKS.Trade.PerpsV2,
 						externalLink: true,
 						i18nLabel: 'header.nav.v2-alpha',
-						badge: [
-							{
-								i18nLabel: 'header.nav.alpha-badge',
-								color: 'red',
-							},
-						],
 						Icon: LinkIconLight,
 					},
 			  ]

--- a/translations/en.json
+++ b/translations/en.json
@@ -16,7 +16,7 @@
 			"markets": "futures",
 			"isolated-margin": "Isolated Margin",
 			"cross-margin": "Cross Margin",
-			"v2-alpha": "Try Futures V2 Alpha",
+			"v2-alpha": "Try Futures V2",
 			"leaderboard-alltime": "All Time",
 			"competition-round-1": "Round 1",
 			"competition-round-2": "Round 2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updates navigation banner to Perps V2 (removes the alpha tag/badge)

<img width="338" alt="Screenshot 2023-02-10 at 10 15 07" src="https://user-images.githubusercontent.com/548702/218101064-9db41588-9160-451f-bbce-6eac92f76a67.png">
