### PR TITLE
Fixed the sorting issue of fav markets in dropdown list

### DIFF
--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -102,8 +102,20 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 
 		const sortedMarkets = markets
 			.filter((m) => favMarkets.includes(m.asset))
-			.sort((a, b) => getMarketName(a.asset).localeCompare(getMarketName(b.asset)))
-			.concat(markets.filter((m) => !favMarkets.includes(m.asset)));
+			.sort((a, b) =>
+				getBasePriceRateInfo(b.asset)?.price.sub(getBasePriceRateInfo(a.asset)?.price).gt(0)
+					? 1
+					: -1
+			)
+			.concat(
+				markets
+					.filter((m) => !favMarkets.includes(m.asset))
+					.sort((a, b) =>
+						getBasePriceRateInfo(b.asset)?.price.sub(getBasePriceRateInfo(a.asset)?.price).gt(0)
+							? 1
+							: -1
+					)
+			);
 
 		return sortedMarkets.map((market) => {
 			const pastPrice = getPastPrice(market.asset);
@@ -169,7 +181,6 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 						<StyledTable
 							highlightRowsOnHover
 							rowStyle={{ padding: '0' }}
-							sortBy={[{ id: 'priceNum', desc: true }]}
 							onTableRowClick={(row) => onSelectMarket(row.original.asset)}
 							columns={[
 								{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The change in #2241 breaks the favorites feature of the market dropdown. The favorite markets are not sticking to the top when opening the markets dropdown. This PR fixed this issue.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
