### PR TITLE
Make the market dropdown full screen on mobile

### DIFF
--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -35,8 +35,8 @@ import media from 'styles/media';
 import { floorNumber, formatDollars, zeroBN } from 'utils/formatters/number';
 import { getMarketName, getSynthDescription, MarketKeyByAsset } from 'utils/futures';
 
-import MarketsDropdownSelector, { MARKET_SELECTOR_HEIGHT_MOBILE } from './MarketsDropdownSelector';
 import { TRADE_PANEL_WIDTH_LG, TRADE_PANEL_WIDTH_MD } from '../styles';
+import MarketsDropdownSelector, { MARKET_SELECTOR_HEIGHT_MOBILE } from './MarketsDropdownSelector';
 
 type MarketsDropdownProps = {
 	mobile?: boolean;
@@ -303,6 +303,11 @@ const MarketsList = styled.div<{ mobile?: boolean; height: number }>`
 	${media.lessThan('xxl')`
 		width: ${TRADE_PANEL_WIDTH_MD}px;
 	`}
+
+	${media.lessThan('md')`
+		width: 100%;
+	`}
+
 	border-top: ${(props) => props.theme.colors.selectedTheme.border};
 	background-color: ${(props) =>
 		props.theme.colors.selectedTheme.newTheme.containers.primary.background};

--- a/sections/futures/Trade/MarketsDropdownSelector.tsx
+++ b/sections/futures/Trade/MarketsDropdownSelector.tsx
@@ -99,6 +99,10 @@ export const ContentContainer = styled(FlexDivCentered)<{ mobile?: boolean }>`
 		width: ${TRADE_PANEL_WIDTH_MD}px;
 	`}
 
+	${media.lessThan('md')`
+		width: 100%;
+	`}
+
 	${(props) =>
 		props.mobile &&
 		css`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The width of the market dropdown on mobile is no full screen.
![image](https://github.com/Kwenta/kwenta/assets/4819006/7bc26721-53cf-4549-84d8-54dcd4bd0b20)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/3e207afa-ee83-4e82-bcdb-8bfeb1b5baab)
