### PR TITLE
Various bug fixes

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -74,6 +74,7 @@ const InnerApp: FC<AppProps> = ({ Component, pageProps }: AppPropsWithLayout) =>
 	return isReady ? (
 		<RainbowKitProvider
 			chains={chains}
+			initialChain={10}
 			theme={currentTheme === 'dark' ? darkTheme() : lightTheme()}
 		>
 			<ThemeProvider theme={theme}>

--- a/queries/rates/constants.ts
+++ b/queries/rates/constants.ts
@@ -1,7 +1,5 @@
 import { chain } from 'containers/Connector/config';
 
-export const RATES_ENDPOINT_MAIN = `https://gateway.thegraph.com/api/${process.env.NEXT_PUBLIC_THEGRAPH_API_KEY}/subgraphs/id/HLy7PdmPJuVGjjmPNz1vW5RCCRpqzRWony2fSn7UKpf9`;
-
 export const RATES_ENDPOINT_OP_MAINNET = `https://subgraph.satsuma-prod.com/${process.env.NEXT_PUBLIC_SATSUMA_API_KEY}/kwenta/optimism-latest-rates/api`;
 
 export const RATES_ENDPOINT_OP_GOERLI =
@@ -19,7 +17,6 @@ export const COMMODITIES_BASE_API_URL =
 export const FOREX_BASE_API_URL = 'https://api.exchangerate.host/latest';
 
 export const RATES_ENDPOINTS = {
-	[chain.mainnet.id]: RATES_ENDPOINT_MAIN,
 	[chain.goerli.id]: RATES_ENDPOINT_GOERLI,
 	[chain.optimism.id]: RATES_ENDPOINT_OP_MAINNET,
 	[chain.optimismGoerli.id]: RATES_ENDPOINT_OP_GOERLI,

--- a/sections/futures/MobileTrade/MobileTrade.tsx
+++ b/sections/futures/MobileTrade/MobileTrade.tsx
@@ -1,17 +1,38 @@
 import React from 'react';
+import styled from 'styled-components';
 
+import Connector from 'containers/Connector';
+import useIsL2 from 'hooks/useIsL2';
+
+import FuturesUnsupportedNetwork from '../Trade/FuturesUnsupported';
 import MarketsDropdown from '../Trade/MarketsDropdown';
 import OverviewTabs from './OverviewTabs';
 import PositionDetails from './PositionDetails';
 import UserTabs from './UserTabs';
 
-const MobileTrade: React.FC = () => (
-	<>
-		<MarketsDropdown mobile />
-		<OverviewTabs />
-		<PositionDetails />
-		<UserTabs />
-	</>
-);
+const MobileTrade: React.FC = () => {
+	const isL2 = useIsL2();
+	const { walletAddress } = Connector.useContainer();
+	return (
+		<>
+			<MarketsDropdown mobile />
+			<OverviewTabs />
+			{walletAddress && !isL2 ? (
+				<SwitchNetworkContainer>
+					<FuturesUnsupportedNetwork />
+				</SwitchNetworkContainer>
+			) : (
+				<>
+					<PositionDetails />
+					<UserTabs />
+				</>
+			)}
+		</>
+	);
+};
+
+const SwitchNetworkContainer = styled.div`
+	padding: 15px;
+`;
 
 export default MobileTrade;

--- a/sections/futures/MobileTrade/OverviewTabs/OverviewTabs.tsx
+++ b/sections/futures/MobileTrade/OverviewTabs/OverviewTabs.tsx
@@ -70,6 +70,7 @@ const MainTabButtonsContainer = styled.div`
 	grid-column-gap: 15px;
 	overflow: auto;
 	padding: 0 15px;
+	margin-top: 5px;
 `;
 
 export default OverviewTabs;

--- a/sections/futures/MobileTrade/PositionDetails.tsx
+++ b/sections/futures/MobileTrade/PositionDetails.tsx
@@ -2,8 +2,6 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import UploadIcon from 'assets/svg/futures/upload-icon.svg';
-import Connector from 'containers/Connector';
-import useIsL2 from 'hooks/useIsL2';
 import FuturesPositionsTable from 'sections/dashboard/FuturesPositionsTable';
 import { SectionHeader, SectionSeparator, SectionTitle } from 'sections/futures/mobile';
 import { selectFuturesType, selectPosition } from 'state/futures/selectors';
@@ -12,27 +10,16 @@ import { resetButtonCSS } from 'styles/common';
 
 import PositionCard from '../PositionCard';
 import ShareModal from '../ShareModal';
-import FuturesUnsupportedNetwork from '../Trade/FuturesUnsupported';
 
 const PositionDetails = () => {
 	const position = useAppSelector(selectPosition);
 	const accountType = useAppSelector(selectFuturesType);
-	const isL2 = useIsL2();
-	const { walletAddress } = Connector.useContainer();
 
 	const [showShareModal, setShowShareModal] = useState(false);
 
 	const handleOpenShareModal = useCallback(() => {
 		setShowShareModal(!showShareModal);
 	}, [showShareModal]);
-
-	if (walletAddress && !isL2) {
-		return (
-			<SwitchNetworkContainer>
-				<FuturesUnsupportedNetwork />
-			</SwitchNetworkContainer>
-		);
-	}
 
 	return position?.position ? (
 		<>
@@ -78,10 +65,6 @@ const IconButton = styled.button`
 		height: 14px;
 		fill: ${(props) => props.theme.colors.selectedTheme.gray};
 	}
-`;
-
-const SwitchNetworkContainer = styled.div`
-	padding: 10px 15px;
 `;
 
 export default PositionDetails;

--- a/sections/futures/MobileTrade/PositionDetails.tsx
+++ b/sections/futures/MobileTrade/PositionDetails.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import UploadIcon from 'assets/svg/futures/upload-icon.svg';
+import Connector from 'containers/Connector';
+import useIsL2 from 'hooks/useIsL2';
 import FuturesPositionsTable from 'sections/dashboard/FuturesPositionsTable';
 import { SectionHeader, SectionSeparator, SectionTitle } from 'sections/futures/mobile';
 import { selectFuturesType, selectPosition } from 'state/futures/selectors';
@@ -10,16 +12,27 @@ import { resetButtonCSS } from 'styles/common';
 
 import PositionCard from '../PositionCard';
 import ShareModal from '../ShareModal';
+import FuturesUnsupportedNetwork from '../Trade/FuturesUnsupported';
 
 const PositionDetails = () => {
 	const position = useAppSelector(selectPosition);
 	const accountType = useAppSelector(selectFuturesType);
+	const isL2 = useIsL2();
+	const { walletAddress } = Connector.useContainer();
 
 	const [showShareModal, setShowShareModal] = useState(false);
 
 	const handleOpenShareModal = useCallback(() => {
 		setShowShareModal(!showShareModal);
 	}, [showShareModal]);
+
+	if (walletAddress && !isL2) {
+		return (
+			<SwitchNetworkContainer>
+				<FuturesUnsupportedNetwork />
+			</SwitchNetworkContainer>
+		);
+	}
 
 	return position?.position ? (
 		<>
@@ -65,6 +78,10 @@ const IconButton = styled.button`
 		height: 14px;
 		fill: ${(props) => props.theme.colors.selectedTheme.gray};
 	}
+`;
+
+const SwitchNetworkContainer = styled.div`
+	padding: 10px 15px;
 `;
 
 export default PositionDetails;

--- a/sections/futures/MobileTrade/drawers/BaseDrawer.tsx
+++ b/sections/futures/MobileTrade/drawers/BaseDrawer.tsx
@@ -42,13 +42,9 @@ const BaseDrawer: React.FC<BaseDrawerProps> = ({ open, closeDrawer, items, butto
 );
 
 const StyledModal = styled(FullScreenModal)`
-	top: initial;
+	top: 0;
 	bottom: 74px;
-	height: 100%;
-
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
+	overflow: scroll;
 
 	background-color: transparent;
 
@@ -67,9 +63,6 @@ const StyledModal = styled(FullScreenModal)`
 `;
 
 const Background = styled.div`
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
 	background-color: rgba(0, 0, 0, 0.5);
 	height: 100%;
 	width: 100%;

--- a/sections/futures/Trade/FuturesUnsupported.tsx
+++ b/sections/futures/Trade/FuturesUnsupported.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import Button from 'components/Button';
+import { FlexDivCentered } from 'components/layout/flex';
 import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
 import { BorderedPanel } from 'styles/common';
 
@@ -11,9 +13,11 @@ const FuturesUnsupportedNetwork = () => {
 		<MessageContainer>
 			<Title>{t('futures.page-title')}</Title>
 			<UnsupportedMessage>{t('common.l2-cta')}</UnsupportedMessage>
-			<LinkContainer>
-				<div onClick={switchToL2}>{t('homepage.l2.cta-buttons.switch-l2')}</div>
-			</LinkContainer>
+			<ButtonContainer>
+				<Button variant="yellow" onClick={switchToL2}>
+					{t('homepage.l2.cta-buttons.switch-l2')}
+				</Button>
+			</ButtonContainer>
 		</MessageContainer>
 	);
 };
@@ -22,13 +26,10 @@ const UnsupportedMessage = styled.div`
 	margin-top: 12px;
 `;
 
-const LinkContainer = styled.div`
-	margin-top: 12px;
-	div {
-		cursor: pointer;
-		font-size: 12px;
-		color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
-	}
+const ButtonContainer = styled(FlexDivCentered)`
+	width: 100%;
+	justify-content: center;
+	margin-top: 15px;
 `;
 
 const Title = styled.div`

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -667,7 +667,7 @@ export const selectMarginTransfers = createSelector(
 	(state: RootState) => state.futures,
 	(wallet, network, type, asset, futures) => {
 		if (!wallet) return [];
-		const account = futures[accountType(type)].accounts[network][wallet];
+		const account = futures[accountType(type)].accounts[network]?.[wallet];
 		const marginTransfers = account?.marginTransfers ?? [];
 		return marginTransfers.filter(
 			(o) => accountType(type) === 'isolatedMargin' && o.asset === asset


### PR DESCRIPTION
## Description
Various bug fixes

## Related issue
closes #2099
closes #2100
relates to #2101 

## Changes
- Only fetches rates from Optimism now which fixes a bug when trying to fetch rates from the graph L1 when connected to mainnet
- Displays a network switch prompt on the market mobile page when not connected to L2
- Updates the style of the network switch button to make it more prominent
- Fixes an issue where you cannot close the trade confirmation modal on some smaller mobile screens

## Screenshots
<img width="397" alt="Screenshot 2023-03-17 at 16 08 15" src="https://user-images.githubusercontent.com/3802342/225959398-4cd98d96-ec32-46bb-9474-54e24f0678a7.png">
<img width="392" alt="Screenshot 2023-03-17 at 16 07 27" src="https://user-images.githubusercontent.com/3802342/225959405-e79976ff-5299-4b08-8915-0cfcaf4ff9fa.png">
<img width="402" alt="Screenshot 2023-03-17 at 16 13 19" src="https://user-images.githubusercontent.com/3802342/225960340-a1b76a88-db6e-448f-a356-c3f95e57465c.png">


