### PR TITLE
Show WETH/KWENTA LP APR without staking LP

### DIFF
--- a/sdk/constants/period.ts
+++ b/sdk/constants/period.ts
@@ -4,6 +4,7 @@ export enum Period {
 	ONE_DAY = 'ONE_DAY',
 	ONE_WEEK = 'ONE_WEEK',
 	ONE_MONTH = 'ONE_MONTH',
+	ONE_YEAR = 'ONE_YEAR',
 }
 
 export const PERIOD_IN_HOURS: Record<Period, number> = {
@@ -12,6 +13,7 @@ export const PERIOD_IN_HOURS: Record<Period, number> = {
 	ONE_DAY: 24,
 	ONE_MONTH: 672,
 	ONE_WEEK: 168,
+	ONE_YEAR: 8766,
 };
 
 export const PERIOD_IN_SECONDS: Record<Period, number> = {
@@ -20,6 +22,7 @@ export const PERIOD_IN_SECONDS: Record<Period, number> = {
 	ONE_DAY: 24 * 60 * 60,
 	ONE_MONTH: 672 * 60 * 60,
 	ONE_WEEK: 168 * 60 * 60,
+	ONE_YEAR: 8766 * 60 * 60,
 };
 
 export const SECONDS_PER_DAY = 24 * 60 * 60;

--- a/sections/earn/StakeGrid.tsx
+++ b/sections/earn/StakeGrid.tsx
@@ -7,7 +7,7 @@ import { GridContainer } from 'sections/earn/grid';
 import { claimRewards, fetchEarnTokenPrices } from 'state/earn/actions';
 import { selectEarnApy, selectEarnedRewards, selectYieldPerDay } from 'state/earn/selectors';
 import { useAppDispatch, useAppSelector, usePollAction } from 'state/hooks';
-import { formatPercent, toWei, truncateNumbers } from 'utils/formatters/number';
+import { formatPercent, truncateNumbers } from 'utils/formatters/number';
 
 import GridData from './GridData';
 
@@ -48,7 +48,7 @@ const StakeGrid = () => {
 			</GridData>
 			<GridData
 				title={t('dashboard.stake.tabs.staking.annual-percentage-rate')}
-				value={formatPercent(earnApy.div(toWei('100')), { minDecimals: 2 })}
+				value={formatPercent(earnApy, { minDecimals: 2 })}
 			/>
 			<TimeRemainingData />
 		</GridContainer>

--- a/state/earn/selectors.ts
+++ b/state/earn/selectors.ts
@@ -73,10 +73,15 @@ export const selectLpTokenValue = createSelector(
 
 export const selectEarnApy = createSelector(
 	selectLpTokenValue,
-	selectYieldPerDay,
 	selectKwentaPrice,
-	(lpTokenValue, yieldPerDay, kwentaPrice) =>
+	(state: RootState) => state.earn.rewardRate,
+	(state: RootState) => state.earn.totalSupply,
+	(lpTokenValue, kwentaPrice, rewardRate, totalSupply) =>
 		lpTokenValue.gt(0)
-			? toWei(yieldPerDay).mul(kwentaPrice).mul(toWei('365')).div(lpTokenValue)
+			? toWei(rewardRate)
+					.div(totalSupply)
+					.mul(PERIOD_IN_SECONDS.ONE_YEAR)
+					.mul(kwentaPrice)
+					.div(lpTokenValue)
 			: zeroBN
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current calculation of APR is based on the user's daily yield. It requires the user to stake LP token to see the APR.
In this PR, we changed the calculation logic to use the `rewardRate` to calculate APR. So the user can see APR without staking LP tokens.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Make our LP APR more eye-catching.

## How Has This Been Tested?
1. Use a wallet without staking LP token and see the APR
2. Use a wallet with staking LP token and see the APR

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/218486881-aae38d39-152a-4e6e-a349-f13535ed190c.png)
