### PR TITLE
Fixed the width of sub menu on landing page nav

### DIFF
--- a/sections/shared/Layout/HomeLayout/Header.tsx
+++ b/sections/shared/Layout/HomeLayout/Header.tsx
@@ -161,9 +161,9 @@ const StyledMenu = styled.div`
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	z-index: 10;
 	border-radius: 6px;
-	width: 120px;
+	max-width: 150px;
 	margin: auto;
-	padding: 10px 0px;
+	padding: 10px 15px;
 	margin-top: 35px;
 	display: flex;
 	flex-direction: column;
@@ -189,7 +189,7 @@ const StyledMenu = styled.div`
 const StyledMenuItem = styled.p`
 	font-family: ${(props) => props.theme.fonts.bold};
 	cursor: pointer;
-	width: 90px;
+	width: 100%;
 	font-size: 15px;
 	height: 30px;
 	color: ${(props) => props.theme.colors.common.secondaryGray};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`Kwenta State Log` is too long for the current width of the sub-menu. This PR is to make the sub-menu a bit wider.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/218874530-16831a8d-7662-46fa-b1c9-fd040d8019f2.png)
