### PR TITLE
Reduce buffer times

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -37,8 +37,8 @@ export const DEFAULT_NP_LEVERAGE_ADJUSTMENT: number = 1;
 export const DEFAULT_LEADERBOARD_ROWS = 20;
 
 // for perps v2
-export const DEFAULT_DELAYED_EXECUTION_BUFFER = 30;
-export const DEFAULT_DELAYED_CANCEL_BUFFER = 30;
+export const DEFAULT_DELAYED_EXECUTION_BUFFER = 15;
+export const DEFAULT_DELAYED_CANCEL_BUFFER = 15;
 
 export const CROSS_MARGIN_ENABLED = true;
 


### PR DESCRIPTION
Reduce the buffer times for order execution and order cancellation to 15 seconds. This will reduce the time before the "Execute" or "Cancel" buttons display to more closely match the contract logic.