### PR TITLE
Fixed the issue that missing snx op file blocks the rewards claim

### DIFF
--- a/sdk/services/kwentaToken.ts
+++ b/sdk/services/kwentaToken.ts
@@ -517,6 +517,7 @@ export default class KwentaTokenService {
 		);
 
 		const rewards = responses
+			.filter(Boolean)
 			.map((d) => {
 				const reward = d.claims[walletAddress];
 

--- a/sdk/services/kwentaToken.ts
+++ b/sdk/services/kwentaToken.ts
@@ -517,7 +517,6 @@ export default class KwentaTokenService {
 		);
 
 		const rewards = responses
-			.filter((response) => response !== null)
 			.map((d) => {
 				const reward = d.claims[walletAddress];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user can't claim the trading rewards when missing one distribution file. 
The PR fixed the above issue. So the user can claim the other rewards if one of the distribution file is missing.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
When snx op file is missing, the user can still claim the rewards.


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/235815651-12d0427e-89b1-479e-a70d-5bd9f5a951fa.png)
