### PR TITLE
Make the maxWithdraw as a non-negative number and place the toggle correctly in mid sized screen

### DIFF
--- a/sections/futures/EditPositionModal/EditPositionMarginModal.tsx
+++ b/sections/futures/EditPositionModal/EditPositionMarginModal.tsx
@@ -69,11 +69,13 @@ export default function EditPositionMarginModal() {
 		const currentSize = position?.position?.notionalValue;
 		const max = maxSize?.sub(currentSize).div(market?.appMaxLeverage ?? 1) ?? wei(0);
 		const resultingMarginMax = position?.remainingMargin.sub(max) ?? wei(0);
-		return max.lt(0)
+		const remainingMarginMax = position?.remainingMargin.sub(MIN_MARGIN_AMOUNT) ?? wei(0);
+
+		return max.lt(0) || remainingMarginMax.lt(0)
 			? zeroBN
 			: resultingMarginMax.gte(MIN_MARGIN_AMOUNT)
 			? max
-			: position?.remainingMargin.sub(MIN_MARGIN_AMOUNT) ?? wei(0);
+			: remainingMarginMax;
 	}, [position?.remainingMargin, position?.position?.notionalValue, market?.appMaxLeverage]);
 
 	const maxUsdInputAmount = useMemo(() => (transferType === 0 ? idleMargin : maxWithdraw), [

--- a/sections/futures/MarketDetails/HoursToggle.tsx
+++ b/sections/futures/MarketDetails/HoursToggle.tsx
@@ -101,10 +101,10 @@ const ToggleContainer = styled.div<{ open: boolean }>`
 	cursor: pointer;
 	margin-top: ${(props) => (props.open ? '92px' : '20px')};
 
-	${media.lessThan('sm')`
+	${media.lessThan('md')`
 		position: relative;
 		top: -35px;
-		left: 290px;
+		left: 300px;
 		z-index: ${zIndex.HEADER};
 		margin-top: 0px;
 		width: ${HOURS_TOGGLE_WIDTH};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. The app crashes when the user clicks on the `Withdraw` button of the `EditPositionMarginModal` component.
2. Toggle is misplaced on the medium-sized screens
![image](https://github.com/Kwenta/kwenta/assets/4819006/58227177-83e5-4765-b6c6-0eb9e09a9238)


## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. The user clicks on the `Withdraw` button of the `EditPositionMarginModal` component, and the app doesn't crash.
2. The toggle is placed correctly in a responsive view regardless of the screen width (see the screenshot below).

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/d6139c01-c3de-4cac-9530-8daba18f2844)
