### PR TITLE
Update the earn ui to pause the LP rewards

### DIFF
--- a/pages/dashboard/earn.tsx
+++ b/pages/dashboard/earn.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { FC, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import Button from 'components/Button';
@@ -17,6 +18,8 @@ import media from 'styles/media';
 type EarnPageProps = FC & { getLayout: (page: HTMLElement) => JSX.Element };
 
 const EarnPage: EarnPageProps = () => {
+	const { t } = useTranslation();
+
 	const dispatch = useAppDispatch();
 	const walletAddress = useAppSelector(({ wallet }) => wallet.walletAddress);
 
@@ -39,16 +42,13 @@ const EarnPage: EarnPageProps = () => {
 	return (
 		<>
 			<Head>
-				<title>Earn | Kwenta</title>
+				<title>{t('dashboard.earn.title')}</title>
 			</Head>
 			<PageContent>
 				<FullHeightContainer>
 					<EarnContent>
-						<Heading>Kwenta Liquidity Mining</Heading>
-						<StyledBody>
-							The ETH/KWENTA program rewards liquidity providers on the Uniswap v3 pool via Arrakis
-							Finance. Liquidity providers can stake their pool tokens to earn KWENTA.
-						</StyledBody>
+						<Heading>{t('dashboard.earn.heading')}</Heading>
+						<StyledBody>{t('dashboard.earn.copy')}</StyledBody>
 						<StepOne />
 						<StepTwo />
 						<GitHashID />

--- a/sdk/utils/futures.ts
+++ b/sdk/utils/futures.ts
@@ -439,7 +439,7 @@ export const POTENTIAL_TRADE_STATUS_TO_MESSAGE: { [key: string]: string } = {
 	PRICE_OUT_OF_BOUNDS: 'Price out of acceptable range',
 	CAN_LIQUIDATE: 'Position can be liquidated',
 	CANNOT_LIQUIDATE: 'Position cannot be liquidated',
-	MAX_MARKET_SIZE_EXCEEDED: 'Max market size exceeded',
+	MAX_MARKET_SIZE_EXCEEDED: 'Open interest limit exceeded',
 	MAX_LEVERAGE_EXCEEDED: 'Max leverage exceeded',
 	INSUFFICIENT_MARGIN: 'Insufficient margin',
 	NOT_PERMITTED: 'Not permitted by this address',

--- a/sections/dashboard/MobileDashboard/OpenPositions.tsx
+++ b/sections/dashboard/MobileDashboard/OpenPositions.tsx
@@ -94,8 +94,8 @@ const OpenPositions: React.FC<OpenPositionsProps> = ({ exchangeTokens, exchangeT
 				</SectionHeader>
 
 				<TabButtonsContainer>
-					{POSITIONS_TABS.map(({ name, label, ...rest }) => (
-						<TabButton key={name} title={label} {...rest} />
+					{POSITIONS_TABS.map(({ name, label, badge, ...rest }) => (
+						<TabButton key={name} title={label} badgeCount={badge} {...rest} />
 					))}
 				</TabButtonsContainer>
 			</div>

--- a/sections/dashboard/Overview/Overview.tsx
+++ b/sections/dashboard/Overview/Overview.tsx
@@ -172,8 +172,8 @@ const Overview: FC = () => {
 				/>
 
 				<TabButtonsContainer>
-					{POSITIONS_TABS.map(({ name, label, ...rest }) => (
-						<TabButton key={name} title={label} {...rest} />
+					{POSITIONS_TABS.map(({ name, label, badge, ...rest }) => (
+						<TabButton key={name} title={label} badgeCount={badge} {...rest} />
 					))}
 				</TabButtonsContainer>
 				<TabPanel name={PositionsTab.CROSS_MARGIN} activeTab={activePositionsTab}>

--- a/sections/earn/StakeGrid.tsx
+++ b/sections/earn/StakeGrid.tsx
@@ -7,7 +7,7 @@ import { GridContainer } from 'sections/earn/grid';
 import { claimRewards, fetchEarnTokenPrices } from 'state/earn/actions';
 import { selectEarnApy, selectEarnedRewards, selectYieldPerDay } from 'state/earn/selectors';
 import { useAppDispatch, useAppSelector, usePollAction } from 'state/hooks';
-import { formatPercent, truncateNumbers, zeroBN } from 'utils/formatters/number';
+import { formatPercent, truncateNumbers } from 'utils/formatters/number';
 
 import GridData from './GridData';
 

--- a/sections/earn/StakeGrid.tsx
+++ b/sections/earn/StakeGrid.tsx
@@ -7,7 +7,7 @@ import { GridContainer } from 'sections/earn/grid';
 import { claimRewards, fetchEarnTokenPrices } from 'state/earn/actions';
 import { selectEarnApy, selectEarnedRewards, selectYieldPerDay } from 'state/earn/selectors';
 import { useAppDispatch, useAppSelector, usePollAction } from 'state/hooks';
-import { formatPercent, truncateNumbers } from 'utils/formatters/number';
+import { formatPercent, truncateNumbers, zeroBN } from 'utils/formatters/number';
 
 import GridData from './GridData';
 
@@ -33,7 +33,7 @@ const StakeGrid = () => {
 
 	return (
 		<GridContainer>
-			<GridData title="Your Yield / Day" value={yieldPerDay} hasKwentaLogo />
+			<GridData title="Your Yield / Day" value={truncateNumbers(yieldPerDay, 4)} hasKwentaLogo />
 			<GridData title="Your Rewards" value={truncateNumbers(earnedRewards, 4)} hasKwentaLogo>
 				<Button
 					fullWidth

--- a/sections/earn/StepOne.tsx
+++ b/sections/earn/StepOne.tsx
@@ -1,42 +1,29 @@
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import { SplitContainer } from 'components/layout/grid';
 import { Heading, Description } from 'sections/earn/text';
 
+import EarnStakeCard from './EarnStakeCard';
+import StakeGrid from './StakeGrid';
+
 const StepOne = () => {
+	const { t } = useTranslation();
+
 	return (
 		<StepOneContainer>
-			<Heading>Step 1: Deposit Liquidity</Heading>
-			<Description>
-				Follow the link to Arrakis and deposit your liquidity to the WETH/KWENTA vault.
-			</Description>
-			<a
-				href="https://beta.arrakis.finance/vaults/10/0x56dEa47c40877c2aaC2a689aC56aa56cAE4938d2"
-				target="_blank"
-				rel="noreferrer"
-			>
-				<BigButton>Arrakis WETH/KWENTA Pool ↗</BigButton>
-			</a>
+			<Heading>{t('dashboard.earn.unstake-token.title')}</Heading>
+			<Description>{t('dashboard.earn.unstake-token.copy')}</Description>
+			<SplitContainer>
+				<EarnStakeCard />
+				<StakeGrid />
+			</SplitContainer>
 		</StepOneContainer>
 	);
 };
 
 const StepOneContainer = styled.div`
-	margin: 50px 0;
-`;
-
-const BigButton = styled.div`
-	width: 100%;
-	padding: 60px;
-	text-transform: uppercase;
-	font-size: 21px;
-	font-family: ${(props) => props.theme.fonts.black};
-	color: ${(props) => props.theme.colors.selectedTheme.text.value};
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	border: ${(props) => props.theme.colors.selectedTheme.border};
-	border-radius: 15px;
-	background-color: ${(props) => props.theme.colors.selectedTheme.surfaceFill};
+	margin-top: 50px;
 `;
 
 export default StepOne;

--- a/sections/earn/StepTwo.tsx
+++ b/sections/earn/StepTwo.tsx
@@ -1,25 +1,43 @@
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { SplitContainer } from 'components/layout/grid';
 import { Heading, Description } from 'sections/earn/text';
 
-import EarnStakeCard from './EarnStakeCard';
-import StakeGrid from './StakeGrid';
-
 const StepTwo = () => {
+	const { t } = useTranslation();
+
 	return (
 		<StepTwoContainer>
-			<Heading>Step 2: Stake the pool tokens</Heading>
-			<Description>Stake your pool tokens</Description>
-			<SplitContainer>
-				<EarnStakeCard />
-				<StakeGrid />
-			</SplitContainer>
+			<Heading>{t('dashboard.earn.withdraw-liquidity.title')}</Heading>
+			<Description>{t('dashboard.earn.withdraw-liquidity.copy')}</Description>
+			<a
+				href="https://beta.arrakis.finance/vaults/10/0x56dEa47c40877c2aaC2a689aC56aa56cAE4938d2"
+				target="_blank"
+				rel="noreferrer"
+			>
+				<BigButton>{t('dashboard.earn.withdraw-liquidity.pool-link')}</BigButton>
+			</a>
 		</StepTwoContainer>
 	);
 };
 
 const StepTwoContainer = styled.div`
+	margin-top: 50px;
+`;
+
+const BigButton = styled.div`
+	width: 100%;
+	padding: 60px;
+	text-transform: uppercase;
+	font-size: 21px;
+	font-family: ${(props) => props.theme.fonts.black};
+	color: ${(props) => props.theme.colors.selectedTheme.text.value};
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	border: ${(props) => props.theme.colors.selectedTheme.border};
+	border-radius: 15px;
+	background-color: ${(props) => props.theme.colors.selectedTheme.surfaceFill};
 	margin-bottom: 50px;
 `;
 

--- a/state/earn/actions.ts
+++ b/state/earn/actions.ts
@@ -72,9 +72,7 @@ export const getEarnDetails = createAsyncThunk<void, string | undefined, ThunkCo
 	async (_, { dispatch, extra: { sdk } }) => {
 		const {
 			balance,
-			earned,
 			endDate,
-			rewardRate,
 			totalSupply,
 			lpTokenBalance,
 			allowance,

--- a/state/earn/actions.ts
+++ b/state/earn/actions.ts
@@ -87,9 +87,9 @@ export const getEarnDetails = createAsyncThunk<void, string | undefined, ThunkCo
 			type: 'earn/setEarnDetails',
 			payload: {
 				balance: balance.toString(),
-				earnedRewards: earned.toString(),
+				earnedRewards: '0',
 				endDate,
-				rewardRate: rewardRate.toString(),
+				rewardRate: '0',
 				totalSupply: totalSupply.toString(),
 				lpTokenBalance: lpTokenBalance.toString(),
 				allowance: allowance.toString(),

--- a/state/earn/selectors.ts
+++ b/state/earn/selectors.ts
@@ -76,12 +76,5 @@ export const selectEarnApy = createSelector(
 	selectKwentaPrice,
 	(state: RootState) => state.earn.rewardRate,
 	(state: RootState) => state.earn.totalSupply,
-	(lpTokenValue, kwentaPrice, rewardRate, totalSupply) =>
-		lpTokenValue.gt(0)
-			? toWei(rewardRate)
-					.div(totalSupply)
-					.mul(PERIOD_IN_SECONDS.ONE_YEAR)
-					.mul(kwentaPrice)
-					.div(lpTokenValue)
-			: zeroBN
+	(_lpTokenValue, _kwentaPrice, _rewardRate, _totalSupply) => zeroBN
 );

--- a/translations/en.json
+++ b/translations/en.json
@@ -505,6 +505,20 @@
 				"open-positions": "Open Positions"
 			}
 		},
+		"earn": {
+			"title": "Earn | Kwenta",
+			"heading": "Kwenta Liquidity Mining",
+			"copy": "The program that rewards liquidity providers for the ETH/KWENTA pair through Arrakis Finance has ended.",
+			"unstake-token": {
+				"title": "Step 1. Unstake the pool tokens",
+				"copy": "You can unstake your pool tokens."
+			},
+			"withdraw-liquidity": {
+				"title": "Step 2. Withdraw Your Liuqidity",
+				"copy": "You can now withdraw your liquidity from the Arrakis ETH/KWENTA vault.",
+				"pool-link": "Arrakis WETH/KWENTA Pool ↗"
+			}
+		},
 		"stake": {
 			"portfolio": {
 				"title": "Staking Dashboard",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. The program that rewards liquidity providers for the ETH/KWENTA pair through Arrakis Finance has ended.
Here is the PR to show the latest status of this program.

2. Replace the `market size` with `open interest` in the error preview.
3. Add the badge back to the open position tab on the dashboard.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/223601627-eec6387c-c151-49b1-a37e-c4e4c32df68c.png)
