### PR TITLE
Update Smart Margin prompt and Market Skew

### DIFF
--- a/pages/market.tsx
+++ b/pages/market.tsx
@@ -159,15 +159,7 @@ function TradePanelDesktop() {
 		);
 	}
 
-	if (accountType === 'isolated_margin' && isolatedPositionsCount === 0) {
-		return open ? (
-			<SwitchToSmartMargin onDismiss={() => setOpen(false)} />
-		) : (
-			<TradeIsolatedMargin />
-		);
-	}
-
-	return <TradeIsolatedMargin />;
+	return open ? <SwitchToSmartMargin onDismiss={() => setOpen(false)} /> : <TradeIsolatedMargin />;
 }
 
 Market.getLayout = (page) => <AppLayout>{page}</AppLayout>;

--- a/sections/futures/FeeInfoBox/TradePanelFeeInfo.tsx
+++ b/sections/futures/FeeInfoBox/TradePanelFeeInfo.tsx
@@ -43,8 +43,8 @@ const TradingRewardRow = memo(() => {
 		[walletAddress, stakedKwentaBalance, stakedEscrowedKwentaBalance]
 	);
 
-	const goToStaking = useCallback(() => {
-		router.push(ROUTES.Dashboard.Stake);
+	const goToRewards = useCallback(() => {
+		router.push(ROUTES.Dashboard.Rewards);
 	}, []);
 
 	return (
@@ -53,7 +53,7 @@ const TradingRewardRow = memo(() => {
 			compactBox
 			value=""
 			keyNode={
-				<CompactBox $isEligible={isRewardEligible} onClick={goToStaking}>
+				<CompactBox $isEligible={isRewardEligible} onClick={goToRewards}>
 					<FlexDivRow style={{ marginBottom: '5px' }}>
 						<div>{t('dashboard.stake.tabs.trading-rewards.trading-reward')}</div>
 						<Badge color="gray">

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -156,6 +156,13 @@ const MarketSkew: React.FC<MarketDetailsProps> = memo(({ mobile }) => {
 			value={
 				<>
 					<MarketDetailValue
+						color="green"
+						value={formatPercent(marketInfo ? marketInfo?.openInterest.longPct : 0, {
+							minDecimals: 0,
+						})}
+						mobile={mobile}
+					/>
+					<MarketDetailValue
 						color="red"
 						value={formatPercent(marketInfo ? marketInfo?.openInterest.shortPct : 0, {
 							minDecimals: 0,
@@ -163,13 +170,6 @@ const MarketSkew: React.FC<MarketDetailsProps> = memo(({ mobile }) => {
 						mobile={mobile}
 					/>
 					{'/'}
-					<MarketDetailValue
-						color="green"
-						value={formatPercent(marketInfo ? marketInfo?.openInterest.longPct : 0, {
-							minDecimals: 0,
-						})}
-						mobile={mobile}
-					/>
 				</>
 			}
 		/>

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -162,6 +162,7 @@ const MarketSkew: React.FC<MarketDetailsProps> = memo(({ mobile }) => {
 						})}
 						mobile={mobile}
 					/>
+					{'/'}
 					<MarketDetailValue
 						color="red"
 						value={formatPercent(marketInfo ? marketInfo?.openInterest.shortPct : 0, {
@@ -169,7 +170,6 @@ const MarketSkew: React.FC<MarketDetailsProps> = memo(({ mobile }) => {
 						})}
 						mobile={mobile}
 					/>
-					{'/'}
 				</>
 			}
 		/>

--- a/translations/en.json
+++ b/translations/en.json
@@ -594,7 +594,7 @@
 					"trading-reward": "Trading Rewards:",
 					"not-eligible": "Eligible",
 					"eligible": "Eligible",
-					"stake-to-earn": "Trade to start earning <0>$KWENTA</0> rewards",
+					"stake-to-earn": "Trade to start earning <0>$KWENTA</0> and <0>$OP</0> rewards",
 					"stake-to-start": "Trade to start earning <0>$KWENTA</0> rewards",
 					"learn-more": "Learn More"
 				},

--- a/translations/en.json
+++ b/translations/en.json
@@ -594,8 +594,8 @@
 					"trading-reward": "Trading Rewards:",
 					"not-eligible": "Eligible",
 					"eligible": "Eligible",
-					"stake-to-earn": "Trade to start earning <0>$KWENTA</0> and <0>$OP</0> rewards",
-					"stake-to-start": "Trade to start earning <0>$KWENTA</0> rewards",
+					"stake-to-earn": "Trade to start earning <0>$KWENTA</0> and <0>$OP</> rewards",
+					"stake-to-start": "Trade to start earning <0>$KWENTA</0> and <0>$OP</> rewards",
 					"learn-more": "Learn More"
 				},
 				"escrow": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -594,8 +594,8 @@
 					"trading-reward": "Trading Rewards:",
 					"not-eligible": "Eligible",
 					"eligible": "Eligible",
-					"stake-to-earn": "Trade to start earning <0>$KWENTA</0> and <0>$OP</> rewards",
-					"stake-to-start": "Trade to start earning <0>$KWENTA</0> and <0>$OP</> rewards",
+					"stake-to-earn": "Trade to earn <0>$KWENTA</0> and <0>$OP</> rewards",
+					"stake-to-start": "Trade to earn <0>$KWENTA</0> and <0>$OP</> rewards",
 					"learn-more": "Learn More"
 				},
 				"escrow": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. The smart margin prompt should be hidden when the user has no isolated margin positions.
2. Switch the position of long/short skew
3. Update the rewards badge

## Related issue
#2224 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Case 1:  The user has no isolated margin positions
- Show the prompt when user opens isolated margin

Case 2: The user has isolated margin positions
- The prompt is hidden

## Screenshots (if appropriate):
