### PR TITLE
Hide mobile empty positions table on markets page

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -38,6 +38,7 @@ import MobilePositionRow from './MobilePositionRow';
 type FuturesPositionTableProps = {
 	accountType: FuturesAccountType;
 	showCurrentMarket?: boolean;
+	showEmptyTable?: boolean;
 };
 
 const LegacyLink = () => {
@@ -63,6 +64,7 @@ const LegacyLink = () => {
 const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 	accountType,
 	showCurrentMarket = true,
+	showEmptyTable = true,
 }) => {
 	const { t } = useTranslation();
 	const { synthsMap } = Connector.useContainer();
@@ -294,32 +296,38 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 			</DesktopOnlyView>
 			<MobileOrTabletView>
 				<LegacyLink />
-				<OpenPositionsHeader>
-					<div>{t('dashboard.overview.futures-positions-table.mobile.market')}</div>
-					<OpenPositionsRightHeader>
-						<div>{t('dashboard.overview.futures-positions-table.mobile.price')}</div>
-						<div>{t('dashboard.overview.futures-positions-table.mobile.pnl')}</div>
-					</OpenPositionsRightHeader>
-				</OpenPositionsHeader>
-				<div style={{ margin: '0 15px' }}>
-					{data.length === 0 ? (
-						<NoPositionsText>
-							<Link href={ROUTES.Markets.Home(accountType)}>
-								<div>{t('common.perp-cta')}</div>
-							</Link>
-						</NoPositionsText>
-					) : (
-						data.map((row) => (
-							<MobilePositionRow
-								onClick={() =>
-									router.push(ROUTES.Markets.MarketPair(row.market?.asset ?? 'sETH', accountType))
-								}
-								key={row.market?.asset}
-								row={row}
-							/>
-						))
-					)}
-				</div>
+				{(showEmptyTable || data.length) && (
+					<>
+						<OpenPositionsHeader>
+							<div>{t('dashboard.overview.futures-positions-table.mobile.market')}</div>
+							<OpenPositionsRightHeader>
+								<div>{t('dashboard.overview.futures-positions-table.mobile.price')}</div>
+								<div>{t('dashboard.overview.futures-positions-table.mobile.pnl')}</div>
+							</OpenPositionsRightHeader>
+						</OpenPositionsHeader>
+						<div style={{ margin: '0 15px' }}>
+							{data.length === 0 ? (
+								<NoPositionsText>
+									<Link href={ROUTES.Markets.Home(accountType)}>
+										<div>{t('common.perp-cta')}</div>
+									</Link>
+								</NoPositionsText>
+							) : (
+								data.map((row) => (
+									<MobilePositionRow
+										onClick={() =>
+											router.push(
+												ROUTES.Markets.MarketPair(row.market?.asset ?? 'sETH', accountType)
+											)
+										}
+										key={row.market?.asset}
+										row={row}
+									/>
+								))
+							)}
+						</div>
+					</>
+				)}
 			</MobileOrTabletView>
 		</>
 	);

--- a/sections/futures/MobileTrade/PositionDetails.tsx
+++ b/sections/futures/MobileTrade/PositionDetails.tsx
@@ -31,14 +31,22 @@ const PositionDetails = () => {
 					</IconButton>
 				</SectionHeader>
 				<PositionCard />
-				<FuturesPositionsTable accountType={accountType} showCurrentMarket={false} />
+				<FuturesPositionsTable
+					accountType={accountType}
+					showCurrentMarket={false}
+					showEmptyTable={false}
+				/>
 			</PositionDetailsContainer>
 			{showShareModal && <ShareModal position={position} setShowShareModal={setShowShareModal} />}
 		</>
 	) : (
 		<>
 			<SectionSeparator />
-			<FuturesPositionsTable accountType={accountType} showCurrentMarket={false} />
+			<FuturesPositionsTable
+				accountType={accountType}
+				showCurrentMarket={false}
+				showEmptyTable={false}
+			/>
 		</>
 	);
 };


### PR DESCRIPTION
Hides the positions table entirely on the markets page for mobile screen sizes when there are no positions to show there, since all that get rendered are a table header and the "Trade perpetual futures now!" call to action link. The table should behave exactly the same on the dashboard page as it did before, and should look the same on the markets page if the user has other open positions as well.

## Related issue
https://github.com/Kwenta/kwenta/issues/2074

## How Has This Been Tested?
Tested on Optimism Goerli with Chrome 110.0.5481.117

## Screenshots (if appropriate):
### With no positions open at all:
<img width="320" alt="kwenta-2074-1" src="https://user-images.githubusercontent.com/109358247/223308988-6f21509c-e4c4-4f4f-8dad-d70eddabda96.png">

### With a single position open, viewing the open position:
<img width="320" alt="kwenta-2074-2" src="https://user-images.githubusercontent.com/109358247/223309093-35ae0b79-d58e-47f7-a827-5e0a3f3f0c66.png">

### With a single position open, viewing a different market than the one with the open position
<img width="320" alt="kwenta-2074-3" src="https://user-images.githubusercontent.com/109358247/223309204-3a4b2373-b403-4346-b64b-b2669dc7257e.png">

