### PR TITLE
Fixed the query of trading reward v2

### DIFF
--- a/queries/staking/useGetFuturesFee.ts
+++ b/queries/staking/useGetFuturesFee.ts
@@ -29,7 +29,7 @@ const useGetFuturesFee = (
 				},
 				{
 					timestamp: true,
-					feesCrossMarginAccounts: true,
+					feesSynthetix: true,
 				}
 			);
 			return response;

--- a/queries/staking/useGetFuturesFeeForAccount.ts
+++ b/queries/staking/useGetFuturesFeeForAccount.ts
@@ -24,7 +24,7 @@ const useGetFuturesFeeForAccount = (
 						account: account,
 						timestamp_gt: start,
 						timestamp_lt: end,
-						accountType: 'cross_margin',
+						accountType: 'isolated_margin',
 					},
 					orderDirection: 'desc',
 					orderBy: 'timestamp',

--- a/queries/staking/utils.ts
+++ b/queries/staking/utils.ts
@@ -33,7 +33,7 @@ export type FuturesFeeForAccountProps = {
 
 export type FuturesFeeProps = {
 	timestamp: string;
-	feesCrossMarginAccounts: BigNumber;
+	feesSynthetix: BigNumber;
 };
 
 export type ClaimParams = [number, string, string, string[], number];

--- a/sections/dashboard/Stake/TradingRewardsTab.tsx
+++ b/sections/dashboard/Stake/TradingRewardsTab.tsx
@@ -51,9 +51,8 @@ const TradingRewardsTab: FC<TradingRewardProps> = memo(
 		const totalFuturesFeeQuery = useGetFuturesFee(start, end);
 		const totalFuturesFeePaid = useMemo(() => {
 			const t: FuturesFeeProps[] = totalFuturesFeeQuery.data ?? [];
-
 			return t
-				.map((trade) => formatEther(trade.feesCrossMarginAccounts.toString()))
+				.map((trade) => formatEther(trade.feesSynthetix.toString()))
 				.reduce((acc, curr) => acc.add(wei(curr)), zeroBN);
 		}, [totalFuturesFeeQuery.data]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the query parameter to adapt the change of trading rewards on perps v2

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Switch to the `Trading Rewards` tab and see the `Total Fees in Pool`

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/219066658-76b0c920-9557-4446-ad43-be8ae76ba8cc.png)
