### PR TITLE
Fix OI on stats page

### DIFF
--- a/hooks/useStatsData.ts
+++ b/hooks/useStatsData.ts
@@ -2,26 +2,26 @@ import { useMemo } from 'react';
 
 import { useGetFuturesTradersStats } from 'queries/futures/useGetFuturesTradersStats';
 import { useGetStatsVolumes } from 'queries/futures/useGetStatsVolumes';
-import { selectMarketPrice, selectMarkets } from 'state/futures/selectors';
+import { selectMarkPrices, selectMarkets } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 
 export type StatsTimeframe = '1M' | '1Y' | 'MAX';
 
 const useStatsData = () => {
 	const futuresMarkets = useAppSelector(selectMarkets);
-	const price = useAppSelector(selectMarketPrice);
+	const prices = useAppSelector(selectMarkPrices);
 
 	const { data: volumeData, isLoading: volumeIsLoading } = useGetStatsVolumes();
 	const { data: tradersData, isLoading: tradersIsLoading } = useGetFuturesTradersStats();
 
 	const openInterestData = useMemo(() => {
-		return futuresMarkets.map(({ asset, marketSize }) => {
+		return futuresMarkets.map(({ marketKey, asset, marketSize }) => {
 			return {
 				asset,
-				openInterest: marketSize.mul(price).toNumber(),
+				openInterest: marketSize.mul(prices[marketKey]).toNumber(),
 			};
 		});
-	}, [futuresMarkets, price]);
+	}, [futuresMarkets, prices]);
 
 	return {
 		volumeData,

--- a/state/app/hooks.ts
+++ b/state/app/hooks.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { fetchBalances } from 'state/balances/actions';
 import { sdk } from 'state/config';
+import { fetchMarkets } from 'state/futures/actions';
 import { selectMarkets } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector, usePollAction } from 'state/hooks';
 import { fetchPreviousDayPrices, updatePrices } from 'state/prices/actions';
@@ -13,6 +14,8 @@ export function useAppData(ready: boolean) {
 	const dispatch = useAppDispatch();
 	const wallet = useAppSelector(selectWallet);
 	const markets = useAppSelector(selectMarkets);
+
+	usePollAction('fetchMarkets', fetchMarkets, { dependencies: [wallet] });
 
 	usePollAction('fetchBalances', fetchBalances, { dependencies: [wallet] });
 


### PR DESCRIPTION
Fix the OI chart on the dashboard.

## Description
* Update selectors to look up market prices, correcting a bug where it used selected market price
* Update hooks to query markets, correcting a bug where hitting the stats page directly did not display OI data
