### PR TITLE
fix: duplicate oi cap warning

### DIFF
--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -913,7 +913,7 @@ export const selectPlaceOrderTranslationKey = createSelector(
 	selectFuturesType,
 	(state: RootState) => state.futures[accountType(state.futures.selectedType)].orderType,
 	selectIsMarketCapReached,
-	(position, marginDelta, { freeMargin }, selectedType, orderType, isMarketCapReached) => {
+	(position, marginDelta, { freeMargin }, selectedType, orderType) => {
 		let remainingMargin;
 		if (selectedType === 'isolated_margin') {
 			remainingMargin = position?.remainingMargin || zeroBN;
@@ -928,9 +928,7 @@ export const selectPlaceOrderTranslationKey = createSelector(
 		if (orderType === 'limit') return 'futures.market.trade.button.place-limit-order';
 		if (orderType === 'stop_market') return 'futures.market.trade.button.place-stop-order';
 		if (!!position?.position) return 'futures.market.trade.button.modify-position';
-		return isMarketCapReached
-			? 'futures.market.trade.button.oi-caps-reached'
-			: 'futures.market.trade.button.open-position';
+		return 'futures.market.trade.button.open-position';
 	}
 );
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -826,7 +826,6 @@
 					"open-position": "Open Position",
 					"modify-position": "modify",
 					"deposit-margin-minimum": "Deposit Margin",
-					"oi-caps-reached": "Open Interest Cap Reached",
 					"place-next-price-order": "Place Next Price Order",
 					"place-delayed-order": "Place Order",
 					"place-limit-order": "Place Limit Order",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current design shows two OI cap warnings in the same spot. 

This PR removes the OI cap warning from the Open Position button, so it just stays disabled with the default button text and shows the error message below the button, as intended.

## How it look currently:
![Screenshot 2023-04-18 at 23 38 10](https://user-images.githubusercontent.com/548702/232953267-4068d357-28fe-4911-a648-0ebf02a576b4.png)

## Fix from this PR:

![Screenshot 2023-04-18 at 23 39 50](https://user-images.githubusercontent.com/548702/232953278-3dbacf61-de99-4839-bd71-0d60aaa8360a.png)