### PR TITLE
Fix: Dashboard lock up on load

### DIFF
--- a/state/futures/hooks.ts
+++ b/state/futures/hooks.ts
@@ -81,10 +81,11 @@ export const usePollDashboardFuturesData = () => {
 	const wallet = useAppSelector(selectWallet);
 	const crossMarginAddress = useAppSelector(selectCrossMarginAccount);
 	const networkSupportsCrossMargin = useAppSelector(selectFuturesSupportedNetwork);
+	const selectedAccountType = useAppSelector(selectFuturesType);
 
 	useFetchAction(fetchCrossMarginAccount, {
 		dependencies: [networkId, wallet],
-		disabled: !wallet || !networkSupportsCrossMargin,
+		disabled: !wallet || !networkSupportsCrossMargin || selectedAccountType === 'isolated_margin',
 	});
 
 	usePollAction('fetchSharedFuturesData', fetchSharedFuturesData, {


### PR DESCRIPTION
### Description
Fixes a performance bug where the dashboard can lock up for a few seconds on load.

### Related issue
#2064

### Solution
We need to disable the cross margin account query as it queries by logs which always causes a lockup. When we re-introduce the query for v2 this will no longer be done via contracts logs so can be re-enabled with no issues.