### PR TITLE
Fixed the arb icon on landing page

### DIFF
--- a/utils/icons.ts
+++ b/utils/icons.ts
@@ -81,6 +81,7 @@ export const SYNTH_ICONS: Record<FuturesMarketKey | SynthsName | string, any> = 
 	sDOGE: DOGEIcon,
 	sXMR: XMRIcon,
 	sOP: OPIcon,
+	sARB: ARBIcon,
 	sATOM: ATOMIcon,
 	sFTM: FTMIcon,
 	sNEAR: NEARIcon,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the missing `ARB` icon to the landing page.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/228179261-08be0518-a9e5-45fa-a928-a52024d20ef6.png)
