### PR TITLE
Feat/issue#2046

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -114,6 +114,24 @@ const BaseButton = styled.button<BaseButtonProps>`
 			&::before {
 				display: none;
 			}
+
+			&.long {
+				color: ${(props) => props.theme.colors.selectedTheme.black};
+				background: ${(props) => props.theme.colors.selectedTheme.green};
+			}
+			&.long:hover {
+				color: ${(props) => props.theme.colors.selectedTheme.green};
+				background: ${(props) => props.theme.colors.selectedTheme.button.fillHover};
+			}
+
+			&.short {
+				color: ${(props) => props.theme.colors.selectedTheme.black};
+				background: ${(props) => props.theme.colors.selectedTheme.red};
+			}
+			&.short:hover {
+				color: ${(props) => props.theme.colors.selectedTheme.red};
+				background: ${(props) => props.theme.colors.selectedTheme.button.fillHover};
+			}
 		`}
 
 	${(props) =>

--- a/sections/futures/Trade/ManagePosition.tsx
+++ b/sections/futures/Trade/ManagePosition.tsx
@@ -143,6 +143,7 @@ const ManagePosition: React.FC = () => {
 						data-testid="trade-open-position-button"
 						noOutline
 						fullWidth
+						className={leverageSide}
 						disabled={!!placeOrderDisabledReason}
 						onClick={() => dispatch(setOpenModal('futures_modify_position_confirm'))}
 					>

--- a/sections/futures/Trade/TradeConfirmationModal.tsx
+++ b/sections/futures/Trade/TradeConfirmationModal.tsx
@@ -171,7 +171,7 @@ export default function TradeConfirmationModal({
 				<StyledBaseModal
 					onDismiss={onDismiss}
 					isOpen
-					title={t('futures.market.trade.confirmation.modal.confirm-order')}
+					title={t(`futures.market.trade.confirmation.modal.confirm-order.${leverageSide}`)}
 				>
 					{dataRows.map((row, i) => {
 						if (!row) return null;
@@ -204,12 +204,14 @@ export default function TradeConfirmationModal({
 						data-testid="trade-open-position-confirm-order-button"
 						variant="flat"
 						onClick={onConfirmOrder}
+						className={leverageSide}
 						disabled={!positionDetails || isSubmitting || !!disabledReason}
 					>
 						{isSubmitting ? (
 							<ButtonLoader />
 						) : (
-							disabledReason || t('futures.market.trade.confirmation.modal.confirm-order')
+							disabledReason ||
+							t(`futures.market.trade.confirmation.modal.confirm-order.${leverageSide}`)
 						)}
 					</ConfirmTradeButton>
 					{errorMessage && (
@@ -227,13 +229,15 @@ export default function TradeConfirmationModal({
 					buttons={
 						<MobileConfirmTradeButton
 							variant="flat"
+							className={leverageSide}
 							onClick={onConfirmOrder}
 							disabled={!positionDetails || isSubmitting || !!disabledReason}
 						>
 							{isSubmitting ? (
 								<ButtonLoader />
 							) : (
-								disabledReason || t('futures.market.trade.confirmation.modal.confirm-order')
+								disabledReason ||
+								t(`futures.market.trade.confirmation.modal.confirm-order.${leverageSide}`)
 							)}
 						</MobileConfirmTradeButton>
 					}

--- a/translations/en.json
+++ b/translations/en.json
@@ -819,7 +819,10 @@
 				},
 				"confirmation": {
 					"modal": {
-						"confirm-order": "Confirm order",
+						"confirm-order": {
+							"long": "Confirm Long order",
+							"short": "Confirm Short order"
+						},
 						"close-order": "Close position",
 						"max-leverage-disclaimer": "Note: A next price update could cause your order to exceed maximum leverage resulting in the order being dropped by the keeper.",
 						"disabled-min-margin": "Minimum market margin of $50 required",
@@ -853,7 +856,6 @@
 				"fees": {
 					"tooltip": "Fees are displayed as maker / taker. Maker fees apply to orders that reduce the market skew. Taker fees apply to orders that increase the market skew.",
 					"keeper-tooltip": "Fixed fee to cover automated order execution"
-
 				},
 				"orders": {
 					"manage-keeper-deposit": {
@@ -909,12 +911,12 @@
 						"fee-total": "Total Fees",
 						"estimated-fill": "Estimated Fill Price",
 						"estimated-price-impact": "Estimated Price Impact",
-						"fee-estimated": "Estimated Trade Fee",
+						"fee-estimated": "Est. Trade Fees",
 						"liquidation-price": "Liquidation Price",
 						"time-delay": "Delay Until Executable",
 						"keeper-deposit": "Execution Fee",
 						"gas-fee": "Network Gas Fee",
-						"order-type": "Order Type",
+						"order-type": "Type",
 						"market-order": "Market",
 						"next-price-order": "Next Price",
 						"delayed-order": "Delayed",


### PR DESCRIPTION
- [x] Make submit trade button the color of the trade side
- [x] Make the submit button in the confirmation view the color of the trade side
- [x] Update confirmation submit button labels to include side, e.g. "Submit Short Order"
- [x] Use the colored trade side label in the trade confirmation view
- [x] Update the confirmation view layout

| | |
|-|-|
| ![image](https://user-images.githubusercontent.com/5858657/221897694-5743f73c-8ffe-4402-8557-0c962e3762d3.png) | ![image](https://user-images.githubusercontent.com/5858657/221897778-0352013b-0335-4b36-a334-0abea38451a7.png) |

| | |
|-|-|
| ![image](https://user-images.githubusercontent.com/5858657/221898297-69cc088f-c174-43b0-928f-a83fa51e4ba0.png) | ![image](https://user-images.githubusercontent.com/5858657/221898391-656f42b2-fbfc-487a-8943-772077e36366.png) |


![image](https://user-images.githubusercontent.com/5858657/221898837-35f7434e-c588-4eb5-a10d-7613a3762d38.png)
![image](https://user-images.githubusercontent.com/5858657/221898965-2cb95583-8eea-47fe-9258-2cddabc70951.png)
![image](https://user-images.githubusercontent.com/5858657/221899062-37ca6449-0012-46ca-a793-d3f81ecb95d0.png)

