### PR TITLE
Number decimal formatting updates and fix market trade history

### DIFF
--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -57,6 +57,23 @@ const splitBaseQuote = (symbolName: string) => {
 	return { base, quote };
 };
 
+const getPriceScale = (asset: string | null) => {
+	switch (asset) {
+		case 'BTC':
+			return 1;
+		case 'BNB':
+		case 'ETH':
+		case 'XAU':
+			return 100;
+		case 'DOGE':
+		case 'FTM':
+		case 'AUD':
+			return 10000;
+		default:
+			return 1000;
+	}
+};
+
 const fetchCombinedCandles = async (
 	base: string,
 	quote: string,
@@ -194,16 +211,18 @@ const DataFeedFactory = (
 		resolveSymbol: (symbolName: string, onSymbolResolvedCallback: (val: any) => any) => {
 			const { base, quote } = splitBaseQuote(symbolName);
 
+			const asset = getDisplayAsset(base);
+
 			var symbol_stub = {
 				name: symbolName,
-				description: `${getDisplayAsset(base)} / ${getDisplayAsset(quote)} (Oracle)`,
+				description: `${asset} / ${getDisplayAsset(quote)} (Oracle)`,
 				type: 'crypto',
 				session: '24x7',
 				timezone: 'Etc/UTC',
 				ticker: symbolName,
 				exchange: '',
 				minmov: 1,
-				pricescale: 10000,
+				pricescale: getPriceScale(asset),
 				has_intraday: true,
 				intraday_multipliers: supportedResolutions,
 				supported_resolution: supportedResolutions,

--- a/components/TVChart/DataFeed.ts
+++ b/components/TVChart/DataFeed.ts
@@ -60,7 +60,6 @@ const splitBaseQuote = (symbolName: string) => {
 const getPriceScale = (asset: string | null) => {
 	switch (asset) {
 		case 'BTC':
-			return 1;
 		case 'BNB':
 		case 'ETH':
 		case 'XAU':

--- a/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
+++ b/sections/dashboard/FuturesHistoryTable/FuturesHistoryTable.tsx
@@ -11,7 +11,6 @@ import Currency from 'components/Currency';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import FuturesIcon from 'components/Nav/FuturesIcon';
 import Table, { TableNoResults } from 'components/Table';
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { ETH_UNIT } from 'constants/network';
 import { NO_VALUE } from 'constants/placeholder';
 import ROUTES from 'constants/routes';
@@ -34,7 +33,7 @@ import { FetchStatus } from 'state/types';
 import { selectNetwork } from 'state/wallet/selectors';
 import { formatShortDateWithoutYear } from 'utils/formatters/date';
 import { formatCryptoCurrency, formatDollars } from 'utils/formatters/number';
-import { getDisplayAsset, getMarketName, isDecimalFour, MarketKeyByAsset } from 'utils/futures';
+import { getDisplayAsset, getMarketName, MarketKeyByAsset } from 'utils/futures';
 
 import TimeDisplay from '../../futures/Trades/TimeDisplay';
 
@@ -160,7 +159,7 @@ const FuturesHistoryTable: FC = () => {
 								Cell: (cellProps: CellProps<FuturesTrade>) => {
 									return conditionalRender(
 										cellProps.row.original.size,
-										<>{formatCryptoCurrency(cellProps.value)}</>
+										<>{formatCryptoCurrency(cellProps.value, { suggestDecimals: true })}</>
 									);
 								},
 								width: 100,
@@ -169,12 +168,9 @@ const FuturesHistoryTable: FC = () => {
 								Header: <div>{t('dashboard.history.futures-history-table.price')}</div>,
 								accessor: 'price',
 								Cell: (cellProps: CellProps<FuturesTrade>) => {
-									const formatOptions = isDecimalFour(cellProps.row.original.asset)
-										? { sign: '$', minDecimals: DEFAULT_CRYPTO_DECIMALS }
-										: { sign: '$' };
 									return conditionalRender(
 										cellProps.row.original.price,
-										<>{formatDollars(cellProps.value, formatOptions)}</>
+										<>{formatDollars(cellProps.value, { suggestDecimals: true })}</>
 									);
 								},
 								width: 120,
@@ -189,7 +185,7 @@ const FuturesHistoryTable: FC = () => {
 											<PNL normal>--</PNL>
 										) : (
 											<PNL negative={cellProps.value.lt(wei(0))}>
-												{formatDollars(cellProps.value)}
+												{formatDollars(cellProps.value, { suggestDecimals: true })}
 											</PNL>
 										)
 									);
@@ -309,7 +305,7 @@ const FuturesHistoryTable: FC = () => {
 									return conditionalRender(
 										cellProps.row.original.price,
 										<div>
-											<div>{formatCryptoCurrency(cellProps.value)}</div>
+											<div>{formatCryptoCurrency(cellProps.value, { suggestDecimals: true })}</div>
 											<div>{formatDollars(cellProps.row.original.price ?? 0)}</div>
 										</div>
 									);
@@ -326,7 +322,7 @@ const FuturesHistoryTable: FC = () => {
 											<PNL normal>--</PNL>
 										) : (
 											<PNL negative={cellProps.value.lt(wei(0))}>
-												{formatDollars(cellProps.value)}
+												{formatDollars(cellProps.value, { suggestDecimals: true })}
 											</PNL>
 										)
 									);

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -11,7 +11,6 @@ import ColoredPrice from 'components/ColoredPrice';
 import Currency from 'components/Currency';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import Table, { TableHeader } from 'components/Table';
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import ROUTES from 'constants/routes';
 import Connector from 'containers/Connector';
 import { FuturesMarketAsset } from 'sdk/types/futures';
@@ -119,8 +118,7 @@ const FuturesMarketsTable: FC = () => {
 								accessor: 'price',
 								Cell: (cellProps: CellProps<typeof data[number]>) => {
 									const formatOptions = {
-										minDecimals: DEFAULT_CRYPTO_DECIMALS,
-										isAssetPrice: true,
+										suggestDecimals: true,
 									};
 									return (
 										<ColoredPrice priceInfo={cellProps.row.original.priceInfo}>
@@ -297,7 +295,7 @@ const FuturesMarketsTable: FC = () => {
 												currencyKey="sUSD"
 												price={cellProps.row.original.price}
 												sign="$"
-												formatOptions={{ minDecimals: DEFAULT_CRYPTO_DECIMALS, isAssetPrice: true }}
+												formatOptions={{ suggestDecimals: true }}
 											/>
 										</MarketContainer>
 									</div>

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -12,7 +12,6 @@ import Currency from 'components/Currency';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import Table, { TableNoResults } from 'components/Table';
 import { Body } from 'components/Text';
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { EXTERNAL_LINKS } from 'constants/links';
 import { NO_VALUE } from 'constants/placeholder';
 import ROUTES from 'constants/routes';
@@ -230,8 +229,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 								accessor: 'avgEntryPrice',
 								Cell: (cellProps: CellProps<any>) => {
 									const formatOptions = {
-										minDecimals: DEFAULT_CRYPTO_DECIMALS,
-										isAssetPrice: true,
+										suggestDecimals: true,
 									};
 									return cellProps.row.original.avgEntryPrice === undefined ? (
 										<DefaultCell>{NO_VALUE}</DefaultCell>
@@ -256,8 +254,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 								accessor: 'liquidationPrice',
 								Cell: (cellProps: CellProps<any>) => {
 									const formatOptions = {
-										minDecimals: DEFAULT_CRYPTO_DECIMALS,
-										isAssetPrice: true,
+										suggestDecimals: true,
 									};
 									return (
 										<Currency.Price

--- a/sections/futures/MarketDetails/useGetMarketData.ts
+++ b/sections/futures/MarketDetails/useGetMarketData.ts
@@ -62,11 +62,11 @@ const useGetMarketData = (mobile?: boolean) => {
 		if (mobile) {
 			return {
 				[MarketDataKey.marketPrice]: {
-					value: markPrice ? formatDollars(markPrice.price) : NO_VALUE,
+					value: markPrice ? formatDollars(markPrice.price, { suggestDecimals: true }) : NO_VALUE,
 					color: getColorFromPriceInfo(markPrice),
 				},
 				[MarketDataKey.indexPrice]: {
-					value: indexPrice ? formatDollars(indexPrice.price) : NO_VALUE,
+					value: indexPrice ? formatDollars(indexPrice.price, { suggestDecimals: true }) : NO_VALUE,
 				},
 				[MarketDataKey.dailyChange]: {
 					value:
@@ -97,11 +97,11 @@ const useGetMarketData = (mobile?: boolean) => {
 		} else {
 			return {
 				[MarketDataKey.marketPrice]: {
-					value: markPrice ? formatDollars(markPrice.price) : NO_VALUE,
+					value: markPrice ? formatDollars(markPrice.price, { suggestDecimals: true }) : NO_VALUE,
 					color: getColorFromPriceInfo(markPrice),
 				},
 				[MarketDataKey.indexPrice]: {
-					value: indexPrice ? formatDollars(indexPrice.price) : NO_VALUE,
+					value: indexPrice ? formatDollars(indexPrice.price, { suggestDecimals: true }) : NO_VALUE,
 				},
 				[MarketDataKey.dailyChange]: {
 					value:

--- a/sections/futures/PositionCard/PositionCard.tsx
+++ b/sections/futures/PositionCard/PositionCard.tsx
@@ -139,12 +139,12 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 			marketLongName: getSynthDescription(marketAsset, synthsMap, t),
 			marketPrice: (
 				<>
-					{formatDollars(marketPrice, { minDecimals, isAssetPrice: true })}
+					{formatDollars(marketPrice, { minDecimals, suggestDecimals: true })}
 					{
 						<PreviewArrow showPreview={previewData.sizeIsNotZero && !previewData.showStatus}>
 							{formatDollars(previewData.fillPrice ?? zeroBN, {
 								minDecimals,
-								isAssetPrice: true,
+								suggestDecimals: true,
 							})}
 						</PreviewArrow>
 					}
@@ -210,13 +210,13 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 				<>
 					{formatDollars(positionDetails?.liquidationPrice ?? zeroBN, {
 						minDecimals,
-						isAssetPrice: true,
+						suggestDecimals: true,
 					})}
 					{
 						<PreviewArrow showPreview={previewData.sizeIsNotZero && !previewData.showStatus}>
 							{formatDollars(previewData?.liquidationPrice ?? zeroBN, {
 								minDecimals,
-								isAssetPrice: true,
+								suggestDecimals: true,
 							})}
 						</PreviewArrow>
 					}
@@ -249,13 +249,13 @@ const PositionCard: React.FC<PositionCardProps> = () => {
 				<>
 					{formatDollars(thisPositionHistory?.entryPrice ?? zeroBN, {
 						minDecimals,
-						isAssetPrice: true,
+						suggestDecimals: true,
 					})}
 					{
 						<PreviewArrow showPreview={previewData.sizeIsNotZero && !previewData.showStatus}>
 							{formatDollars(previewData.avgEntryPrice ?? zeroBN, {
 								minDecimals,
-								isAssetPrice: true,
+								suggestDecimals: true,
 							})}
 						</PreviewArrow>
 					}

--- a/sections/futures/ShareModal/PositionMetadata.tsx
+++ b/sections/futures/ShareModal/PositionMetadata.tsx
@@ -128,7 +128,7 @@ const PositionMetadata: FC = () => {
 				</ContainerText>
 				<ContainerText className="date-or-price">
 					{formatDollars(avgEntryPrice ?? zeroBN, {
-						isAssetPrice: true,
+						suggestDecimals: true,
 					})}
 				</ContainerText>
 			</BottomLeftContainer>

--- a/sections/futures/ShareModal/ShareModalButton.tsx
+++ b/sections/futures/ShareModal/ShareModalButton.tsx
@@ -71,7 +71,7 @@ const ShareModalButton: FC<ShareModalButtonProps> = ({ position }) => {
 		const avgEntryPrice = currentPosition?.avgEntryPrice
 			? formatNumber(currentPosition?.avgEntryPrice)
 			: '';
-		const dollarEntry = formatDollars(avgEntryPrice ?? zeroBN, { isAssetPrice: true });
+		const dollarEntry = formatDollars(avgEntryPrice ?? zeroBN, { suggestDecimals: true });
 		const dollarCurrent = formatNumber(marketPrice);
 		const text = getTwitterText(side, marketName, leverage, pnlPct, dollarEntry, dollarCurrent);
 		window.open(`https://twitter.com/intent/tweet?text=${text}`, '_blank');

--- a/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
+++ b/sections/futures/Trade/DelayedOrderConfirmationModal.tsx
@@ -101,11 +101,15 @@ const DelayedOrderConfirmationModal: FC = () => {
 			{
 				label: t('futures.market.user.position.modal.estimated-fill'),
 				tooltipContent: t('futures.market.trade.delayed-order.description'),
-				value: formatDollars(potentialTradeDetails?.price ?? zeroBN, { isAssetPrice: true }),
+				value: formatDollars(potentialTradeDetails?.price ?? zeroBN, {
+					suggestDecimals: true,
+				}),
 			},
 			{
 				label: t('futures.market.user.position.modal.liquidation-price'),
-				value: formatDollars(potentialTradeDetails?.liqPrice ?? zeroBN, { isAssetPrice: true }),
+				value: formatDollars(potentialTradeDetails?.liqPrice ?? zeroBN, {
+					suggestDecimals: true,
+				}),
 			},
 			{
 				label: t('futures.market.user.position.modal.time-delay'),

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -128,7 +128,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 					price: formatCurrency(selectedPriceCurrency.name, basePriceRate, {
 						sign: '$',
 						minDecimals: getMinDecimals(market.asset),
-						isAssetPrice: true,
+						suggestDecimals: true,
 					}),
 					change: formatPercent(
 						basePriceRate && pastPrice?.rate
@@ -175,7 +175,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 						? formatCurrency(selectedPriceCurrency.name, selectedBasePriceRate, {
 								sign: '$',
 								minDecimals: getMinDecimals(marketAsset),
-								isAssetPrice: true,
+								suggestDecimals: true,
 						  })
 						: undefined,
 					change: mobile

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -107,11 +107,11 @@ export default function TradeConfirmationModal({
 			orderType === 'limit' || orderType === 'stop_market'
 				? {
 						label: orderType + ' order price',
-						value: formatDollars(orderPrice, { isAssetPrice: true }),
+						value: formatDollars(orderPrice, { suggestDecimals: true }),
 				  }
 				: {
 						label: 'fill price',
-						value: formatDollars(positionDetails?.price ?? zeroBN, { isAssetPrice: true }),
+						value: formatDollars(positionDetails?.price ?? zeroBN, { suggestDecimals: true }),
 				  },
 			{
 				label: 'price impact',
@@ -123,7 +123,7 @@ export default function TradeConfirmationModal({
 			},
 			{
 				label: 'liquidation price',
-				value: formatDollars(positionDetails?.liqPrice ?? zeroBN, { isAssetPrice: true }),
+				value: formatDollars(positionDetails?.liqPrice ?? zeroBN, { suggestDecimals: true }),
 			},
 			{
 				label: 'resulting margin',

--- a/sections/futures/Trades/Trades.tsx
+++ b/sections/futures/Trades/Trades.tsx
@@ -7,7 +7,6 @@ import LinkIcon from 'assets/svg/app/link-blue.svg';
 import Card from 'components/Card';
 import { GridDivCenteredRow } from 'components/layout/grid';
 import Table, { TableHeader, TableNoResults } from 'components/Table';
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { ETH_UNIT } from 'constants/network';
 import { blockExplorer } from 'containers/Connector/Connector';
 import useIsL2 from 'hooks/useIsL2';
@@ -83,9 +82,7 @@ const Trades: React.FC<TradesProps> = ({ history, isLoading, isLoaded, marketAss
 						sortType: 'basic',
 						Cell: (cellProps: CellProps<FuturesTrade>) => {
 							const formatOptions = {
-								sign: '$',
-								minDecimals: DEFAULT_CRYPTO_DECIMALS,
-								isAssetPrice: true,
+								suggestDecimals: true,
 							};
 							return <>{formatDollars(cellProps.value, formatOptions)}</>;
 						},
@@ -97,7 +94,7 @@ const Trades: React.FC<TradesProps> = ({ history, isLoading, isLoaded, marketAss
 						accessor: 'amount',
 						sortType: 'basic',
 						Cell: (cellProps: CellProps<FuturesTrade>) => (
-							<>{formatCryptoCurrency(cellProps.value)}</>
+							<>{formatCryptoCurrency(cellProps.value, { suggestDecimals: true })}</>
 						),
 						width: 90,
 						sortable: true,

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -4,7 +4,6 @@ import { CellProps } from 'react-table';
 import styled, { css } from 'styled-components';
 
 import Table, { TableHeader } from 'components/Table';
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { NO_VALUE } from 'constants/placeholder';
 import { blockExplorer } from 'containers/Connector/Connector';
 import useGetFuturesTrades from 'queries/futures/useGetFuturesTrades';
@@ -140,7 +139,9 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 							Header: <TableHeader>{t('futures.market.history.price-label')}</TableHeader>,
 							accessor: TableColumnAccessor.Price,
 							Cell: (cellProps: CellProps<any>) => {
-								const formatOptions = { minDecimals: DEFAULT_CRYPTO_DECIMALS, isAssetPrice: true };
+								const formatOptions = {
+									suggestDecimals: true,
+								};
 
 								return (
 									<PriceValue>

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -59,7 +59,7 @@ const UserInfo: React.FC = () => {
 	const trades = useAppSelector(selectUsersTradesForMarket);
 
 	useFetchAction(fetchTradesForSelectedMarket, {
-		dependencies: [walletAddress, accountType, position?.position?.size.toString()],
+		dependencies: [walletAddress, accountType, marketAsset, position?.position?.size.toString()],
 		disabled: !walletAddress,
 	});
 

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -29,7 +29,7 @@ export type FormatNumberOptions = {
 	maxDecimals?: number;
 	prefix?: string;
 	suffix?: string;
-	isAssetPrice?: boolean;
+	suggestDecimals?: boolean;
 } & TruncatedOptions;
 
 export type FormatCurrencyOptions = {
@@ -37,7 +37,7 @@ export type FormatCurrencyOptions = {
 	maxDecimals?: number;
 	sign?: string;
 	currencyKey?: string;
-	isAssetPrice?: boolean;
+	suggestDecimals?: boolean;
 } & TruncatedOptions;
 
 const DEFAULT_CURRENCY_DECIMALS = 2;
@@ -88,7 +88,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 	const prefix = options?.prefix;
 	const suffix = options?.suffix;
 	const shouldTruncate = options?.truncate;
-	const isAssetPrice = options?.isAssetPrice;
+	const suggestDecimals = options?.suggestDecimals;
 	let truncation = options?.truncation;
 
 	let weiValue = wei(0);
@@ -120,7 +120,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 
 	const decimals = truncation
 		? truncation.decimals
-		: isAssetPrice
+		: suggestDecimals
 		? suggestedDecimals(weiBeforeAsString)
 		: options?.minDecimals ?? DEFAULT_NUMBER_DECIMALS;
 
@@ -151,7 +151,7 @@ export const formatCryptoCurrency = (value: WeiSource, options?: FormatCurrencyO
 		suffix: options?.currencyKey,
 		minDecimals: options?.minDecimals ?? DEFAULT_CRYPTO_DECIMALS,
 		maxDecimals: options?.maxDecimals,
-		isAssetPrice: options?.isAssetPrice,
+		suggestDecimals: options?.suggestDecimals,
 	});
 
 export const formatFiatCurrency = (value: WeiSource, options?: FormatCurrencyOptions) =>
@@ -229,8 +229,9 @@ export const weiFromWei = (weiAmount: WeiSource) => {
 
 export const suggestedDecimals = (value: WeiSource) => {
 	value = wei(value).toNumber();
-	if (value >= 10000) return 0;
-	if (value >= 10 || value === 0) return 2;
+	if (value >= 100000) return 0;
+	if (value >= 100 || value === 0) return 2;
+	if (value >= 10) return 3;
 	if (value >= 0.1) return 4;
 	if (value >= 0.01) return 5;
 	return 6;


### PR DESCRIPTION
- Ensures market detail and trade history values are rendered with correct decimal formatting
- Updates the suggested decimal function to increase number of digits for some ranges
- Fixes a bug where trade history on the markets page was not loading when switching markets