### PR TITLE
Fix: Missing items on mobile positions

### DIFF
--- a/components/Currency/CurrencyPrice/CurrencyPrice.tsx
+++ b/components/Currency/CurrencyPrice/CurrencyPrice.tsx
@@ -17,7 +17,7 @@ type CurrencyPriceProps = {
 	conversionRate?: WeiSource;
 	formatOptions?: FormatCurrencyOptions;
 	truncate?: boolean;
-	side?: 'secondary' | 'positive' | 'negative' | 'preview';
+	colorType?: 'secondary' | 'positive' | 'negative' | 'preview';
 	colored?: boolean;
 };
 
@@ -26,7 +26,7 @@ export const CurrencyPrice: FC<CurrencyPriceProps> = memo(
 		price,
 		change,
 		formatOptions,
-		side,
+		colorType: side,
 		sign,
 		currencyKey = 'sUSD',
 		conversionRate = 1,

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -205,12 +205,12 @@ const FuturesMarketsTable: FC = () => {
 											<Currency.Price
 												price={cellProps.row.original.longInterest}
 												truncate
-												side="positive"
+												colorType="positive"
 											/>
 											<Currency.Price
 												price={cellProps.row.original.shortInterest}
 												truncate
-												side="negative"
+												colorType="negative"
 											/>
 										</OpenInterestContainer>
 									);

--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -127,7 +127,7 @@ const PositionsTab = () => {
 								<Currency.Price
 									price={row.position.notionalValue}
 									formatOptions={row.position.notionalValue.gte(1e6) ? { truncate: true } : {}}
-									side="secondary"
+									colorType="secondary"
 								/>
 								<Spacer width={5} />
 								<Pill
@@ -187,6 +187,10 @@ const PositionsTab = () => {
 							</FlexDivRowCentered>
 						</PositionRow>
 						<PositionRow>
+							<Body color="secondary">Liquidation</Body>
+							<Currency.Price price={row.position.liquidationPrice} colorType="preview" />
+						</PositionRow>
+						<PositionRow>
 							<Body color="secondary">Unrealized PnL</Body>
 							<Currency.Price price={row.position.pnl} colored />
 						</PositionRow>
@@ -202,7 +206,7 @@ const PositionsTab = () => {
 								{row.stopLoss === undefined ? (
 									<Body color="secondary">{NO_VALUE}</Body>
 								) : (
-									<Currency.Price price={row.stopLoss} side="secondary" />
+									<Currency.Price price={row.stopLoss} colorType="secondary" />
 								)}
 								<Spacer width={5} />
 								<Pill

--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -129,6 +129,20 @@ const PositionsTab = () => {
 									formatOptions={row.position.notionalValue.gte(1e6) ? { truncate: true } : {}}
 									side="secondary"
 								/>
+								<Spacer width={5} />
+								<Pill
+									size="medium"
+									onClick={() =>
+										dispatch(
+											setShowPositionModal({
+												type: 'futures_edit_position_size',
+												marketKey: row.market.marketKey,
+											})
+										)
+									}
+								>
+									Edit
+								</Pill>
 							</FlexDivRowCentered>
 						</PositionRow>
 						<PositionRow>
@@ -150,6 +164,20 @@ const PositionsTab = () => {
 							<Body color="secondary">Market Margin</Body>
 							<FlexDivRowCentered>
 								<NumericValue value={row.position.initialMargin} />
+								<Spacer width={5} />
+								<Pill
+									size="medium"
+									onClick={() =>
+										dispatch(
+											setShowPositionModal({
+												type: 'futures_edit_position_margin',
+												marketKey: row.market.marketKey,
+											})
+										)
+									}
+								>
+									Edit
+								</Pill>
 							</FlexDivRowCentered>
 						</PositionRow>
 						<PositionRow>
@@ -234,6 +262,7 @@ const PositionItem = styled.div`
 const PositionRow = styled.div`
 	display: flex;
 	justify-content: space-between;
+	min-height: 22px;
 
 	&:not(:last-of-type) {
 		margin-bottom: 10px;

--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -129,20 +129,24 @@ const PositionsTab = () => {
 									formatOptions={row.position.notionalValue.gte(1e6) ? { truncate: true } : {}}
 									colorType="secondary"
 								/>
-								<Spacer width={5} />
-								<Pill
-									size="medium"
-									onClick={() =>
-										dispatch(
-											setShowPositionModal({
-												type: 'futures_edit_position_size',
-												marketKey: row.market.marketKey,
-											})
-										)
-									}
-								>
-									Edit
-								</Pill>
+								{accountType === 'cross_margin' && (
+									<>
+										<Spacer width={5} />
+										<Pill
+											size="medium"
+											onClick={() =>
+												dispatch(
+													setShowPositionModal({
+														type: 'futures_edit_position_size',
+														marketKey: row.market.marketKey,
+													})
+												)
+											}
+										>
+											Edit
+										</Pill>
+									</>
+								)}
 							</FlexDivRowCentered>
 						</PositionRow>
 						<PositionRow>
@@ -164,20 +168,24 @@ const PositionsTab = () => {
 							<Body color="secondary">Market Margin</Body>
 							<FlexDivRowCentered>
 								<NumericValue value={row.position.initialMargin} />
-								<Spacer width={5} />
-								<Pill
-									size="medium"
-									onClick={() =>
-										dispatch(
-											setShowPositionModal({
-												type: 'futures_edit_position_margin',
-												marketKey: row.market.marketKey,
-											})
-										)
-									}
-								>
-									Edit
-								</Pill>
+								{accountType === 'cross_margin' && (
+									<>
+										<Spacer width={5} />
+										<Pill
+											size="medium"
+											onClick={() =>
+												dispatch(
+													setShowPositionModal({
+														type: 'futures_edit_position_margin',
+														marketKey: row.market.marketKey,
+													})
+												)
+											}
+										>
+											Edit
+										</Pill>
+									</>
+								)}
 							</FlexDivRowCentered>
 						</PositionRow>
 						<PositionRow>
@@ -208,20 +216,24 @@ const PositionsTab = () => {
 								) : (
 									<Currency.Price price={row.stopLoss} colorType="secondary" />
 								)}
-								<Spacer width={5} />
-								<Pill
-									size="medium"
-									onClick={() =>
-										dispatch(
-											setShowPositionModal({
-												type: 'futures_edit_stop_loss_take_profit',
-												marketKey: row.market.marketKey,
-											})
-										)
-									}
-								>
-									Edit
-								</Pill>
+								{accountType === 'cross_margin' && (
+									<>
+										<Spacer width={5} />
+										<Pill
+											size="medium"
+											onClick={() =>
+												dispatch(
+													setShowPositionModal({
+														type: 'futures_edit_stop_loss_take_profit',
+														marketKey: row.market.marketKey,
+													})
+												)
+											}
+										>
+											Edit
+										</Pill>
+									</>
+								)}
 							</FlexDivRowCentered>
 						</PositionRow>
 					</PositionItem>

--- a/sections/futures/UserInfo/PositionsTable.tsx
+++ b/sections/futures/UserInfo/PositionsTable.tsx
@@ -157,7 +157,7 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 											<Currency.Price
 												price={cellProps.row.original.position.notionalValue}
 												formatOptions={formatOptions}
-												side="secondary"
+												colorType="secondary"
 											/>
 										</div>
 										<Spacer width={10} />
@@ -212,7 +212,7 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 									<Currency.Price
 										price={cellProps.row.original.position.liquidationPrice}
 										formatOptions={{ suggestDecimals: true }}
-										side="preview"
+										colorType="preview"
 									/>
 								);
 							},


### PR DESCRIPTION
## Description

- Add edit buttons to mobile positions (closes #2269)
- Add liquidation price to mobile positions (closes #2266)

## Screenshots (if appropriate):

<img width="373" alt="Screenshot 2023-04-21 at 07 54 50" src="https://user-images.githubusercontent.com/3802342/233564255-76257bb7-81ef-47a8-bb1f-7ac710005420.png">

