### PR TITLE
Add search bar to the dashboard's market list

### DIFF
--- a/pages/dashboard/markets.tsx
+++ b/pages/dashboard/markets.tsx
@@ -1,8 +1,11 @@
 import Head from 'next/head';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
+import Search from 'components/Table/Search';
 import DashboardLayout from 'sections/dashboard/DashboardLayout';
-import Markets from 'sections/dashboard/Markets';
+import FuturesMarketsTable from 'sections/dashboard/FuturesMarketsTable';
 import { fetchMarkets } from 'state/futures/actions';
 import { useAppSelector, usePollAction } from 'state/hooks';
 import { selectNetwork } from 'state/wallet/selectors';
@@ -12,6 +15,7 @@ type MarketsProps = React.FC & { getLayout: (page: HTMLElement) => JSX.Element }
 const MarketsPage: MarketsProps = () => {
 	const { t } = useTranslation();
 	const network = useAppSelector(selectNetwork);
+	const [search, setSearch] = useState('');
 	usePollAction('fetchMarkets', fetchMarkets, { dependencies: [network] });
 
 	return (
@@ -19,10 +23,19 @@ const MarketsPage: MarketsProps = () => {
 			<Head>
 				<title>{t('dashboard-markets.page-title')}</title>
 			</Head>
-			<Markets />
+			<SearchBarContainer>
+				<Search autoFocus value={search} onChange={setSearch} disabled={false} />
+			</SearchBarContainer>
+			<FuturesMarketsTable search={search} />
 		</>
 	);
 };
+
+const SearchBarContainer = styled.div`
+	display: flex;
+	height: 100%;
+	width: 100%;
+`;
 
 MarketsPage.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
 

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -1,6 +1,6 @@
 import { wei } from '@synthetixio/wei';
 import { useRouter } from 'next/router';
-import { FC, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CellProps } from 'react-table';
 import styled from 'styled-components';
@@ -26,7 +26,11 @@ import { selectPreviousDayPrices, selectOffchainPricesInfo } from 'state/prices/
 import { formatDollars } from 'utils/formatters/number';
 import { getSynthDescription, MarketKeyByAsset } from 'utils/futures';
 
-const FuturesMarketsTable: FC = () => {
+type FuturesMarketsTableProps = {
+	search?: string;
+};
+
+const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => {
 	const { t } = useTranslation();
 	const router = useRouter();
 
@@ -38,7 +42,10 @@ const FuturesMarketsTable: FC = () => {
 	const markPrices = useAppSelector(selectMarkPrices);
 
 	let data = useMemo(() => {
-		return futuresMarkets.map((market) => {
+		const markets = search
+			? futuresMarkets.filter((m) => m.asset.toLowerCase().includes(search.toLowerCase()))
+			: futuresMarkets;
+		return markets.map((market) => {
 			const description = getSynthDescription(market.asset, t);
 			const volume = futuresVolumes[market.marketKey]?.volume;
 			const assetPriceInfo = pricesInfo[market.asset];

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -24,7 +24,7 @@ import {
 import { useAppSelector } from 'state/hooks';
 import { selectPreviousDayPrices, selectOffchainPricesInfo } from 'state/prices/selectors';
 import { formatDollars } from 'utils/formatters/number';
-import { getSynthDescription, MarketKeyByAsset } from 'utils/futures';
+import { AssetDisplayByAsset, getSynthDescription, MarketKeyByAsset } from 'utils/futures';
 
 type FuturesMarketsTableProps = {
 	search?: string;
@@ -42,8 +42,13 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 	const markPrices = useAppSelector(selectMarkPrices);
 
 	let data = useMemo(() => {
-		const markets = search
-			? futuresMarkets.filter((m) => m.asset.toLowerCase().includes(search.toLowerCase()))
+		const lowerSearch = search?.toLowerCase();
+		const markets = lowerSearch
+			? futuresMarkets.filter(
+					(m) =>
+						m.asset.toLowerCase().includes(lowerSearch) ||
+						AssetDisplayByAsset[m.asset]?.toLocaleLowerCase().includes(lowerSearch)
+			  )
 			: futuresMarkets;
 		return markets.map((market) => {
 			const description = getSynthDescription(market.asset, t);
@@ -72,7 +77,7 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 				marketClosureReason: market.marketClosureReason,
 			};
 		});
-	}, [futuresMarkets, pastRates, futuresVolumes, markPrices, pricesInfo, t]);
+	}, [search, futuresMarkets, t, futuresVolumes, pricesInfo, pastRates, markPrices]);
 
 	return (
 		<>

--- a/sections/dashboard/Overview/Overview.tsx
+++ b/sections/dashboard/Overview/Overview.tsx
@@ -7,6 +7,7 @@ import TabButton from 'components/Button/TabButton';
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import FuturesIcon from 'components/Nav/FuturesIcon';
 import { TabPanel } from 'components/Tab';
+import Search from 'components/Table/Search';
 import * as Text from 'components/Text';
 import { ETH_ADDRESS, ETH_COINGECKO_ADDRESS } from 'constants/currency';
 import Connector from 'containers/Connector';
@@ -68,6 +69,7 @@ const Overview: FC = () => {
 	const oneInchEnabled = network.id === 10;
 
 	const [exchangeTokens, setExchangeTokens] = useState<any>([]);
+	const [search, setSearch] = useState('');
 
 	useFetchAction(fetchTokenList, { dependencies: [network] });
 
@@ -201,7 +203,10 @@ const Overview: FC = () => {
 					<SynthBalancesTable exchangeTokens={exchangeTokens} />
 				</TabPanel>
 				<SubHeading>{t('dashboard.overview.markets-tabs.futures')}</SubHeading>
-				<FuturesMarketsTable />
+				<SearchBarContainer>
+					<Search autoFocus value={search} onChange={setSearch} disabled={false} />
+				</SearchBarContainer>
+				<FuturesMarketsTable search={search} />
 			</DesktopOnlyView>
 			<MobileOrTabletView>
 				<MobileDashboard exchangeTokens={exchangeTokens} />
@@ -209,6 +214,12 @@ const Overview: FC = () => {
 		</>
 	);
 };
+
+const SearchBarContainer = styled.div`
+	display: flex;
+	height: 100%;
+	width: 100%;
+`;
 
 const TabButtonsContainer = styled.div`
 	display: flex;
@@ -226,6 +237,7 @@ const SubHeading = styled(Text.Heading).attrs({ variant: 'h4' })`
 	font-family: ${(props) => props.theme.fonts.bold};
 	font-size: 16px;
 	margin-top: 20px;
+	margin-bottom: 16px;
 	font-variant: all-small-caps;
 	color: ${(props) => props.theme.colors.selectedTheme.yellow};
 `;

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -33,10 +33,15 @@ import { selectPreviousDayPrices } from 'state/prices/selectors';
 import { FetchStatus } from 'state/types';
 import media from 'styles/media';
 import { floorNumber, formatDollars, zeroBN } from 'utils/formatters/number';
-import { getMarketName, getSynthDescription, MarketKeyByAsset } from 'utils/futures';
+import {
+	AssetDisplayByAsset,
+	getMarketName,
+	getSynthDescription,
+	MarketKeyByAsset,
+} from 'utils/futures';
 
-import MarketsDropdownSelector, { MARKET_SELECTOR_HEIGHT_MOBILE } from './MarketsDropdownSelector';
 import { TRADE_PANEL_WIDTH_LG, TRADE_PANEL_WIDTH_MD } from '../styles';
+import MarketsDropdownSelector, { MARKET_SELECTOR_HEIGHT_MOBILE } from './MarketsDropdownSelector';
 
 type MarketsDropdownProps = {
 	mobile?: boolean;
@@ -98,8 +103,13 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	const selectedPastPrice = getPastPrice(marketAsset);
 
 	const options = useMemo(() => {
-		const markets = search
-			? futuresMarkets.filter((m) => m.asset.toLowerCase().includes(search.toLowerCase()))
+		const lowerSearch = search?.toLowerCase();
+		const markets = lowerSearch
+			? futuresMarkets.filter(
+					(m) =>
+						m.asset.toLowerCase().includes(lowerSearch) ||
+						AssetDisplayByAsset[m.asset]?.toLocaleLowerCase().includes(lowerSearch)
+			  )
 			: futuresMarkets;
 
 		const sortedMarkets = markets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a search bar to the market similar to what has been added for the markets drop-down selector.

## Related issue
#2090

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the Dashboard page
2. Type the market in the search bar
3. Show the correct market in the table

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4819006/236898264-30383bf5-2a0a-4008-8996-ff60289adec9.png)
