### PR TITLE
Remove dropdown autofocus

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -84,6 +84,10 @@ export default class MyDocument extends Document {
 						type="font/woff2"
 						crossOrigin="anonymous"
 					/>
+					<meta
+						name="viewport"
+						content="width=device-width, initial-scale=1.0, maximum-scale=1.0,user-scalable=0"
+					/>
 				</Head>
 				<body>
 					<Main />

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -124,7 +124,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 					height={Math.max(window.innerHeight - (mobile ? 135 : 250), 300)}
 				>
 					<SearchBarContainer>
-						<Search onChange={setSearch} value={search} border={false} />
+						<Search autoFocus onChange={setSearch} value={search} border={false} />
 					</SearchBarContainer>
 					<TableContainer>
 						<StyledTable

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -124,7 +124,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 					height={Math.max(window.innerHeight - (mobile ? 135 : 250), 300)}
 				>
 					<SearchBarContainer>
-						<Search autoFocus onChange={setSearch} value={search} border={false} />
+						<Search onChange={setSearch} value={search} border={false} />
 					</SearchBarContainer>
 					<TableContainer>
 						<StyledTable


### PR DESCRIPTION
Using the `autoFocus` property is causing mobile to zoom on selection of a new market. Add a meta tag to adjust this behavior

## Description
- Add a meta tag to the document to avoid unwanted zooming on mobile/iPhones

## Issues
closes #2075