### PR TITLE
Improve trade input UX

### DIFF
--- a/components/Input/InputHeaderRow.tsx
+++ b/components/Input/InputHeaderRow.tsx
@@ -8,21 +8,23 @@ import InputTitle from './InputTitle';
 type Props = {
 	label: string | ReactElement;
 	rightElement?: ReactElement;
+	disabled?: boolean;
 };
 
-export default function InputHeaderRow({ label, rightElement }: Props) {
+export default function InputHeaderRow({ label, rightElement, disabled }: Props) {
 	return (
-		<Container>
+		<Container $disabled={disabled}>
 			<InputTitle>{label}</InputTitle>
 			{rightElement}
 		</Container>
 	);
 }
 
-const Container = styled(FlexDivRow)`
+const Container = styled(FlexDivRow)<{ $disabled?: boolean }>`
 	width: 100%;
 	align-items: center;
 	justify-content: space-between;
 	margin-bottom: 8px;
 	cursor: default;
+	opacity: ${(props) => (props.$disabled ? 0.4 : 1)};
 `;

--- a/components/Input/NumericInput.tsx
+++ b/components/Input/NumericInput.tsx
@@ -39,6 +39,7 @@ const NumericInput: FC<NumericInputProps> = memo(
 		maxLength = 'none',
 		className,
 		roundedCorner = true,
+		disabled,
 		...props
 	}) => {
 		const handleChange = useCallback(
@@ -66,6 +67,7 @@ const NumericInput: FC<NumericInputProps> = memo(
 				$length={value.length}
 				className={className}
 				$roundedCorner={roundedCorner}
+				$disabled={disabled}
 			>
 				{left && (
 					<>
@@ -76,6 +78,7 @@ const NumericInput: FC<NumericInputProps> = memo(
 				<input
 					data-testid={dataTestId}
 					value={value}
+					disabled={disabled}
 					type="text"
 					inputMode="decimal"
 					onChange={handleChange}
@@ -104,6 +107,7 @@ const InputContainer = styled.div<{
 	$suffix?: string;
 	$length: number;
 	$roundedCorner?: boolean;
+	$disabled?: boolean;
 }>`
 	display: flex;
 	align-items: center;
@@ -119,6 +123,7 @@ const InputContainer = styled.div<{
 	padding: 0 10px;
 	height: 38px;
 	box-sizing: border-box;
+	opacity: ${(props) => (props.$disabled ? 0.4 : 1)};
 
 	& > input {
 		display: flex;

--- a/sections/futures/LeverageInput/LeverageInput.tsx
+++ b/sections/futures/LeverageInput/LeverageInput.tsx
@@ -20,6 +20,7 @@ import {
 	selectPosition,
 	selectFuturesType,
 	selectCrossMarginMarginDelta,
+	selectTradeSizeInputsDisabled,
 } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { floorNumber, truncateNumbers, zeroBN } from 'utils/formatters/number';
@@ -48,6 +49,7 @@ const LeverageInput: FC = memo(() => {
 	const leverageInput = useAppSelector(selectLeverageInput);
 	const futuresType = useAppSelector(selectFuturesType);
 	const crossMarginMarginDelta = useAppSelector(selectCrossMarginMarginDelta);
+	const isDisabled = useAppSelector(selectTradeSizeInputsDisabled);
 
 	const availableMargin = useMemo(() => {
 		return futuresType === 'isolated_margin' ? position?.remainingMargin : crossMarginMarginDelta;
@@ -67,10 +69,6 @@ const LeverageInput: FC = memo(() => {
 		[marketPrice, dispatch, availableMargin]
 	);
 
-	const isDisabled = useMemo(() => {
-		return availableMargin?.lte(0) || maxLeverage.lte(0);
-	}, [maxLeverage, availableMargin]);
-
 	const leverageButtons = marketInfo?.maxLeverage.eq(25)
 		? ['2', '5', '10', '25']
 		: ['2', '5', '10'];
@@ -86,6 +84,7 @@ const LeverageInput: FC = memo(() => {
 	return (
 		<LeverageInputWrapper>
 			<InputHeaderRow
+				disabled={isDisabled}
 				label={
 					<LeverageTitle>
 						{t('futures.market.trade.input.leverage.title')}&nbsp; —
@@ -125,11 +124,11 @@ const LeverageInput: FC = memo(() => {
 						<LeverageButton
 							key={l}
 							mono
+							disabled={isDisabled}
 							variant="flat"
 							onClick={() => {
 								onLeverageChange(l);
 							}}
-							disabled={maxLeverage.lt(l) || marketInfo?.isSuspended}
 						>
 							{l}x
 						</LeverageButton>

--- a/sections/futures/OrderSizing/OrderSizing.tsx
+++ b/sections/futures/OrderSizing/OrderSizing.tsx
@@ -12,12 +12,11 @@ import {
 	selectPosition,
 	selectTradeSizeInputs,
 	selectCrossMarginOrderPrice,
-	selectFuturesType,
 	selectSelectedInputDenomination,
 	selectMaxUsdSizeInput,
-	selectCrossMarginMarginDelta,
 	selectLeverageSide,
 	selectAvailableOi,
+	selectTradeSizeInputsDisabled,
 } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import {
@@ -32,23 +31,21 @@ import { DenominationToggle } from './DenominationToggle';
 
 type OrderSizingProps = {
 	isMobile?: boolean;
-	disabled?: boolean;
 };
 
-const OrderSizing: React.FC<OrderSizingProps> = memo(({ disabled, isMobile }) => {
+const OrderSizing: React.FC<OrderSizingProps> = memo(({ isMobile }) => {
 	const dispatch = useAppDispatch();
 
 	const { susdSizeString, nativeSizeString } = useAppSelector(selectTradeSizeInputs);
 
 	const position = useAppSelector(selectPosition);
-	const selectedAccountType = useAppSelector(selectFuturesType);
 	const marketAssetRate = useAppSelector(selectMarketPrice);
 	const orderPrice = useAppSelector(selectCrossMarginOrderPrice);
 	const assetInputType = useAppSelector(selectSelectedInputDenomination);
 	const maxUsdInputAmount = useAppSelector(selectMaxUsdSizeInput);
-	const marginDelta = useAppSelector(selectCrossMarginMarginDelta);
 	const tradeSide = useAppSelector(selectLeverageSide);
 	const availableOi = useAppSelector(selectAvailableOi);
+	const isDisabled = useAppSelector(selectTradeSizeInputsDisabled);
 
 	const tradePrice = useMemo(() => (orderPrice ? wei(orderPrice) : marketAssetRate), [
 		orderPrice,
@@ -92,12 +89,6 @@ const OrderSizing: React.FC<OrderSizingProps> = memo(({ disabled, isMobile }) =>
 		[dispatch, assetInputType]
 	);
 
-	const isDisabled = useMemo(() => {
-		const remaining =
-			selectedAccountType === 'isolated_margin' ? position?.remainingMargin || zeroBN : marginDelta;
-		return remaining.lte(0) || disabled;
-	}, [position?.remainingMargin, disabled, selectedAccountType, marginDelta]);
-
 	const invalid = useMemo(() => {
 		return (
 			(assetInputType === 'usd' &&
@@ -120,6 +111,7 @@ const OrderSizing: React.FC<OrderSizingProps> = memo(({ disabled, isMobile }) =>
 	return (
 		<OrderSizingContainer>
 			<InputHeaderRow
+				disabled={isDisabled}
 				label={
 					<InputTitle>
 						Size

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -772,6 +772,19 @@ export const selectTradeSizeInputs = createSelector(
 	}
 );
 
+export const selectTradeSizeInputsDisabled = createSelector(
+	selectMarginDeltaInputValue,
+	selectFuturesType,
+	selectPosition,
+	(marginDeltaInput, selectedAccountType, position) => {
+		const remaining =
+			selectedAccountType === 'isolated_margin'
+				? position?.remainingMargin || zeroBN
+				: wei(marginDeltaInput || 0);
+		return remaining.lte(0);
+	}
+);
+
 export const selectEditPositionModalInfo = createSelector(
 	selectFuturesType,
 	selectEditPositionModalMarket,

--- a/utils/logError.ts
+++ b/utils/logError.ts
@@ -21,4 +21,5 @@ export const IGNORE_ERRORS = [
 	'timeout exceeded',
 	'Unsupported network',
 	'request aborted',
+	'Transaction reverted without a reason string',
 ];


### PR DESCRIPTION
## Description

Some users were getting stuck with the trade input panel, not being aware that it's required to input margin amount first. These changes make sure any inputs that first require margin are disabled when no margin and also makes the disabled more obvious by decreasing the opacity.

## Screenshots (if appropriate):
<img width="366" alt="Screenshot 2023-04-24 at 09 01 06" src="https://user-images.githubusercontent.com/3802342/233935319-8b3651f7-0824-41ad-b4ef-63ff4b300f41.png">
