### PR TITLE
Hide the option from the nav

### DIFF
--- a/sections/shared/Layout/AppLayout/Header/constants.tsx
+++ b/sections/shared/Layout/AppLayout/Header/constants.tsx
@@ -24,6 +24,7 @@ export type MenuLink = {
 	i18nLabel: string;
 	link: string;
 	links?: SubMenuLink[] | null;
+	hidden?: boolean;
 };
 
 export type MenuLinks = MenuLink[];
@@ -141,6 +142,7 @@ export const getMenuLinks = (isMobile: boolean): MenuLinks => [
 				Icon: LinkIconLight,
 			},
 		],
+		hidden: true,
 	},
 	{
 		i18nLabel: 'header.nav.exchange',
@@ -168,7 +170,7 @@ export const getMenuLinks = (isMobile: boolean): MenuLinks => [
 	},
 ];
 
-export const DESKTOP_NAV_LINKS = getMenuLinks(false);
-export const MOBILE_NAV_LINKS = getMenuLinks(true);
+export const DESKTOP_NAV_LINKS = getMenuLinks(false).filter((m) => !m.hidden);
+export const MOBILE_NAV_LINKS = getMenuLinks(true).filter((m) => !m.hidden);
 
 export const MENU_LINKS_WALLET_CONNECTED: MenuLinks = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hide the `options` from the navigation header on both desktop and mobile.

## Related issue
#2055 

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
