### PR TITLE
Added legacy link to mobile trade and updated the sytle

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -7,11 +7,11 @@ import styled, { useTheme } from 'styled-components';
 
 import LinkArrow from 'assets/svg/app/link-arrow.svg';
 import MarketBadge from 'components/Badge/MarketBadge';
+import Button from 'components/Button';
 import ChangePercent from 'components/ChangePercent';
 import Currency from 'components/Currency';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import Table, { TableNoResults } from 'components/Table';
-import { Body } from 'components/Text';
 import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { EXTERNAL_LINKS } from 'constants/links';
 import { NO_VALUE } from 'constants/placeholder';
@@ -40,12 +40,30 @@ type FuturesPositionTableProps = {
 	showCurrentMarket?: boolean;
 };
 
+const LegacyLink = () => {
+	const { t } = useTranslation();
+	const theme = useTheme();
+	return (
+		<ButtonContainer>
+			<Button
+				fullWidth
+				variant="flat"
+				size="sm"
+				noOutline={true}
+				onClick={() => window.open(EXTERNAL_LINKS.Trade.V1, '_blank', 'noopener noreferrer')}
+			>
+				{t('dashboard.overview.futures-positions-table.legacy-link')}
+				<StyledArrow fill={theme.colors.selectedTheme.text.value} />
+			</Button>
+		</ButtonContainer>
+	);
+};
+
 const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 	accountType,
 	showCurrentMarket = true,
 }) => {
 	const { t } = useTranslation();
-	const theme = useTheme();
 	const { synthsMap } = Connector.useContainer();
 	const router = useRouter();
 	const { switchToL2 } = useNetworkSwitcher();
@@ -97,12 +115,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 		<>
 			<DesktopOnlyView>
 				<div>
-					<StyledBody>
-						<a target="_blank" rel="noopener noreferrer" href={EXTERNAL_LINKS.Trade.V1}>
-							{t('dashboard.overview.futures-positions-table.legacy-link')}{' '}
-							<StyledArrow fill={theme.colors.selectedTheme.text.value} />
-						</a>
-					</StyledBody>
+					<LegacyLink />
 					<Table
 						data={data}
 						showPagination
@@ -283,12 +296,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 				</div>
 			</DesktopOnlyView>
 			<MobileOrTabletView>
-				<StyledBody>
-					<a target="_blank" rel="noopener noreferrer" href={EXTERNAL_LINKS.Trade.V1}>
-						{t('dashboard.overview.futures-positions-table.legacy-link')}{' '}
-						<StyledArrow fill={theme.colors.selectedTheme.text.value} />
-					</a>
-				</StyledBody>
+				<LegacyLink />
 				<OpenPositionsHeader>
 					<div>{t('dashboard.overview.futures-positions-table.mobile.market')}</div>
 					<OpenPositionsRightHeader>
@@ -320,13 +328,8 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 	);
 };
 
-const StyledBody = styled(Body)`
+const ButtonContainer = styled.div`
 	margin: 8px 0px 16px;
-	padding: 15px 0px;
-	border-radius: 10px;
-	text-align: center;
-	background: ${(props) => props.theme.colors.selectedTheme.tab.background.active};
-	border: ${(props) => props.theme.colors.selectedTheme.border};
 
 	${media.lessThan('md')`
 		margin: 8px 15px 16px;
@@ -335,6 +338,8 @@ const StyledBody = styled(Body)`
 
 const StyledArrow = styled(LinkArrow)`
 	margin-left: 2px;
+	width: 9px;
+	height: 9px;
 `;
 
 const PnlContainer = styled.div`

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -50,6 +50,7 @@ const LegacyLink = () => {
 				variant="flat"
 				size="sm"
 				noOutline={true}
+				textTransform="none"
 				onClick={() => window.open(EXTERNAL_LINKS.Trade.V1, '_blank', 'noopener noreferrer')}
 			>
 				{t('dashboard.overview.futures-positions-table.legacy-link')}

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -29,6 +29,7 @@ import {
 	selectPositionHistory,
 } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
+import media from 'styles/media';
 import { formatNumber } from 'utils/formatters/number';
 import { getSynthDescription } from 'utils/futures';
 
@@ -96,6 +97,12 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 		<>
 			<DesktopOnlyView>
 				<div>
+					<StyledBody>
+						<a target="_blank" rel="noopener noreferrer" href={EXTERNAL_LINKS.Trade.V1}>
+							{t('dashboard.overview.futures-positions-table.legacy-link')}{' '}
+							<StyledArrow fill={theme.colors.selectedTheme.text.value} />
+						</a>
+					</StyledBody>
 					<Table
 						data={data}
 						showPagination
@@ -273,15 +280,15 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 							},
 						]}
 					/>
-					<StyledBody>
-						<a target="_blank" rel="noopener noreferrer" href={EXTERNAL_LINKS.Trade.V1}>
-							{t('dashboard.overview.futures-positions-table.legacy-link')}{' '}
-							<StyledArrow fill={theme.colors.selectedTheme.text.value} />
-						</a>
-					</StyledBody>
 				</div>
 			</DesktopOnlyView>
 			<MobileOrTabletView>
+				<StyledBody>
+					<a target="_blank" rel="noopener noreferrer" href={EXTERNAL_LINKS.Trade.V1}>
+						{t('dashboard.overview.futures-positions-table.legacy-link')}{' '}
+						<StyledArrow fill={theme.colors.selectedTheme.text.value} />
+					</a>
+				</StyledBody>
 				<OpenPositionsHeader>
 					<div>{t('dashboard.overview.futures-positions-table.mobile.market')}</div>
 					<OpenPositionsRightHeader>
@@ -308,24 +315,22 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 						))
 					)}
 				</div>
-				<StyledBody>
-					<a target="_blank" rel="noopener noreferrer" href={EXTERNAL_LINKS.Trade.V1}>
-						{t('dashboard.overview.futures-positions-table.legacy-link')}{' '}
-						<StyledArrow fill={theme.colors.selectedTheme.text.value} />
-					</a>
-				</StyledBody>
 			</MobileOrTabletView>
 		</>
 	);
 };
 
 const StyledBody = styled(Body)`
-	margin-top: 8px;
+	margin: 8px 0px 16px;
+	padding: 15px 0px;
+	border-radius: 10px;
 	text-align: center;
-	text-decoration: underline;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+	background: ${(props) => props.theme.colors.selectedTheme.tab.background.active};
+	border: ${(props) => props.theme.colors.selectedTheme.border};
+
+	${media.lessThan('md')`
+		margin: 8px 15px 16px;
+	`};
 `;
 
 const StyledArrow = styled(LinkArrow)`

--- a/sections/futures/MobileTrade/PositionDetails.tsx
+++ b/sections/futures/MobileTrade/PositionDetails.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import UploadIcon from 'assets/svg/futures/upload-icon.svg';
+import FuturesPositionsTable from 'sections/dashboard/FuturesPositionsTable';
 import { SectionHeader, SectionSeparator, SectionTitle } from 'sections/futures/mobile';
-import { selectPosition } from 'state/futures/selectors';
+import { selectFuturesType, selectPosition } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
 import { resetButtonCSS } from 'styles/common';
 
@@ -12,6 +13,7 @@ import ShareModal from '../ShareModal';
 
 const PositionDetails = () => {
 	const position = useAppSelector(selectPosition);
+	const accountType = useAppSelector(selectFuturesType);
 
 	const [showShareModal, setShowShareModal] = useState(false);
 
@@ -29,11 +31,15 @@ const PositionDetails = () => {
 					</IconButton>
 				</SectionHeader>
 				<PositionCard />
+				<FuturesPositionsTable accountType={accountType} showCurrentMarket={false} />
 			</PositionDetailsContainer>
 			{showShareModal && <ShareModal position={position} setShowShareModal={setShowShareModal} />}
 		</>
 	) : (
-		<SectionSeparator />
+		<>
+			<SectionSeparator />
+			<FuturesPositionsTable accountType={accountType} showCurrentMarket={false} />
+		</>
 	);
 };
 

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -9,7 +9,7 @@ const lightTheme = {
 		yellow: { background: common.primaryYellow, text: 'black' },
 		gray: { background: common.primaryGray, text: 'black' },
 	},
-	tab: { background: { active: 'transparent', inactive: '#e8e8e8' } },
+	tab: { background: { active: '#e8e8e8', inactive: 'transparent' } },
 	button: {
 		border: 'rgb(0 0 0 / 10%)',
 		fill: '#e8e8e8',

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -9,7 +9,7 @@ const lightTheme = {
 		yellow: { background: common.primaryYellow, text: 'black' },
 		gray: { background: common.primaryGray, text: 'black' },
 	},
-	tab: { background: { active: '#e8e8e8', inactive: 'transparent' } },
+	tab: { background: { active: 'transparent', inactive: '#e8e8e8' } },
 	button: {
 		border: 'rgb(0 0 0 / 10%)',
 		fill: '#e8e8e8',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Make the legacy link more visible on the market page
2. Add the legacy link to the mobile market page

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Make it easier for users to switch between v1 and v2

## How Has This Been Tested?
1. Open the market page on the desktop and see the legacy link with the new style
2. Open the market page on the mobile and see the legacy link

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/218337248-78b5e448-a27f-4c64-9427-12973d3c26ef.png)
![image](https://user-images.githubusercontent.com/4819006/218337398-cb957b19-0099-4699-9d7f-200582cb0504.png)
