### PR TITLE
Fix stats page date format

### DIFF
--- a/queries/files/constants.ts
+++ b/queries/files/constants.ts
@@ -1,3 +1,3 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket';
 
-export const FLEEK_BASE_URL = 'https://storage.fleek.zone';
+export const FLEEK_BASE_URL = 'https://storage.kwenta.io';

--- a/queries/files/constants.ts
+++ b/queries/files/constants.ts
@@ -1,3 +1,3 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket';
 
-export const FLEEK_BASE_URL = 'https://storage.kwenta.io';
+export const FLEEK_BASE_URL = 'https://storage.fleek.zone';

--- a/sections/stats/charts/Traders.tsx
+++ b/sections/stats/charts/Traders.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'styled-components';
 
 import { MiniLoader } from 'components/Loader';
 import useStatsData from 'hooks/useStatsData';
-import { formatShortDate, toJSTimestamp } from 'utils/formatters/date';
+import { formatShortDateUTC, toJSTimestamp } from 'utils/formatters/date';
 
 import { initChart } from '../initChart';
 import type { EChartsOption } from '../initChart';
@@ -37,7 +37,7 @@ export const Traders = () => {
 			xAxis: {
 				...defaultOptions.xAxis,
 				type: 'category',
-				data: dailyStatsData.map(({ timestamp }) => formatShortDate(toJSTimestamp(timestamp))),
+				data: dailyStatsData.map(({ timestamp }) => formatShortDateUTC(toJSTimestamp(timestamp))),
 			},
 			yAxis: [
 				{

--- a/sections/stats/charts/Trades.tsx
+++ b/sections/stats/charts/Trades.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'styled-components';
 
 import { MiniLoader } from 'components/Loader';
 import useStatsData from 'hooks/useStatsData';
-import { formatShortDate, toJSTimestamp } from 'utils/formatters/date';
+import { formatShortDateUTC, toJSTimestamp } from 'utils/formatters/date';
 
 import { initChart } from '../initChart';
 import type { EChartsOption } from '../initChart';
@@ -37,7 +37,7 @@ export const Trades = () => {
 			xAxis: {
 				...defaultOptions.xAxis,
 				type: 'category',
-				data: dailyStatsData.map(({ timestamp }) => formatShortDate(toJSTimestamp(timestamp))),
+				data: dailyStatsData.map(({ timestamp }) => formatShortDateUTC(toJSTimestamp(timestamp))),
 			},
 			yAxis: [
 				{

--- a/sections/stats/charts/Volume.tsx
+++ b/sections/stats/charts/Volume.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'styled-components';
 
 import { MiniLoader } from 'components/Loader';
 import useStatsData from 'hooks/useStatsData';
-import { formatShortDate, toJSTimestamp } from 'utils/formatters/date';
+import { formatShortDateUTC, toJSTimestamp } from 'utils/formatters/date';
 import { formatDollars } from 'utils/formatters/number';
 
 import { initChart } from '../initChart';
@@ -44,7 +44,7 @@ export const Volume = () => {
 			xAxis: {
 				...defaultOptions.xAxis,
 				type: 'category',
-				data: dailyStatsData.map(({ timestamp }) => formatShortDate(toJSTimestamp(timestamp))),
+				data: dailyStatsData.map(({ timestamp }) => formatShortDateUTC(toJSTimestamp(timestamp))),
 			},
 			yAxis: [
 				{

--- a/utils/formatters/date.ts
+++ b/utils/formatters/date.ts
@@ -14,6 +14,11 @@ export const toJSTimestamp = (timestamp: number) => timestamp * 1000;
 
 export const formatShortDate = (date: Date | number) => formatDate(date, 'yyyy-MM-dd');
 
+export const formatShortDateUTC = (date: Date | number) => {
+	const dateString = new Date(date).toISOString();
+	return dateString.substring(0, 10);
+};
+
 export const formatShortDateWithTime = (date: Date | number) =>
 	formatDate(date, 'MMM d, yyyy H:mma');
 export const formatDateWithTime = (date: Date | number) => formatDate(date, 'd MMM yyyy H:mm');


### PR DESCRIPTION
Add a new date formatter that does not convert timezones before formatting, for use in situations where we want UTC.
