### PR TITLE
Update Fleek Base URL

### DIFF
--- a/queries/files/constants.ts
+++ b/queries/files/constants.ts
@@ -1,3 +1,3 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket';
 
-export const FLEEK_BASE_URL = 'https://storage.kwenta.io';
+export const FLEEK_BASE_URL = 'https://storage.fleek.zone';


### PR DESCRIPTION
The stats page data is returning old data. Update the fleek URL to the one which hosts the fresh data.