### PR TITLE
Fix position history query

### DIFF
--- a/sdk/queries/futures.ts
+++ b/sdk/queries/futures.ts
@@ -96,7 +96,7 @@ export const queryPositionHistory = (sdk: KwentaSDK, account: string) => {
 		sdk.futures.futuresGqlEndpoint,
 		{
 			where: {
-				account: account,
+				abstractAccount: account,
 			},
 			first: 99999,
 			orderBy: 'openTimestamp',

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -994,7 +994,7 @@ export const fetchFuturesPositionHistory = createAsyncThunk<
 		const wallet = selectWallet(getState());
 		const futuresSupported = selectFuturesSupportedNetwork(getState());
 		if (!wallet || !account || !futuresSupported) return;
-		const history = await sdk.futures.getPositionHistory(wallet);
+		const history = await sdk.futures.getPositionHistory(account);
 		return { accountType, account, wallet, networkId, history: serializePositionHistory(history) };
 	} catch (err) {
 		notifyError('Failed to fetch position history', err);


### PR DESCRIPTION
Fix an issue where smart margin position history gets requested for isolated margin accounts. The result is that sometimes isolated margin positions will display the avg entry price of their smart margin position.

## Description
* Update the position history query to use _either_ the wallet address or the smart margin account address
* Update the query to use `abstractAccount` to match the address above
