### PR TITLE
Use transaction service with gas buffer in exchange swap functions

### DIFF
--- a/sdk/services/transactions.ts
+++ b/sdk/services/transactions.ts
@@ -31,7 +31,7 @@ export default class TransactionsService {
 		method: string,
 		args: any[],
 		txnOptions: Partial<ethers.providers.TransactionRequest> = {},
-		options?: any
+		options?: { gasLimitBuffer?: number }
 	) {
 		const txn = {
 			to: contract.address,


### PR DESCRIPTION
## Description
There have been some out of gas errors when using the exchange, likely caused due to complex gas calculations where the estimate can fluctuate.

To mitigate this we needed to pass the transactions through the sdk transactions service where a buffer is added to the calculation.

## Related issue
https://github.com/Kwenta/kwenta/issues/2043

## How Has This Been Tested?
Tested with swaps between 1inch assets but was unable to test synthswap transactions due to insufficient liquidity error (unrelated to changes). 
