### PR TITLE
Fix: Issue where users end up with a dust position after closing

### DIFF
--- a/sections/futures/ClosePositionModal/ClosePositionModal.tsx
+++ b/sections/futures/ClosePositionModal/ClosePositionModal.tsx
@@ -85,7 +85,7 @@ export default function ClosePositionModal() {
 	);
 
 	const invalidSize = useMemo(() => {
-		return sizeWei.gt(maxNativeValue);
+		return sizeWei.abs().gt(maxNativeValue.abs());
 	}, [sizeWei, maxNativeValue]);
 
 	const orderError = useMemo(() => {
@@ -137,8 +137,10 @@ export default function ClosePositionModal() {
 				percent === 1
 					? position.position.size.abs()
 					: floorNumber(position.position.size.abs().mul(percent));
+
 			const sizeDelta = position?.position.side === PositionSide.LONG ? wei(size).neg() : wei(size);
 			const decimals = sizeDelta.abs().eq(position.position.size.abs()) ? undefined : 4;
+
 			dispatch(
 				editClosePositionSizeDelta(market.marketKey, stripZeros(sizeDelta.toString(decimals)))
 			);

--- a/state/futures/reducer.ts
+++ b/state/futures/reducer.ts
@@ -336,6 +336,8 @@ const futuresSlice = createSlice({
 				trade: null,
 				close: null,
 			};
+			state.queryStatuses.isolatedTradePreview = DEFAULT_QUERY_STATUS;
+			state.queryStatuses.crossMarginTradePreview = DEFAULT_QUERY_STATUS;
 		},
 		setCrossMarginTradePreview: (
 			state,

--- a/utils/__tests__/number.test.ts
+++ b/utils/__tests__/number.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers';
 
-import { gweiToWei, formatDollars, weiFromWei } from 'utils/formatters/number';
+import { gweiToWei, formatDollars, weiFromWei, stripZeros } from 'utils/formatters/number';
 
 describe('number utils', () => {
 	test('ether to gwei', () => {
@@ -24,6 +24,13 @@ describe('number utils', () => {
 	});
 	test('should truncate thousands correctly', () => {
 		const formatted = formatDollars('325764.27345', { truncate: true });
-		expect(formatted).toEqual('$326k');
+		expect(formatted).toEqual('$326K');
+	});
+	test('should strip traling zeros correctly', () => {
+		let formatted = stripZeros('325764.2734500000');
+		expect(formatted).toEqual('325764.27345');
+
+		formatted = stripZeros('325760000');
+		expect(formatted).toEqual('325760000');
 	});
 });

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -241,5 +241,6 @@ export const toWei = (value?: string | null, p?: number) => {
 };
 
 export const stripZeros = (value?: string | number) => {
-	return String(parseFloat(String(value)));
+	if (!value) return '';
+	return String(value).replace(/(\.[0-9]*[1-9])0+$|\.0*$/, '$1');
 };


### PR DESCRIPTION
## Description

parseFloat in the strip zeros util included some rounding which resulted in dust positions being left open after closing. Changed to use a regex instead.

## Related issue
closes #2274

