### PR TITLE
Add share button to position rows and remove from top bar

### DIFF
--- a/sections/futures/ShareModal/AmountContainer.tsx
+++ b/sections/futures/ShareModal/AmountContainer.tsx
@@ -14,8 +14,8 @@ type AmountContainerProps = {
 };
 
 const AmountContainer: FC<AmountContainerProps> = ({ position }) => {
-	const marketAsset = useAppSelector(selectMarketAsset);
-
+	const defaultAsset = useAppSelector(selectMarketAsset);
+	const marketAsset = position?.asset ?? defaultAsset;
 	const marketName = getMarketName(marketAsset);
 	const positionDetails = position?.position ?? null;
 	const leverage = formatNumber(positionDetails?.leverage ?? zeroBN) + 'x';

--- a/sections/futures/ShareModal/AmountContainer.tsx
+++ b/sections/futures/ShareModal/AmountContainer.tsx
@@ -2,22 +2,19 @@ import { FC, useMemo } from 'react';
 import styled from 'styled-components';
 
 import CurrencyIcon from 'components/Currency/CurrencyIcon';
-import { FuturesPosition, PositionSide } from 'sdk/types/futures';
+import { PositionSide } from 'sdk/types/futures';
 import { selectMarketAsset } from 'state/futures/selectors';
+import { SharePositionParams } from 'state/futures/types';
 import { useAppSelector } from 'state/hooks';
 import media from 'styles/media';
 import { formatNumber, zeroBN } from 'utils/formatters/number';
 import { getMarketName, MarketKeyByAsset } from 'utils/futures';
 
-type AmountContainerProps = {
-	position: FuturesPosition | null | undefined;
-};
-
-const AmountContainer: FC<AmountContainerProps> = ({ position }) => {
+const AmountContainer: FC<SharePositionParams> = ({ asset, position }) => {
 	const defaultAsset = useAppSelector(selectMarketAsset);
-	const marketAsset = position?.asset ?? defaultAsset;
+	const marketAsset = asset ?? defaultAsset;
 	const marketName = getMarketName(marketAsset);
-	const positionDetails = position?.position ?? null;
+	const positionDetails = position ?? null;
 	const leverage = formatNumber(positionDetails?.leverage ?? zeroBN) + 'x';
 	const side = positionDetails?.side === 'long' ? PositionSide.LONG : PositionSide.SHORT;
 	const pnlPct = positionDetails?.pnlPct.mul(100);

--- a/sections/futures/ShareModal/PositionMetadata.tsx
+++ b/sections/futures/ShareModal/PositionMetadata.tsx
@@ -1,13 +1,18 @@
+import Wei from '@synthetixio/wei';
 import { format } from 'date-fns';
-import { FC, useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { selectMarketPrice, selectSelectedMarketPositionHistory } from 'state/futures/selectors';
-import { useAppSelector } from 'state/hooks';
+import { FuturesPositionHistory } from 'sdk/types/futures';
 import media from 'styles/media';
 import getLocale from 'utils/formatters/getLocale';
 import { formatDollars, formatNumber, zeroBN } from 'utils/formatters/number';
+
+type PositionMetadataProps = {
+	positionHistory: FuturesPositionHistory | null | undefined;
+	marketPrice: Wei;
+};
 
 function getColor(props: any) {
 	let color = '';
@@ -80,31 +85,22 @@ function getFontFamily(props: any) {
 	}
 }
 
-const PositionMetadata: FC = () => {
+const PositionMetadata: React.FC<PositionMetadataProps> = ({ positionHistory, marketPrice }) => {
 	const { t } = useTranslation();
 	const [currentTimestamp, setCurrentTimestamp] = useState(0);
 
-	const currentPosition = useAppSelector(selectSelectedMarketPositionHistory);
-	const marketPrice = useAppSelector(selectMarketPrice);
-
-	let avgEntryPrice = '',
-		openAtDate = '',
-		openAtTime = '',
-		createdOnDate = '',
-		createdOnTime = '';
-
-	avgEntryPrice = currentPosition?.avgEntryPrice.toNumber().toString() ?? '';
-	const openTimestamp = currentPosition?.openTimestamp ?? 0;
-
-	openAtDate = format(openTimestamp, 'PP', { locale: getLocale() });
-	openAtTime = format(openTimestamp, 'HH:mm:ss', { locale: getLocale() });
-	createdOnDate = format(currentTimestamp, 'PP', { locale: getLocale() });
-	createdOnTime = format(currentTimestamp, 'HH:mm:ss', { locale: getLocale() });
+	const avgEntryPrice = positionHistory?.avgEntryPrice.toNumber().toString() ?? '';
+	const openTimestamp = positionHistory?.openTimestamp ?? 0;
 
 	useLayoutEffect(() => {
 		const now = new Date().getTime();
 		setCurrentTimestamp(now);
 	}, []);
+
+	const openAtDate = format(openTimestamp, 'PP', { locale: getLocale() });
+	const openAtTime = format(openTimestamp, 'HH:mm:ss', { locale: getLocale() });
+	const createdOnDate = format(currentTimestamp, 'PP', { locale: getLocale() });
+	const createdOnTime = format(currentTimestamp, 'HH:mm:ss', { locale: getLocale() });
 
 	return (
 		<>

--- a/sections/futures/ShareModal/PositionMetadata.tsx
+++ b/sections/futures/ShareModal/PositionMetadata.tsx
@@ -1,18 +1,12 @@
-import Wei from '@synthetixio/wei';
 import { format } from 'date-fns';
 import { useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { FuturesPositionHistory } from 'sdk/types/futures';
+import { SharePositionParams } from 'state/futures/types';
 import media from 'styles/media';
 import getLocale from 'utils/formatters/getLocale';
 import { formatDollars, formatNumber, zeroBN } from 'utils/formatters/number';
-
-type PositionMetadataProps = {
-	positionHistory: FuturesPositionHistory | null | undefined;
-	marketPrice: Wei;
-};
 
 function getColor(props: any) {
 	let color = '';
@@ -85,7 +79,7 @@ function getFontFamily(props: any) {
 	}
 }
 
-const PositionMetadata: React.FC<PositionMetadataProps> = ({ positionHistory, marketPrice }) => {
+const PositionMetadata: React.FC<SharePositionParams> = ({ positionHistory, marketPrice }) => {
 	const { t } = useTranslation();
 	const [currentTimestamp, setCurrentTimestamp] = useState(0);
 
@@ -132,7 +126,9 @@ const PositionMetadata: React.FC<PositionMetadataProps> = ({ positionHistory, ma
 				<ContainerText className="header">
 					{t('futures.modals.share.position-metadata.current-price')}
 				</ContainerText>
-				<ContainerText className="date-or-price">{formatNumber(marketPrice)}</ContainerText>
+				<ContainerText className="date-or-price">
+					{formatNumber(marketPrice ?? zeroBN)}
+				</ContainerText>
 			</BottomRightContainer>
 		</>
 	);

--- a/sections/futures/ShareModal/ShareModal.tsx
+++ b/sections/futures/ShareModal/ShareModal.tsx
@@ -1,3 +1,4 @@
+import Wei from '@synthetixio/wei';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -6,7 +7,7 @@ import MobilePNLGraphicPNG from 'assets/png/mobile-pnl-graphic.png';
 import PNLGraphicPNG from 'assets/png/pnl-graphic.png';
 import BaseModal from 'components/BaseModal';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
-import { FuturesPosition } from 'sdk/types/futures';
+import { FuturesPosition, FuturesPositionHistory } from 'sdk/types/futures';
 import media from 'styles/media';
 
 import AmountContainer from './AmountContainer';
@@ -15,10 +16,17 @@ import ShareModalButton from './ShareModalButton';
 
 type ShareModalProps = {
 	position: FuturesPosition | null | undefined;
+	positionHistory: FuturesPositionHistory | null | undefined;
+	marketPrice: Wei;
 	setShowShareModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const ShareModal: FC<ShareModalProps> = ({ position, setShowShareModal }) => {
+const ShareModal: FC<ShareModalProps> = ({
+	position,
+	positionHistory,
+	marketPrice,
+	setShowShareModal,
+}) => {
 	const { t } = useTranslation();
 
 	return (
@@ -39,7 +47,7 @@ const ShareModal: FC<ShareModalProps> = ({ position, setShowShareModal }) => {
 							</MobileOrTabletView>
 						</PNLImageFrame>
 						<AmountContainer position={position} />
-						<PositionMetadata />
+						<PositionMetadata positionHistory={positionHistory} marketPrice={marketPrice} />
 					</PNLGraphic>
 					<ShareModalButton position={position} />
 				</ModalWindow>

--- a/sections/futures/ShareModal/ShareModal.tsx
+++ b/sections/futures/ShareModal/ShareModal.tsx
@@ -1,4 +1,3 @@
-import Wei from '@synthetixio/wei';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -7,7 +6,7 @@ import MobilePNLGraphicPNG from 'assets/png/mobile-pnl-graphic.png';
 import PNLGraphicPNG from 'assets/png/pnl-graphic.png';
 import BaseModal from 'components/BaseModal';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
-import { FuturesPosition, FuturesPositionHistory } from 'sdk/types/futures';
+import { SharePositionParams } from 'state/futures/types';
 import media from 'styles/media';
 
 import AmountContainer from './AmountContainer';
@@ -15,18 +14,11 @@ import PositionMetadata from './PositionMetadata';
 import ShareModalButton from './ShareModalButton';
 
 type ShareModalProps = {
-	position: FuturesPosition | null | undefined;
-	positionHistory: FuturesPositionHistory | null | undefined;
-	marketPrice: Wei;
+	sharePosition: SharePositionParams;
 	setShowShareModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const ShareModal: FC<ShareModalProps> = ({
-	position,
-	positionHistory,
-	marketPrice,
-	setShowShareModal,
-}) => {
+const ShareModal: FC<ShareModalProps> = ({ sharePosition, setShowShareModal }) => {
 	const { t } = useTranslation();
 
 	return (
@@ -46,10 +38,13 @@ const ShareModal: FC<ShareModalProps> = ({
 								<PNLImage src={MobilePNLGraphicPNG} aria-label="pnl-graphic" />
 							</MobileOrTabletView>
 						</PNLImageFrame>
-						<AmountContainer position={position} />
-						<PositionMetadata positionHistory={positionHistory} marketPrice={marketPrice} />
+						<AmountContainer asset={sharePosition.asset} position={sharePosition.position} />
+						<PositionMetadata
+							positionHistory={sharePosition.positionHistory}
+							marketPrice={sharePosition.marketPrice}
+						/>
 					</PNLGraphic>
-					<ShareModalButton position={position} />
+					<ShareModalButton position={sharePosition} />
 				</ModalWindow>
 			</BaseModal>
 		</>

--- a/sections/futures/ShareModal/ShareModalButton.tsx
+++ b/sections/futures/ShareModal/ShareModalButton.tsx
@@ -6,13 +6,8 @@ import styled from 'styled-components';
 import TwitterIcon from 'assets/svg/social/twitter.svg';
 import Button from 'components/Button';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
-import { FuturesPosition, PositionSide } from 'sdk/types/futures';
-import {
-	selectMarketAsset,
-	selectMarketPrice,
-	selectSelectedMarketPositionHistory,
-} from 'state/futures/selectors';
-import { useAppSelector } from 'state/hooks';
+import { PositionSide } from 'sdk/types/futures';
+import { SharePositionParams } from 'state/futures/types';
 import { formatDollars, formatNumber, zeroBN } from 'utils/formatters/number';
 import { getMarketName } from 'utils/futures';
 
@@ -42,15 +37,11 @@ function downloadPng(dataUrl: string) {
 }
 
 type ShareModalButtonProps = {
-	position: FuturesPosition | null | undefined;
+	position: SharePositionParams;
 };
 
 const ShareModalButton: FC<ShareModalButtonProps> = ({ position }) => {
 	const { t } = useTranslation();
-
-	const marketAsset = useAppSelector(selectMarketAsset);
-	const marketPrice = useAppSelector(selectMarketPrice);
-	const currentPosition = useAppSelector(selectSelectedMarketPositionHistory);
 
 	const handleDownloadImage = async () => {
 		let node = document.getElementById('pnl-graphic');
@@ -62,17 +53,17 @@ const ShareModalButton: FC<ShareModalButtonProps> = ({ position }) => {
 	};
 
 	const handleTweet = () => {
-		const positionDetails = position?.position ?? null;
+		const positionDetails = position.position ?? null;
 		const side = positionDetails?.side === 'long' ? PositionSide.LONG : PositionSide.SHORT;
-		const marketName = getMarketName(marketAsset);
+		const marketName = getMarketName(position.asset!);
 		const leverage = formatNumber(positionDetails?.leverage ?? zeroBN) + 'x';
 		const pnlPct = `+${positionDetails?.pnlPct.mul(100).toNumber().toFixed(2)}%`;
 
-		const avgEntryPrice = currentPosition?.avgEntryPrice
-			? formatNumber(currentPosition?.avgEntryPrice)
+		const avgEntryPrice = position.positionHistory?.avgEntryPrice
+			? formatNumber(position.positionHistory?.avgEntryPrice)
 			: '';
 		const dollarEntry = formatDollars(avgEntryPrice ?? zeroBN, { suggestDecimals: true });
-		const dollarCurrent = formatNumber(marketPrice);
+		const dollarCurrent = formatNumber(position.marketPrice ?? zeroBN);
 		const text = getTwitterText(side, marketName, leverage, pnlPct, dollarEntry, dollarCurrent);
 		window.open(`https://twitter.com/intent/tweet?text=${text}`, '_blank');
 	};

--- a/sections/futures/UserInfo/PositionsTable.tsx
+++ b/sections/futures/UserInfo/PositionsTable.tsx
@@ -1,11 +1,12 @@
 import { useRouter } from 'next/router';
-import { FC, useMemo } from 'react';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CellProps } from 'react-table';
 import styled from 'styled-components';
 
+import UploadIcon from 'assets/svg/futures/upload-icon.svg';
 import Currency from 'components/Currency';
-import { FlexDivRowCentered } from 'components/layout/flex';
+import { FlexDivRow, FlexDivRowCentered } from 'components/layout/flex';
 import Pill from 'components/Pill';
 import Spacer from 'components/Spacer';
 import Table, { TableHeader, TableNoResults } from 'components/Table';
@@ -22,11 +23,13 @@ import {
 	selectIsolatedMarginPositions,
 	selectMarketAsset,
 	selectMarkets,
+	selectPosition,
 	selectPositionHistory,
 } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { formatPercent } from 'utils/formatters/number';
 
+import ShareModal from '../ShareModal';
 import TableMarketDetails from './TableMarketDetails';
 
 type FuturesPositionTableProps = {
@@ -48,6 +51,8 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 	const currentMarket = useAppSelector(selectMarketAsset);
 	const futuresMarkets = useAppSelector(selectMarkets);
 	const accountType = useAppSelector(selectFuturesType);
+	const [showShareModal, setShowShareModal] = useState(false);
+	const position = useAppSelector(selectPosition);
 
 	let data = useMemo(() => {
 		const positions = accountType === 'cross_margin' ? crossMarginPositions : isolatedPositions;
@@ -75,6 +80,10 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 		positionHistory,
 		currentMarket,
 	]);
+
+	const handleOpenShareModal = useCallback(() => {
+		setShowShareModal((s) => !s);
+	}, []);
 
 	return (
 		<Container>
@@ -324,21 +333,34 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 							accessor: 'pos',
 							Cell: (cellProps: CellProps<typeof data[number]>) => {
 								return (
-									<div>
-										<Pill
-											onClick={() =>
-												dispatch(
-													setShowPositionModal({
-														type: 'futures_close_position',
-														marketKey: cellProps.row.original.market.marketKey,
-													})
-												)
-											}
-											size="small"
-										>
-											Close
-										</Pill>
-									</div>
+									<FlexDivRow style={{ columnGap: '5px' }}>
+										<div>
+											<Pill
+												onClick={() =>
+													dispatch(
+														setShowPositionModal({
+															type: 'futures_close_position',
+															marketKey: cellProps.row.original.market.marketKey,
+														})
+													)
+												}
+												size="small"
+											>
+												Close
+											</Pill>
+										</div>
+										<div>
+											<Pill fullWidth onClick={handleOpenShareModal} size="small">
+												<FlexDivRowCentered>
+													<UploadIcon
+														width={6}
+														style={{ marginRight: '2px', marginBottom: '1px' }}
+													/>
+													Share
+												</FlexDivRowCentered>
+											</Pill>
+										</div>
+									</FlexDivRow>
 								);
 							},
 							width: 90,
@@ -346,6 +368,7 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 					]}
 				/>
 			</TableContainer>
+			{showShareModal && <ShareModal position={position} setShowShareModal={setShowShareModal} />}
 		</Container>
 	);
 };

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -7,7 +7,6 @@ import TransfersIcon from 'assets/svg/futures/deposit-withdraw-arrows.svg';
 import OpenPositionsIcon from 'assets/svg/futures/icon-open-positions.svg';
 import OrderHistoryIcon from 'assets/svg/futures/icon-order-history.svg';
 import PositionIcon from 'assets/svg/futures/icon-position.svg';
-import UploadIcon from 'assets/svg/futures/upload-icon.svg';
 import TabButton from 'components/Button/TabButton';
 import Spacer from 'components/Spacer';
 import { TabPanel } from 'components/Tab';
@@ -65,7 +64,6 @@ const UserInfo: React.FC = memo(() => {
 	});
 
 	const [showShareModal, setShowShareModal] = useState(false);
-	const [hasOpenPosition, setHasOpenPosition] = useState(false);
 	const [openProfitCalcModal, setOpenProfitCalcModal] = useState(false);
 
 	const tabQuery = useMemo(() => {
@@ -82,10 +80,6 @@ const UserInfo: React.FC = memo(() => {
 
 	const handleOpenProfitCalc = useCallback(() => {
 		setOpenProfitCalcModal((s) => !s);
-	}, []);
-
-	const handleOpenShareModal = useCallback(() => {
-		setShowShareModal((s) => !s);
 	}, []);
 
 	const refetchTrades = useCallback(() => {
@@ -169,10 +163,6 @@ const UserInfo: React.FC = memo(() => {
 		]
 	);
 
-	useEffect(() => {
-		setHasOpenPosition(!!position?.position);
-	}, [position]);
-
 	const filteredTabs = TABS.filter((tab) => !tab.disabled);
 
 	return (
@@ -201,14 +191,6 @@ const UserInfo: React.FC = memo(() => {
 						title="Calculator"
 						icon={<CalculatorIcon />}
 						onClick={handleOpenProfitCalc}
-					/>
-					<TabButton
-						inline
-						key={FuturesTab.SHARE}
-						title="Share"
-						disabled={!hasOpenPosition}
-						icon={<UploadIcon />}
-						onClick={handleOpenShareModal}
 					/>
 				</TabRight>
 			</TabButtonsContainer>

--- a/sections/futures/UserInfo/UserInfo.tsx
+++ b/sections/futures/UserInfo/UserInfo.tsx
@@ -25,7 +25,6 @@ import { useAppSelector, useFetchAction, useAppDispatch } from 'state/hooks';
 import { selectWallet } from 'state/wallet/selectors';
 
 import ProfitCalculator from '../ProfitCalculator';
-import ShareModal from '../ShareModal';
 import Trades from '../Trades';
 import Transfers from '../Transfers';
 import ConditionalOrdersTable from './ConditionalOrdersTable';
@@ -63,7 +62,6 @@ const UserInfo: React.FC = memo(() => {
 		disabled: !walletAddress,
 	});
 
-	const [showShareModal, setShowShareModal] = useState(false);
 	const [openProfitCalcModal, setOpenProfitCalcModal] = useState(false);
 
 	const tabQuery = useMemo(() => {
@@ -212,7 +210,6 @@ const UserInfo: React.FC = memo(() => {
 			</TabPanel>
 
 			{openProfitCalcModal && <ProfitCalculator setOpenProfitCalcModal={setOpenProfitCalcModal} />}
-			{showShareModal && <ShareModal position={position} setShowShareModal={setShowShareModal} />}
 		</UserInfoContainer>
 	);
 });

--- a/state/futures/types.ts
+++ b/state/futures/types.ts
@@ -18,6 +18,7 @@ import {
 	FuturesMarketAsset,
 	MarginTransfer,
 	FuturesAccountType,
+	FuturesFilledPosition,
 } from 'sdk/types/futures';
 import { PricesInfo } from 'state/prices/types';
 import { QueryStatus } from 'state/types';
@@ -352,6 +353,13 @@ export type TradePreviewParams = {
 
 export type DebouncedPreviewParams = TradePreviewParams & {
 	debounceCount: number;
+};
+
+export type SharePositionParams = {
+	asset?: FuturesMarketAsset;
+	position?: FuturesFilledPosition;
+	positionHistory?: FuturesPositionHistory;
+	marketPrice?: Wei;
 };
 
 export const futuresPositionKeys = new Set([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Desktop: add share button to position rows and remove from top bar
2. Mobile: add share button to position rows

## Related issue
#2210 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
#### Desktop:
1. Open the market page and click the share button on the row
2. Verify the share info
3. Click the download image and verify the share info of the image
#### Mobile:
1. Open the market page and click the share button on the row
2. Verify the share info
3. Click the download image and verify the share info of the image
4. Click the tweet button and verify the share info of tweet text

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/233473695-d83cdf1d-1049-46e8-bc2e-d1cdc425fba6.png)
![image](https://user-images.githubusercontent.com/4819006/233858261-e3f9634c-7ff8-477f-bbf0-40ad04c8162e.png)
![image](https://user-images.githubusercontent.com/4819006/233858217-38cf7886-ca9f-4528-96b9-d055e6fc1dc9.png)
![image](https://user-images.githubusercontent.com/4819006/233858227-ded35196-17c2-4be6-aea5-3b9594d9cc0d.png)
![image](https://user-images.githubusercontent.com/4819006/233858248-ca7684a3-e3ac-48c3-84dc-82a3ae3b8544.png)


