### PR TITLE
Extend market drop down height

### DIFF
--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -157,6 +157,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	return (
 		<SelectContainer mobile={mobile}>
 			<Select
+				maxMenuHeight={Math.max(window.innerHeight - (mobile ? 135 : 250), 300)}
 				instanceId={`markets-dropdown-${marketAsset}`}
 				controlHeight={55}
 				menuWidth={'100%'}


### PR DESCRIPTION
## Motivation and Context
Now we have a larger list of markets it would be good to increase the height of the markets drop down so more are displayed on screen at one time.

There will be a follow up task to add search and sort functions on this list.

## Screenshots (if appropriate):
<img width="583" alt="Screenshot 2023-02-10 at 16 49 40" src="https://user-images.githubusercontent.com/3802342/218151990-27d10807-7c98-43b5-b1ea-cbc7aaf7024a.png">

<img width="464" alt="Screenshot 2023-02-10 at 17 03 33" src="https://user-images.githubusercontent.com/3802342/218152475-219c8bdd-9078-435d-b66a-658eb82bd10f.png">

