### PR TITLE
Fix leverage text

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -212,7 +212,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 								accessor: 'leverage',
 								Cell: (cellProps: CellProps<any>) => {
 									return (
-										<Body>{formatNumber(cellProps.row.original.position.leverage ?? 0)}x</Body>
+										<Body mono>{formatNumber(cellProps.row.original.position.leverage ?? 0)}x</Body>
 									);
 								},
 								width: 90,


### PR DESCRIPTION
Fix leverage text that is missing a `mono` label

Old:
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/10401554/228329887-28a7fa33-5bfb-46d5-8270-6133e4defb12.png">

New:
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/10401554/228329996-3501290f-07ea-4ea1-bdfe-1c6013961583.png">
