### PR TITLE
Add sorting to mobile markets table

### DIFF
--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -454,6 +454,7 @@ const MarketContainer = styled.div`
 `;
 
 const StyledMobileTable = styled(StyledTable)`
+	margin-top: 4px;
 	border-radius: initial;
 	border-top: none;
 	border-left: none;

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -272,6 +272,7 @@ const FuturesMarketsTable: FC = () => {
 					onTableRowClick={(row) => {
 						router.push(ROUTES.Markets.MarketPair(row.original.asset, accountType));
 					}}
+					sortBy={[{ id: 'dailyVolume', desc: true }]}
 					columns={[
 						{
 							Header: () => (
@@ -350,7 +351,7 @@ const FuturesMarketsTable: FC = () => {
 									</TableHeader>
 								</div>
 							),
-							accessor: '24h-change',
+							accessor: 'dailyVolume',
 							Cell: (cellProps: CellProps<typeof data[number]>) => {
 								return (
 									<div>
@@ -372,6 +373,15 @@ const FuturesMarketsTable: FC = () => {
 									</div>
 								);
 							},
+							sortable: true,
+							sortType: useMemo(
+								() => (rowA: any, rowB: any) => {
+									const rowOne = rowA.original.volume;
+									const rowTwo = rowB.original.volume;
+									return rowOne > rowTwo ? 1 : -1;
+								},
+								[]
+							),
 							width: 120,
 						},
 					]}

--- a/sections/dashboard/Markets/Markets.tsx
+++ b/sections/dashboard/Markets/Markets.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import TabButton from 'components/Button/TabButton';
-import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import { DesktopOnlyView } from 'components/Media';
 import { TabPanel } from 'components/Tab';
 
 import FuturesMarketsTable from '../FuturesMarketsTable';

--- a/sections/dashboard/Markets/Markets.tsx
+++ b/sections/dashboard/Markets/Markets.tsx
@@ -41,13 +41,6 @@ const Markets: FC = () => {
 					))}
 				</TabButtonsContainer>
 			</DesktopOnlyView>
-			<MobileOrTabletView>
-				<TabButtonsContainer mobile>
-					{MARKETS_TABS.map(({ name, label, active, onClick }) => (
-						<TabButton key={name} title={label} active={active} onClick={onClick} />
-					))}
-				</TabButtonsContainer>
-			</MobileOrTabletView>
 
 			<TabPanel name={MarketsTab.FUTURES} activeTab={activeMarketsTab}>
 				<FuturesMarketsTable />


### PR DESCRIPTION
Add default sort by volume on mobile `FuturesMarketsTable`. Also removes a tab that only has one option:

Old:
![image](https://user-images.githubusercontent.com/10401554/218587302-0d05a667-2af6-47c0-9a9d-e2f0e747df91.png)


New:
![image](https://user-images.githubusercontent.com/10401554/218587161-1f83a0df-b3b0-4c55-a3e4-f7fc69e36329.png)
