### PR TITLE
Fixed the market name on mobile trade history

### DIFF
--- a/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/TradesTab.tsx
@@ -88,7 +88,7 @@ const TradesTab = () => {
 					columns={[
 						{
 							Header: <TableHeader>{t('futures.market.user.trades.table.date')}</TableHeader>,
-							accessor: 'timestamp',
+							accessor: 'time',
 							Cell: (cellProps: CellProps<FuturesTrade>) => (
 								<GridDivCenteredRow>
 									<TimeDisplay value={cellProps.value} />

--- a/sections/futures/MobileTrade/drawers/TradeDrawer.tsx
+++ b/sections/futures/MobileTrade/drawers/TradeDrawer.tsx
@@ -19,7 +19,7 @@ const TradeDrawer: React.FC<TradeDrawerProps> = ({ trade, closeDrawer }) => {
 		return [
 			{
 				label: 'Market',
-				value: trade.market,
+				value: trade.market.marketName,
 			},
 			{
 				label: 'Side',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The following issues have been fixed in this PR
1. The app crashes when the user clicks on the row of the trade history.
2. The timestamp of the trade is incorrect.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open mobile trade and check the timestamp of the trade
2. Click on the row of the trade history

## Screenshots (if appropriate):
