### PR TITLE
Fix smart margin on leaderboard

### DIFF
--- a/sdk/queries/futures.ts
+++ b/sdk/queries/futures.ts
@@ -136,6 +136,51 @@ export const queryPositionHistory = (sdk: KwentaSDK, account: string) => {
 	);
 };
 
+export const queryCompletePositionHistory = (sdk: KwentaSDK, account: string) => {
+	return getFuturesPositions(
+		sdk.futures.futuresGqlEndpoint,
+		{
+			where: {
+				account: account,
+			},
+			first: 99999,
+			orderBy: 'openTimestamp',
+			orderDirection: 'desc',
+		},
+		{
+			id: true,
+			lastTxHash: true,
+			openTimestamp: true,
+			closeTimestamp: true,
+			timestamp: true,
+			market: true,
+			marketKey: true,
+			asset: true,
+			account: true,
+			abstractAccount: true,
+			accountType: true,
+			isOpen: true,
+			isLiquidated: true,
+			trades: true,
+			totalVolume: true,
+			size: true,
+			initialMargin: true,
+			margin: true,
+			pnl: true,
+			feesPaid: true,
+			netFunding: true,
+			pnlWithFeesPaid: true,
+			netTransfers: true,
+			totalDeposits: true,
+			fundingIndex: true,
+			entryPrice: true,
+			avgEntryPrice: true,
+			lastPrice: true,
+			exitPrice: true,
+		}
+	);
+};
+
 export const queryIsolatedMarginTransfers = async (sdk: KwentaSDK, account: string) => {
 	const response = await request(sdk.futures.futuresGqlEndpoint, ISOLATED_MARGIN_FRAGMENT, {
 		walletAddress: account,

--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -24,6 +24,7 @@ import {
 	queryIsolatedMarginTransfers,
 	queryPositionHistory,
 	queryTrades,
+	queryCompletePositionHistory,
 } from 'sdk/queries/futures';
 import { NetworkId } from 'sdk/types/common';
 import { NetworkOverrideOptions } from 'sdk/types/common';
@@ -551,6 +552,11 @@ export default class FuturesService {
 
 	public async getPositionHistory(walletAddress: string) {
 		const response = await queryPositionHistory(this.sdk, walletAddress);
+		return response ? mapFuturesPositions(response) : [];
+	}
+
+	public async getCompletePositionHistory(walletAddress: string) {
+		const response = await queryCompletePositionHistory(this.sdk, walletAddress);
 		return response ? mapFuturesPositions(response) : [];
 	}
 

--- a/sections/leaderboard/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory.tsx
@@ -189,13 +189,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 										accessor: 'pnl',
 										Cell: (cellProps: CellProps<typeof data[number]>) => (
 											<PnlContainer>
-												<Currency.Price
-													currencyKey="sUSD"
-													price={cellProps.row.original.pnl}
-													sign="$"
-													conversionRate={1}
-													colored={true}
-												/>
+												<Currency.Price price={cellProps.row.original.pnl} colored />
 												<StyledValue $value={cellProps.row.original.pnl}>
 													{cellProps.row.original.pnlPct}
 												</StyledValue>
@@ -272,13 +266,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 										accessor: 'pnl',
 										Cell: (cellProps: CellProps<typeof data[number]>) => (
 											<PnlContainer>
-												<ColorCodedPrice
-													currencyKey="sUSD"
-													price={cellProps.row.original.pnl}
-													$value={cellProps.row.original.pnl}
-													sign="$"
-													conversionRate={1}
-												/>
+												<Currency.Price price={cellProps.row.original.pnl} colored />
 												<StyledValue $value={cellProps.row.original.pnl}>
 													{cellProps.row.original.pnlPct}
 												</StyledValue>

--- a/sections/leaderboard/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory.tsx
@@ -347,11 +347,6 @@ const valueColor = css<{ $value: WeiSource }>`
 			: props.theme.colors.selectedTheme.button.text.primary};
 `;
 
-const ColorCodedPrice = styled(Currency.Price)<{ $value: WeiSource }>`
-	align-items: right;
-	${valueColor}
-`;
-
 const StyledValue = styled.div<{ $value: WeiSource }>`
 	font-family: ${(props) => props.theme.fonts.mono};
 	font-size: 13px;

--- a/sections/leaderboard/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory.tsx
@@ -189,9 +189,12 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 										accessor: 'pnl',
 										Cell: (cellProps: CellProps<typeof data[number]>) => (
 											<PnlContainer>
-												<ColorCodedPrice
+												<Currency.Price
+													currencyKey="sUSD"
 													price={cellProps.row.original.pnl}
-													$value={cellProps.row.original.pnl}
+													sign="$"
+													conversionRate={1}
+													colored={true}
 												/>
 												<StyledValue $value={cellProps.row.original.pnl}>
 													{cellProps.row.original.pnlPct}

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -998,7 +998,7 @@ export const fetchPositionHistoryForTrader = createAsyncThunk<
 		const networkId = selectNetwork(getState());
 		const futuresSupported = selectFuturesSupportedNetwork(getState());
 		if (!futuresSupported) return;
-		const history = await sdk.futures.getPositionHistory(traderAddress);
+		const history = await sdk.futures.getCompletePositionHistory(traderAddress);
 		return { history: serializePositionHistory(history), networkId, address: traderAddress };
 	} catch (err) {
 		notifyError('Failed to fetch history for trader ' + traderAddress, err);


### PR DESCRIPTION
Add smart margin positions to the leaderboard by splitting the position history query.

## Description
* Add a new position history query to query by `account` (in addition to the `abstractAccount` query)
* Update the leaderboard query to use the complete position history

