### PR TITLE
Bump state migration

### DIFF
--- a/state/migrations.ts
+++ b/state/migrations.ts
@@ -58,7 +58,7 @@ export const migrations = {
 			home: HOME_INITIAL_STATE,
 		};
 	},
-	10: (state: any) => {
+	11: (state: any) => {
 		return {
 			...state,
 			futures: FUTURES_INITIAL_STATE,


### PR DESCRIPTION
Need to clean the futures state so `priceImpactDelta` value is updated.

Fixes the issue with sending `500000000000000000000000000000000000` to contract.