### PR TITLE
chore: add sentry ci

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,13 @@
+- uses: actions/checkout@v3
+  with:
+    fetch-depth: 0
+
+- name: Create Sentry release
+  uses: getsentry/action-release@v1
+  env:
+    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+  with:
+    environment: production
+    sourcemaps: '/'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -8,8 +8,8 @@ jobs:
   steps: 
     - name: Sentry
       uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      with:
+        fetch-depth: 0
 
     - name: Create Sentry release
       uses: getsentry/action-release@v1

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, dev ]
 
 jobs:
+  name: sentry
   runs-on: ubuntu-latest
 
 steps: 

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [ main, dev ]
 
-jobs:
-  name: sentry
-  runs-on: ubuntu-latest
-
 steps: 
   - uses: actions/checkout@v3
     with:

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,14 +5,13 @@ on:
     branches: [ main, dev ]
 
 jobs:
-  build:
+  sentry_checkout:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
 
     - name: Create Sentry release
       uses: getsentry/action-release@v1

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,13 +1,16 @@
-- uses: actions/checkout@v3
-  with:
-    fetch-depth: 0
+name: "Sentry"
 
-- name: Create Sentry release
-  uses: getsentry/action-release@v1
-  env:
-    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-    SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-    SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-  with:
-    environment: production
-    sourcemaps: '/'
+steps: 
+  - uses: actions/checkout@v3
+    with:
+      fetch-depth: 0
+
+  - name: Create Sentry release
+    uses: getsentry/action-release@v1
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+    with:
+      environment: production
+      sourcemaps: '/'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   steps: 
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+    - name: Sentry
+      uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
     - name: Create Sentry release
       uses: getsentry/action-release@v1

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,5 +1,12 @@
 name: "Sentry"
 
+on:
+  push:
+    branches: [ main, dev ]
+
+jobs:
+  runs-on: ubuntu-latest
+
 steps: 
   - uses: actions/checkout@v3
     with:

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -4,17 +4,18 @@ on:
   push:
     branches: [ main, dev ]
 
-steps: 
-  - uses: actions/checkout@v3
-    with:
-      fetch-depth: 0
+jobs:
+  steps: 
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-  - name: Create Sentry release
-    uses: getsentry/action-release@v1
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-    with:
-      environment: production
-      sourcemaps: '/'
+    - name: Create Sentry release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      with:
+        environment: production
+        sourcemaps: '/'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,11 +5,14 @@ on:
     branches: [ main, dev ]
 
 jobs:
-  steps: 
-    - name: Sentry
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+  build:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
 
     - name: Create Sentry release
       uses: getsentry/action-release@v1

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,19 +5,22 @@ on:
     branches: [ main, dev ]
 
 jobs:
+  sentry_release:
+    name: Sentry
     runs-on: ubuntu-latest
+    
     steps: 
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-    - name: Create Sentry release
-      uses: getsentry/action-release@v1
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      with:
-        environment: production
-        sourcemaps: '/'
+       - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+          sourcemaps: '/'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     
     steps: 
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-       - name: Create Sentry release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        with:
-          environment: production
-          sourcemaps: '/'
+    - name: Create Sentry release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      with:
+        environment: production
+        sourcemaps: '/'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main, dev ]
 
 jobs:
-  sentry_checkout:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds Sentry Release CI as a Github Action workflow to the repository, according to https://github.com/marketplace/actions/sentry-release

Secrets have been added to `kwenta/kwenta` repository.

Note: Sourcemaps folder needs to be double checked, according to the docs `sourceRoot = '/'` however this might differ from our config.

## Related issue
closes #2290 

