### PR TITLE
Reset the status of submit/approve after page refresh

### DIFF
--- a/state/exchange/reducer.ts
+++ b/state/exchange/reducer.ts
@@ -201,6 +201,8 @@ const exchangeSlice = createSlice({
 			state.txProvider = action.payload.txProvider;
 			state.allowance = action.payload.allowance;
 			state.oneInchQuoteError = false;
+			state.approvalStatus = FetchStatus.Idle;
+			state.isSubmitting = false;
 		});
 	},
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We got a few users' reports that the button on the exchange page is disabled with the label `submitting` or `approving`.
They may face the issue that the button status isn't reset, so they can't use the exchange page anymore.

## Related issue
Similar issue #1985 

## Motivation and Context
Make the dapp usable for the user again.

## How Has This Been Tested?
Asked the user to test the deployment in this PR and it works.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/219216851-3ea90739-1a51-4f74-ae6a-803664da0524.png)