### PR TITLE
UI Refresh: Mobile (Pending and Orders Tabs)

### DIFF
--- a/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
@@ -66,22 +66,24 @@ const ConditionalOrdersTab: React.FC = () => {
 								</div>
 							</FlexDiv>
 							<FlexDiv>
-								<Pill onClick={cancelOrder(order.id)}>Cancel</Pill>
+								<Pill color="red" onClick={cancelOrder(order.id)}>
+									Cancel
+								</Pill>
 								<Spacer width={10} />
 								<Pill>Edit</Pill>
 							</FlexDiv>
 						</OrderMeta>
 						<OrderRow>
 							<Body color="secondary">Size</Body>
-							<div>{order.sizeTxt}</div>
+							<Body>{order.sizeTxt}</Body>
 						</OrderRow>
 						<OrderRow>
 							<Body color="secondary">Reduce Only</Body>
-							<div>{order.reduceOnly ? 'yes' : 'no'}</div>
+							<Body>{order.reduceOnly ? 'Yes' : 'No'}</Body>
 						</OrderRow>
 						<OrderRow>
 							<Body color="secondary">Side</Body>
-							<PositionType side={order.side!} />;
+							<PositionType side={order.side!} />
 						</OrderRow>
 						<OrderRow>
 							<Body color="secondary">CL Price</Body>
@@ -89,7 +91,7 @@ const ConditionalOrdersTab: React.FC = () => {
 						</OrderRow>
 						<OrderRow>
 							<Body color="secondary">Reserved Margin</Body>
-							<div>{formatDollars(order.marginDelta?.gt(0) ? order.marginDelta : '0')}</div>
+							<Body mono>{formatDollars(order.marginDelta?.gt(0) ? order.marginDelta : '0')}</Body>
 						</OrderRow>
 					</OrderItem>
 				))

--- a/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
@@ -66,11 +66,11 @@ const ConditionalOrdersTab: React.FC = () => {
 								</div>
 							</FlexDiv>
 							<FlexDiv>
-								<Pill color="red" onClick={cancelOrder(order.id)}>
+								<Pill size="medium" color="red" onClick={cancelOrder(order.id)}>
 									Cancel
 								</Pill>
 								<Spacer width={10} />
-								<Pill>Edit</Pill>
+								<Pill size="medium">Edit</Pill>
 							</FlexDiv>
 						</OrderMeta>
 						<OrderRow>

--- a/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
@@ -1,24 +1,139 @@
+import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
-import ConditionalOrdersTable from 'sections/futures/UserInfo/ConditionalOrdersTable';
+import Currency from 'components/Currency';
+import { FlexDiv } from 'components/layout/flex';
+import Pill from 'components/Pill';
+import Spacer from 'components/Spacer';
+import { TableNoResults } from 'components/Table';
+import { Body } from 'components/Text';
+import { PositionSide } from 'sdk/types/futures';
+import PositionType from 'sections/futures/PositionType';
+import { cancelConditionalOrder } from 'state/futures/actions';
+import {
+	selectAllConditionalOrders,
+	selectCancellingConditionalOrder,
+	selectMarketAsset,
+} from 'state/futures/selectors';
+import { useAppDispatch, useAppSelector } from 'state/hooks';
+import { formatDollars } from 'utils/formatters/number';
 
 const ConditionalOrdersTab: React.FC = () => {
+	const dispatch = useAppDispatch();
+
+	const marketAsset = useAppSelector(selectMarketAsset);
+	const openConditionalOrders = useAppSelector(selectAllConditionalOrders);
+	const isCancellingOrder = useAppSelector(selectCancellingConditionalOrder);
+
+	const cancelOrder = useCallback(
+		(orderId: number) => () => {
+			dispatch(cancelConditionalOrder(orderId));
+		},
+		[dispatch]
+	);
+
+	const rows = useMemo(() => {
+		const ordersWithCancel = openConditionalOrders.sort((a, b) => {
+			return b.asset === marketAsset && a.asset !== marketAsset
+				? 1
+				: b.asset === marketAsset && a.asset === marketAsset
+				? 0
+				: -1;
+		});
+		const cancellingIndex = ordersWithCancel.findIndex((o) => o.id === isCancellingOrder);
+		ordersWithCancel[cancellingIndex] = {
+			...ordersWithCancel[cancellingIndex],
+			isCancelling: true,
+		};
+		return ordersWithCancel;
+	}, [openConditionalOrders, isCancellingOrder, marketAsset]);
+
 	return (
-		<Container>
-			<TableContainer>
-				<ConditionalOrdersTable />
-			</TableContainer>
-		</Container>
+		<OrdersTabContainer>
+			{rows.length === 0 ? (
+				<TableNoResults>You have no open orders</TableNoResults>
+			) : (
+				rows.map((order) => (
+					<OrderItem>
+						<OrderMeta $side={order.side!}>
+							<FlexDiv>
+								<div className="position-side-bar" />
+								<div>
+									<Body>{order.market}</Body>
+									<Body capitalized color="secondary">
+										{order.orderTypeDisplay}
+									</Body>
+								</div>
+							</FlexDiv>
+							<FlexDiv>
+								<Pill onClick={cancelOrder(order.id)}>Cancel</Pill>
+								<Spacer width={10} />
+								<Pill>Edit</Pill>
+							</FlexDiv>
+						</OrderMeta>
+						<OrderRow>
+							<Body color="secondary">Size</Body>
+							<div>{order.sizeTxt}</div>
+						</OrderRow>
+						<OrderRow>
+							<Body color="secondary">Reduce Only</Body>
+							<div>{order.reduceOnly ? 'yes' : 'no'}</div>
+						</OrderRow>
+						<OrderRow>
+							<Body color="secondary">Side</Body>
+							<PositionType side={order.side!} />;
+						</OrderRow>
+						<OrderRow>
+							<Body color="secondary">CL Price</Body>
+							<Currency.Price price={order.targetPrice} />
+						</OrderRow>
+						<OrderRow>
+							<Body color="secondary">Reserved Margin</Body>
+							<div>{formatDollars(order.marginDelta?.gt(0) ? order.marginDelta : '0')}</div>
+						</OrderRow>
+					</OrderItem>
+				))
+			)}
+		</OrdersTabContainer>
 	);
 };
 
-const Container = styled.div`
-	width: 100%;
-	overflow: scroll;
+const OrdersTabContainer = styled.div`
+	padding-top: 15px;
 `;
 
-const TableContainer = styled.div`
-	width: 1000px;
+const OrderMeta = styled.div<{ $side: PositionSide }>`
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 20px;
+
+	.position-side-bar {
+		height: 100%;
+		width: 4px;
+		margin-right: 8px;
+		background-color: ${(props) =>
+			props.theme.colors.selectedTheme.newTheme.text[
+				props.$side === PositionSide.LONG ? 'positive' : 'negative'
+			]};
+	}
+`;
+
+const OrderItem = styled.div`
+	margin: 0 20px;
+	padding: 20px 0;
+
+	&:not(:last-of-type) {
+		border-bottom: ${(props) => props.theme.colors.selectedTheme.border};
+	}
+`;
+
+const OrderRow = styled.div`
+	display: flex;
+	justify-content: space-between;
+
+	&:not(:last-of-type) {
+		margin-bottom: 10px;
+	}
 `;
 
 export default ConditionalOrdersTab;

--- a/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/ConditionalOrdersTab.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import Currency from 'components/Currency';
 import { FlexDiv } from 'components/layout/flex';
 import Pill from 'components/Pill';
-import Spacer from 'components/Spacer';
 import { TableNoResults } from 'components/Table';
 import { Body } from 'components/Text';
 import { PositionSide } from 'sdk/types/futures';
@@ -69,8 +68,6 @@ const ConditionalOrdersTab: React.FC = () => {
 								<Pill size="medium" color="red" onClick={cancelOrder(order.id)}>
 									Cancel
 								</Pill>
-								<Spacer width={10} />
-								<Pill size="medium">Edit</Pill>
 							</FlexDiv>
 						</OrderMeta>
 						<OrderRow>

--- a/sections/futures/MobileTrade/UserTabs/OrdersTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/OrdersTab.tsx
@@ -160,6 +160,7 @@ const OrdersTab: React.FC = () => {
 							<FlexDiv>
 								{order.show && order.isStale && (
 									<Pill
+										size="medium"
 										onClick={handleCancel(order.marketAddress, order.isOffchain)}
 										disabled={order.isCancelling}
 										color="red"
@@ -171,6 +172,7 @@ const OrdersTab: React.FC = () => {
 									<>
 										<Spacer width={10} />
 										<Pill
+											size="medium"
 											onClick={handleExecute(
 												order.marketKey,
 												order.marketAddress,

--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -170,11 +170,11 @@ const PositionsTab = () => {
 								) : (
 									<Currency.Price price={row.takeProfit} />
 								)}
-								<Spacer width={5} />
+								<Body>/</Body>
 								{row.stopLoss === undefined ? (
-									<Body>{NO_VALUE}</Body>
+									<Body color="secondary">{NO_VALUE}</Body>
 								) : (
-									<Currency.Price price={row.stopLoss} />
+									<Currency.Price price={row.stopLoss} side="secondary" />
 								)}
 								<Spacer width={5} />
 								<Pill

--- a/sections/futures/Trade/MarketsDropdownSelector.tsx
+++ b/sections/futures/Trade/MarketsDropdownSelector.tsx
@@ -1,9 +1,8 @@
 import Wei from '@synthetixio/wei';
 import { FC } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import MarketBadge from 'components/Badge/MarketBadge';
-import ColoredPrice from 'components/ColoredPrice';
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
 import { FlexDivCentered } from 'components/layout/flex';
 import { StyledCaretDownIcon } from 'components/Select/Select';
@@ -32,29 +31,34 @@ type Props = {
 const MarketsDropdownSelector: FC<Props> = (props) => (
 	<Container {...props}>
 		<ContentContainer mobile={props.mobile}>
-			<CurrencyIcon currencyKey={MarketKeyByAsset[props.asset]} width="31px" height="31px" />
-			<div className="currency-meta">
-				<CurrencyLabel weight="bold">
-					{props.label}
-					<MarketBadge
-						currencyKey={props.asset}
-						isFuturesMarketClosed={props.isMarketClosed}
-						futuresClosureReason={props.closureReason}
-					/>
-				</CurrencyLabel>
-			</div>
-			{props.mobile && (
-				<div style={{ marginRight: 15 }}>
-					<ColoredPrice priceInfo={props.priceDetails.priceInfo}>
-						{formatDollars(props.priceDetails.priceInfo?.price ?? '0')}
-					</ColoredPrice>
-					<NumericValue value={props.priceDetails.oneDayChange} colored>
-						{formatPercent(props.priceDetails.oneDayChange)}
-					</NumericValue>
+			<LeftContainer $mobile={props.mobile}>
+				<CurrencyIcon currencyKey={MarketKeyByAsset[props.asset]} width="31px" height="31px" />
+				<div className="currency-meta">
+					<CurrencyLabel weight="bold">
+						{props.label}
+						<MarketBadge
+							currencyKey={props.asset}
+							isFuturesMarketClosed={props.isMarketClosed}
+							futuresClosureReason={props.closureReason}
+						/>
+					</CurrencyLabel>
 				</div>
+				{props.mobile && <StyledCaretDownIcon />}
+			</LeftContainer>
+			{props.mobile && (
+				<MobileRightContainer>
+					<div>
+						<NumericValue value={props.priceDetails.priceInfo}>
+							{formatDollars(props.priceDetails.priceInfo?.price ?? '0')}
+						</NumericValue>
+						<NumericValue value={props.priceDetails.oneDayChange} colored>
+							{formatPercent(props.priceDetails.oneDayChange)}
+						</NumericValue>
+					</div>
+				</MobileRightContainer>
 			)}
 
-			<StyledCaretDownIcon />
+			{!props.mobile && <StyledCaretDownIcon />}
 		</ContentContainer>
 	</Container>
 );
@@ -90,43 +94,39 @@ export const ContentContainer = styled(FlexDivCentered)<{ mobile?: boolean }>`
 		background: ${(props) =>
 			props.theme.colors.selectedTheme.newTheme.button.cell.hover.background};
 	}
-	.name {
-		font-family: ${(props) => props.theme.fonts.regular};
-		font-size: 12.5px;
-		line-height: 12.5px;
-		margin: 0;
-		color: ${(props) => props.theme.colors.selectedTheme.gray};
-	}
 
 	p {
 		margin: 0;
-	}
-
-	.price {
-		font-family: ${(props) => props.theme.fonts.mono};
-		color: ${(props) => props.theme.colors.selectedTheme.gray};
-		font-size: 15px;
-	}
-
-	.change {
-		font-family: ${(props) => props.theme.fonts.mono};
-		font-size: 11.5px;
-		text-align: right;
 	}
 
 	&:not(:last-of-type) {
 		margin-bottom: 4px;
 	}
 
-	.green {
-		color: ${(props) => props.theme.colors.selectedTheme.green};
-	}
-
-	.red {
-		color: ${(props) => props.theme.colors.selectedTheme.red};
-	}
 	height: ${(props) =>
 		props.mobile ? MARKET_SELECTOR_HEIGHT_MOBILE : MARKETS_DETAILS_HEIGHT_DESKTOP - 2}px;
+`;
+
+const LeftContainer = styled.div<{ $mobile?: boolean }>`
+	flex: 1;
+	display: flex;
+	align-items: center;
+
+	${(props) =>
+		props.$mobile &&
+		css`
+			padding-right: 15px;
+			border-right: ${props.theme.colors.selectedTheme.border};
+		`}
+`;
+
+const MobileRightContainer = styled.div`
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	padding-left: 15px;
+	text-align: right;
 `;
 
 export default MarketsDropdownSelector;

--- a/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileMenuModal.tsx
+++ b/sections/shared/Layout/AppLayout/Header/MobileUserMenu/MobileMenuModal.tsx
@@ -167,6 +167,7 @@ const Container = styled.div<{ hasBorder?: boolean }>`
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+	overflow-y: scroll;
 
 	${(props) =>
 		props.hasBorder &&


### PR DESCRIPTION
## Description
This PR implements the designs for the `Pending` and `Orders` tabs on the mobile futures screen.

## Related issue
N/A

## Motivation and Context
UI Refresh Mobile

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
