### PR TITLE
fix: remove underline

### DIFF
--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -233,7 +233,6 @@ const PriceValue = styled(Body).attrs({ mono: true })`
 
 const TimeValue = styled(Body)`
 	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
-	text-decoration: underline;
 `;
 
 const DirectionalValue = styled(PriceValue)<{ negative?: boolean; normal?: boolean }>`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove underline from trading history timestamp as it does not link anywhere.

## Related issue
closes #2117

