### PR TITLE
Reset the status when the transaction fails to execute

### DIFF
--- a/state/staking/reducer.ts
+++ b/state/staking/reducer.ts
@@ -126,14 +126,26 @@ const stakingSlice = createSlice({
 		builder.addCase(stakeKwenta.pending, (state) => {
 			state.stakeStatus = FetchStatus.Loading;
 		});
+		builder.addCase(stakeKwenta.rejected, (state) => {
+			state.stakeStatus = FetchStatus.Idle;
+		});
 		builder.addCase(unstakeKwenta.pending, (state) => {
 			state.unstakeStatus = FetchStatus.Loading;
+		});
+		builder.addCase(unstakeKwenta.rejected, (state) => {
+			state.unstakeStatus = FetchStatus.Idle;
 		});
 		builder.addCase(stakeEscrow.pending, (state) => {
 			state.stakeEscrowedStatus = FetchStatus.Loading;
 		});
+		builder.addCase(stakeEscrow.rejected, (state) => {
+			state.stakeEscrowedStatus = FetchStatus.Idle;
+		});
 		builder.addCase(unstakeEscrow.pending, (state) => {
 			state.unstakeEscrowedStatus = FetchStatus.Loading;
+		});
+		builder.addCase(unstakeEscrow.rejected, (state) => {
+			state.unstakeEscrowedStatus = FetchStatus.Idle;
 		});
 		builder.addCase(getReward.pending, (state) => {
 			state.getRewardStatus = FetchStatus.Loading;
@@ -152,6 +164,9 @@ const stakingSlice = createSlice({
 		});
 		builder.addCase(vestEscrowedRewards.pending, (state) => {
 			state.vestEscrowedRewardsStatus = FetchStatus.Loading;
+		});
+		builder.addCase(vestEscrowedRewards.rejected, (state) => {
+			state.vestEscrowedRewardsStatus = FetchStatus.Idle;
 		});
 	},
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When staking, if the user cancels the transaction or if the transaction fails, the button does not revert to an active state. This means the user cannot try again, and the button remains in a disabled state until the page reloads. The PR will reset the status when the transaction fails to execute.

## Related issue
#2331 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Click on the `stake` button and the button will be disabled
2. Reject the txn when the metamask pop-up
3. The `stake` button is active again

## Screenshots (if appropriate):
