### PR TITLE
Fixed the size delta for the manual input

### DIFF
--- a/sections/futures/ClosePositionModal/ClosePositionSizeInput.tsx
+++ b/sections/futures/ClosePositionModal/ClosePositionSizeInput.tsx
@@ -6,9 +6,13 @@ import InputTitle from 'components/Input/InputTitle';
 import NumericInput from 'components/Input/NumericInput';
 import { FlexDivRow } from 'components/layout/flex';
 import Spacer from 'components/Spacer';
+import { PositionSide } from 'sdk/types/futures';
 import { selectShowPositionModal } from 'state/app/selectors';
 import { editClosePositionSizeDelta } from 'state/futures/actions';
-import { selectClosePositionOrderInputs } from 'state/futures/selectors';
+import {
+	selectClosePositionOrderInputs,
+	selectEditPositionModalInfo,
+} from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { zeroBN } from 'utils/formatters/number';
 
@@ -21,16 +25,21 @@ const ClosePositionSizeInput: React.FC<OrderSizingProps> = memo(({ isMobile, max
 	const dispatch = useAppDispatch();
 
 	const { nativeSizeDelta } = useAppSelector(selectClosePositionOrderInputs);
+	const { position } = useAppSelector(selectEditPositionModalInfo);
 	const modal = useAppSelector(selectShowPositionModal);
 
 	const onSizeChange = useCallback(
 		(value: string) => {
 			if (modal) {
-				const updatedValue = value.includes('-') ? value.replace('-', '') : `-${value}`;
-				dispatch(editClosePositionSizeDelta(modal.marketKey, updatedValue));
+				dispatch(
+					editClosePositionSizeDelta(
+						modal.marketKey,
+						position?.position?.side === PositionSide.LONG ? '-' + value : value
+					)
+				);
 			}
 		},
-		[dispatch, modal]
+		[dispatch, modal, position?.position?.side]
 	);
 
 	const onChangeValue = useCallback(
@@ -44,7 +53,7 @@ const ClosePositionSizeInput: React.FC<OrderSizingProps> = memo(({ isMobile, max
 		return !nativeSizeDelta || isNaN(Number(nativeSizeDelta)) ? zeroBN : wei(nativeSizeDelta);
 	}, [nativeSizeDelta]);
 
-	const invalid = nativeSizeDelta !== '' && maxNativeValue.lt(nativeSizeDeltaWei);
+	const invalid = nativeSizeDelta !== '' && maxNativeValue.lt(nativeSizeDeltaWei.abs());
 
 	return (
 		<OrderSizingContainer>

--- a/sections/futures/ClosePositionModal/ClosePositionSizeInput.tsx
+++ b/sections/futures/ClosePositionModal/ClosePositionSizeInput.tsx
@@ -26,7 +26,8 @@ const ClosePositionSizeInput: React.FC<OrderSizingProps> = memo(({ isMobile, max
 	const onSizeChange = useCallback(
 		(value: string) => {
 			if (modal) {
-				dispatch(editClosePositionSizeDelta(modal.marketKey, value));
+				const updatedValue = value.includes('-') ? value.replace('-', '') : `-${value}`;
+				dispatch(editClosePositionSizeDelta(modal.marketKey, updatedValue));
 			}
 		},
 		[dispatch, modal]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The side of the close position modal is incorrect for the manual input value.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
1. Open the position
2. Click the close button on the position table 
3. Use a selector or type the value manually.  The preview are correct for both.
4. Confirm the order and the execute the txns successfully

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Open short and close partial position is working
![image](https://user-images.githubusercontent.com/4819006/233335469-e75fdeec-e54f-4ab7-83f5-5a39ef34f599.png)

Open long and close partial position is working
![image](https://user-images.githubusercontent.com/4819006/233335659-538dd619-3f7a-48ae-8b88-42ddf880f199.png)
