### PR TITLE
Revert background color of side selector

### DIFF
--- a/sections/futures/PositionButtons/PositionButtons.tsx
+++ b/sections/futures/PositionButtons/PositionButtons.tsx
@@ -71,7 +71,6 @@ const PositionButton = styled(Button).attrs({ fullWidth: true })<PositionButtonP
 	${(props) => css`
 		font-family: ${props.theme.fonts.bold};
 		color: ${props.theme.colors.selectedTheme.newTheme.button.default.color};
-		background: ${props.theme.colors.selectedTheme.newTheme.button.default.background};
 
 		&:hover {
 			background: ${props.theme.colors.selectedTheme.newTheme.button.default.hover.background};


### PR DESCRIPTION
<img width="396" alt="Screenshot 2023-03-06 at 15 37 22" src="https://user-images.githubusercontent.com/3802342/223157305-60d461e4-1ba9-4e63-8be4-eff1ea53eb67.png">

Was using a new theme background before which was inconsistent to other buttons 