### PR TITLE
Fix the onboarding flow

### DIFF
--- a/components/SocketBridge/SocketBridge.tsx
+++ b/components/SocketBridge/SocketBridge.tsx
@@ -6,7 +6,8 @@ import ArrowIcon from 'assets/svg/app/arrow-down.svg';
 import Connector from 'containers/Connector';
 import { chain } from 'containers/Connector/config';
 import { fetchBalances } from 'state/balances/actions';
-import { useAppDispatch } from 'state/hooks';
+import { selectFuturesType } from 'state/futures/selectors';
+import { useAppDispatch, useAppSelector } from 'state/hooks';
 import {
 	customizeSocket,
 	socketDefaultChains,
@@ -18,6 +19,7 @@ const SocketBridge = () => {
 	const { activeChain, signer } = Connector.useContainer();
 	const dispatch = useAppDispatch();
 	const customize = customizeSocket(useTheme());
+	const accountType = useAppSelector(selectFuturesType);
 	const onBridgeSuccess = useCallback(() => {
 		dispatch(fetchBalances());
 	}, [dispatch]);
@@ -40,9 +42,11 @@ const SocketBridge = () => {
 				enableSameChainSwaps={true}
 				onBridgeSuccess={onBridgeSuccess}
 			/>
-			<StyledDiv>
-				<ArrowIcon />
-			</StyledDiv>
+			{accountType === 'isolated_margin' && (
+				<StyledDiv>
+					<ArrowIcon />
+				</StyledDiv>
+			)}
 		</BridgeContainer>
 	);
 };

--- a/sections/futures/Trade/SmartMarginOnboardModal.tsx
+++ b/sections/futures/Trade/SmartMarginOnboardModal.tsx
@@ -1,0 +1,111 @@
+import dynamic from 'next/dynamic';
+import React, { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import BaseModal from 'components/BaseModal';
+import Error from 'components/ErrorView';
+import { FlexDivRowCentered } from 'components/layout/flex';
+import Spacer from 'components/Spacer';
+import { selectSusdBalance } from 'state/balances/selectors';
+import { selectIsolatedTransferError } from 'state/futures/selectors';
+import { useAppSelector } from 'state/hooks';
+import { formatDollars } from 'utils/formatters/number';
+
+type Props = {
+	onDismiss(): void;
+};
+
+const SocketBridge = dynamic(() => import('../../../components/SocketBridge'), {
+	ssr: false,
+});
+
+const SmartMarginOnboardModal: React.FC<Props> = memo(({ onDismiss }) => {
+	const { t } = useTranslation();
+
+	const txError = useAppSelector(selectIsolatedTransferError);
+	const susdBalance = useAppSelector(selectSusdBalance);
+
+	return (
+		<StyledBaseModal
+			title={t('futures.market.trade.margin.modal.bridge.title')}
+			isOpen
+			onDismiss={onDismiss}
+		>
+			<Disclaimer>{t('futures.market.trade.margin.modal.bridge.no-balance')}</Disclaimer>
+
+			<Spacer height={10} />
+
+			<SocketBridge />
+
+			<Spacer height={20} />
+
+			<BalanceContainer>
+				<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
+				<BalanceText>
+					<span>{formatDollars(susdBalance)}</span> sUSD
+				</BalanceText>
+			</BalanceContainer>
+
+			<MinimumAmountDisclaimer>
+				{t('futures.market.trade.margin.modal.deposit.disclaimer')}
+			</MinimumAmountDisclaimer>
+
+			{txError && (
+				<Error containerStyle={{ margin: '16px 0 0 0' }} message={txError} formatter="revert" />
+			)}
+		</StyledBaseModal>
+	);
+});
+
+export const StyledBaseModal = styled(BaseModal)`
+	[data-reach-dialog-content] {
+		width: 400px;
+		margin-top: 5vh;
+	}
+`;
+
+export const BalanceContainer = styled(FlexDivRowCentered)`
+	margin-bottom: 8px;
+	p {
+		margin: 0;
+	}
+`;
+
+export const BalanceText = styled.p<{ $gold?: boolean }>`
+	color: ${(props) =>
+		props.$gold ? props.theme.colors.selectedTheme.yellow : props.theme.colors.selectedTheme.gray};
+	span {
+		color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	}
+`;
+
+export const MaxButton = styled.button`
+	height: 22px;
+	padding: 4px 10px;
+	background: ${(props) => props.theme.colors.selectedTheme.button.background};
+	border-radius: 11px;
+	font-family: ${(props) => props.theme.fonts.mono};
+	font-size: 13px;
+	line-height: 13px;
+	border: ${(props) => props.theme.colors.selectedTheme.border};
+	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	cursor: pointer;
+`;
+
+const MinimumAmountDisclaimer = styled.div`
+	font-size: 12px;
+	margin: 20px 0 10px;
+	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	text-align: center;
+`;
+
+const Disclaimer = styled.div`
+	font-size: 12px;
+	line-height: 120%;
+	margin: 10px 0;
+	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
+	text-align: left;
+`;
+
+export default SmartMarginOnboardModal;

--- a/sections/futures/Trade/TradeBalance.tsx
+++ b/sections/futures/Trade/TradeBalance.tsx
@@ -112,8 +112,6 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 					defaultTab="deposit"
 					isSmartMargin={accountType === 'cross_margin'}
 					onDismiss={() => {
-						// eslint-disable-next-line no-console
-						console.log(`TradeBalance.tsx: onDismiss`);
 						dispatch(setOpenModal(null));
 					}}
 				/>

--- a/sections/futures/Trade/TradeBalance.tsx
+++ b/sections/futures/Trade/TradeBalance.tsx
@@ -20,7 +20,7 @@ import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { formatDollars, zeroBN } from 'utils/formatters/number';
 
 import CrossMarginInfoBox from '../TradeCrossMargin/CrossMarginInfoBox';
-import TransferIsolatedMarginModal from './TransferIsolatedMarginModal';
+import SmartMarginOnboardModal from './SmartMarginOnboardModal';
 
 type TradeBalanceProps = {
 	isMobile?: boolean;
@@ -108,9 +108,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 				<DetailsContainer>{<CrossMarginInfoBox />}</DetailsContainer>
 			)}
 			{openModal === 'futures_smart_margin_socket' && (
-				<TransferIsolatedMarginModal
-					defaultTab="deposit"
-					isSmartMargin={accountType === 'cross_margin'}
+				<SmartMarginOnboardModal
 					onDismiss={() => {
 						dispatch(setOpenModal(null));
 					}}

--- a/sections/futures/Trade/TradeBalance.tsx
+++ b/sections/futures/Trade/TradeBalance.tsx
@@ -20,6 +20,7 @@ import { formatDollars, zeroBN } from 'utils/formatters/number';
 
 import CrossMarginInfoBox from '../TradeCrossMargin/CrossMarginInfoBox';
 import TransferIsolatedMarginModal from './TransferIsolatedMarginModal';
+import { selectSusdBalance } from 'state/balances/selectors';
 
 type TradeBalanceProps = {
 	isMobile?: boolean;
@@ -30,6 +31,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 	const dispatch = useAppDispatch();
 
 	const idleMargin = useAppSelector(selectIdleMargin);
+	const walletBal = useAppSelector(selectSusdBalance);
 	const accountType = useAppSelector(selectFuturesType);
 	const availableIsolatedMargin = useAppSelector(selectAvailableMargin);
 	const withdrawable = useAppSelector(selectWithdrawableMargin);
@@ -38,8 +40,8 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 	const [expanded, setExpanded] = useState(false);
 
 	const isDepositRequired = useMemo(() => {
-		return MIN_MARGIN_AMOUNT.sub(idleMargin).gt(zeroBN);
-	}, [idleMargin]);
+		return walletBal.lt(MIN_MARGIN_AMOUNT) && withdrawable.eq(0);
+	}, [walletBal, withdrawable]);
 
 	const onClickContainer = () => {
 		if (accountType === 'isolated_margin') return;
@@ -84,7 +86,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 						</FlexDivCol>
 					)}
 				</BalanceContainer>
-				{(accountType === 'isolated_margin' || withdrawable.gt(0) || !isDepositRequired) && (
+				{(accountType === 'isolated_margin' || withdrawable.gt(zeroBN)) && (
 					<Button
 						onClick={() =>
 							dispatch(

--- a/sections/futures/Trade/TradeBalance.tsx
+++ b/sections/futures/Trade/TradeBalance.tsx
@@ -67,7 +67,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 								variant="yellow"
 								size="xsmall"
 								textTransform="none"
-								onClick={() => dispatch(setOpenModal('futures_isolated_transfer'))}
+								onClick={() => dispatch(setOpenModal('futures_smart_margin_socket'))}
 							>
 								{t('header.balance.get-susd')}
 							</Button>
@@ -107,11 +107,15 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 			{expanded && accountType === 'cross_margin' && (
 				<DetailsContainer>{<CrossMarginInfoBox />}</DetailsContainer>
 			)}
-			{openModal === 'futures_isolated_transfer' && (
+			{openModal === 'futures_smart_margin_socket' && (
 				<TransferIsolatedMarginModal
 					defaultTab="deposit"
-					onlyDeposits={accountType === 'cross_margin'}
-					onDismiss={() => dispatch(setOpenModal(null))}
+					isSmartMargin={accountType === 'cross_margin'}
+					onDismiss={() => {
+						// eslint-disable-next-line no-console
+						console.log(`TradeBalance.tsx: onDismiss`);
+						dispatch(setOpenModal(null));
+					}}
 				/>
 			)}
 		</Container>

--- a/sections/futures/Trade/TradeBalance.tsx
+++ b/sections/futures/Trade/TradeBalance.tsx
@@ -9,6 +9,7 @@ import { Body, NumericValue } from 'components/Text';
 import { MIN_MARGIN_AMOUNT } from 'constants/futures';
 import { setOpenModal } from 'state/app/reducer';
 import { selectShowModal } from 'state/app/selectors';
+import { selectSusdBalance } from 'state/balances/selectors';
 import {
 	selectAvailableMargin,
 	selectFuturesType,
@@ -20,7 +21,6 @@ import { formatDollars, zeroBN } from 'utils/formatters/number';
 
 import CrossMarginInfoBox from '../TradeCrossMargin/CrossMarginInfoBox';
 import TransferIsolatedMarginModal from './TransferIsolatedMarginModal';
-import { selectSusdBalance } from 'state/balances/selectors';
 
 type TradeBalanceProps = {
 	isMobile?: boolean;
@@ -110,6 +110,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 			{openModal === 'futures_isolated_transfer' && (
 				<TransferIsolatedMarginModal
 					defaultTab="deposit"
+					onlyDeposits={accountType === 'cross_margin'}
 					onDismiss={() => dispatch(setOpenModal(null))}
 				/>
 			)}

--- a/sections/futures/Trade/TransferIsolatedMarginModal.tsx
+++ b/sections/futures/Trade/TransferIsolatedMarginModal.tsx
@@ -185,7 +185,6 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, defaultTab })
 					? t('futures.market.trade.margin.modal.deposit.button')
 					: t('futures.market.trade.margin.modal.withdraw.button')}
 			</Button>
-
 			{txError && (
 				<Error containerStyle={{ margin: '16px 0 0 0' }} message={txError} formatter="revert" />
 			)}

--- a/sections/futures/Trade/TransferIsolatedMarginModal.tsx
+++ b/sections/futures/Trade/TransferIsolatedMarginModal.tsx
@@ -151,26 +151,21 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, defaultTab })
 					{openSocket ? <SocketBridge /> : <Spacer height={20} />}
 				</>
 			)}
-
-			<>
-				<BalanceContainer>
-					<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
-					<BalanceText>
-						<span>{formatDollars(susdBal)}</span> sUSD
-					</BalanceText>
-				</BalanceContainer>
-				<NumericInput
-					dataTestId="futures-market-trade-deposit-margin-input"
-					placeholder={PLACEHOLDER}
-					value={amount}
-					onChange={(_, v) => setAmount(v)}
-					right={
-						<MaxButton onClick={handleSetMax}>
-							{t('futures.market.trade.margin.modal.max')}
-						</MaxButton>
-					}
-				/>
-			</>
+			<BalanceContainer>
+				<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
+				<BalanceText>
+					<span>{formatDollars(susdBal)}</span> sUSD
+				</BalanceText>
+			</BalanceContainer>
+			<NumericInput
+				dataTestId="futures-market-trade-deposit-margin-input"
+				placeholder={PLACEHOLDER}
+				value={amount}
+				onChange={(_, v) => setAmount(v)}
+				right={
+					<MaxButton onClick={handleSetMax}>{t('futures.market.trade.margin.modal.max')}</MaxButton>
+				}
+			/>
 			{transferType === 0 ? (
 				<MinimumAmountDisclaimer>
 					{t('futures.market.trade.margin.modal.deposit.disclaimer')}
@@ -239,7 +234,7 @@ export const MaxButton = styled.button`
 
 const MinimumAmountDisclaimer = styled.div`
 	font-size: 12px;
-	margin: 20px 0 10px;
+	margin: 10px 0;
 	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
 	text-align: center;
 `;

--- a/sections/futures/Trade/TransferIsolatedMarginModal.tsx
+++ b/sections/futures/Trade/TransferIsolatedMarginModal.tsx
@@ -29,7 +29,6 @@ import { formatDollars, zeroBN } from 'utils/formatters/number';
 type Props = {
 	onDismiss(): void;
 	defaultTab: 'deposit' | 'withdraw';
-	isSmartMargin?: boolean;
 };
 
 type BalanceStatus = 'low_balance' | 'no_balance' | 'high_balance';
@@ -40,11 +39,7 @@ const SocketBridge = dynamic(() => import('../../../components/SocketBridge'), {
 
 const PLACEHOLDER = '$0.00';
 
-const TransferIsolatedMarginModal: React.FC<Props> = ({
-	onDismiss,
-	defaultTab,
-	isSmartMargin = false,
-}) => {
+const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, defaultTab }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
@@ -156,27 +151,26 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({
 					{openSocket ? <SocketBridge /> : <Spacer height={20} />}
 				</>
 			)}
-			{!isSmartMargin && (
-				<>
-					<BalanceContainer>
-						<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
-						<BalanceText>
-							<span>{formatDollars(susdBal)}</span> sUSD
-						</BalanceText>
-					</BalanceContainer>
-					<NumericInput
-						dataTestId="futures-market-trade-deposit-margin-input"
-						placeholder={PLACEHOLDER}
-						value={amount}
-						onChange={(_, v) => setAmount(v)}
-						right={
-							<MaxButton onClick={handleSetMax}>
-								{t('futures.market.trade.margin.modal.max')}
-							</MaxButton>
-						}
-					/>
-				</>
-			)}
+
+			<>
+				<BalanceContainer>
+					<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
+					<BalanceText>
+						<span>{formatDollars(susdBal)}</span> sUSD
+					</BalanceText>
+				</BalanceContainer>
+				<NumericInput
+					dataTestId="futures-market-trade-deposit-margin-input"
+					placeholder={PLACEHOLDER}
+					value={amount}
+					onChange={(_, v) => setAmount(v)}
+					right={
+						<MaxButton onClick={handleSetMax}>
+							{t('futures.market.trade.margin.modal.max')}
+						</MaxButton>
+					}
+				/>
+			</>
 			{transferType === 0 ? (
 				<MinimumAmountDisclaimer>
 					{t('futures.market.trade.margin.modal.deposit.disclaimer')}
@@ -185,19 +179,18 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({
 				<Spacer height={20} />
 			)}
 
-			{!isSmartMargin && (
-				<Button
-					data-testid="futures-market-trade-deposit-margin-button"
-					disabled={isDisabled}
-					fullWidth
-					onClick={transferType === 0 ? onDeposit : onWithdraw}
-					variant="flat"
-				>
-					{transferType === 0
-						? t('futures.market.trade.margin.modal.deposit.button')
-						: t('futures.market.trade.margin.modal.withdraw.button')}
-				</Button>
-			)}
+			<Button
+				data-testid="futures-market-trade-deposit-margin-button"
+				disabled={isDisabled}
+				fullWidth
+				onClick={transferType === 0 ? onDeposit : onWithdraw}
+				variant="flat"
+			>
+				{transferType === 0
+					? t('futures.market.trade.margin.modal.deposit.button')
+					: t('futures.market.trade.margin.modal.withdraw.button')}
+			</Button>
+
 			{txError && (
 				<Error containerStyle={{ margin: '16px 0 0 0' }} message={txError} formatter="revert" />
 			)}

--- a/sections/futures/Trade/TransferIsolatedMarginModal.tsx
+++ b/sections/futures/Trade/TransferIsolatedMarginModal.tsx
@@ -29,7 +29,7 @@ import { formatDollars, zeroBN } from 'utils/formatters/number';
 type Props = {
 	onDismiss(): void;
 	defaultTab: 'deposit' | 'withdraw';
-	onlyDeposits?: boolean;
+	isSmartMargin?: boolean;
 };
 
 type BalanceStatus = 'low_balance' | 'no_balance' | 'high_balance';
@@ -43,7 +43,7 @@ const PLACEHOLDER = '$0.00';
 const TransferIsolatedMarginModal: React.FC<Props> = ({
 	onDismiss,
 	defaultTab,
-	onlyDeposits = false,
+	isSmartMargin = false,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -138,7 +138,7 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({
 		>
 			{balanceStatus === 'high_balance' ? (
 				<StyledSegmentedControl
-					values={onlyDeposits ? ['Deposit'] : ['Deposit', 'Withdraw']}
+					values={['Deposit', 'Withdraw']}
 					selectedIndex={transferType}
 					onChange={onChangeTab}
 				/>
@@ -156,21 +156,27 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({
 					{openSocket ? <SocketBridge /> : <Spacer height={20} />}
 				</>
 			)}
-			<BalanceContainer>
-				<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
-				<BalanceText>
-					<span>{formatDollars(susdBal)}</span> sUSD
-				</BalanceText>
-			</BalanceContainer>
-			<NumericInput
-				dataTestId="futures-market-trade-deposit-margin-input"
-				placeholder={PLACEHOLDER}
-				value={amount}
-				onChange={(_, v) => setAmount(v)}
-				right={
-					<MaxButton onClick={handleSetMax}>{t('futures.market.trade.margin.modal.max')}</MaxButton>
-				}
-			/>
+			{!isSmartMargin && (
+				<>
+					<BalanceContainer>
+						<BalanceText>{t('futures.market.trade.margin.modal.balance')}:</BalanceText>
+						<BalanceText>
+							<span>{formatDollars(susdBal)}</span> sUSD
+						</BalanceText>
+					</BalanceContainer>
+					<NumericInput
+						dataTestId="futures-market-trade-deposit-margin-input"
+						placeholder={PLACEHOLDER}
+						value={amount}
+						onChange={(_, v) => setAmount(v)}
+						right={
+							<MaxButton onClick={handleSetMax}>
+								{t('futures.market.trade.margin.modal.max')}
+							</MaxButton>
+						}
+					/>
+				</>
+			)}
 			{transferType === 0 ? (
 				<MinimumAmountDisclaimer>
 					{t('futures.market.trade.margin.modal.deposit.disclaimer')}
@@ -179,17 +185,19 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({
 				<Spacer height={20} />
 			)}
 
-			<Button
-				data-testid="futures-market-trade-deposit-margin-button"
-				disabled={isDisabled}
-				fullWidth
-				onClick={transferType === 0 ? onDeposit : onWithdraw}
-				variant="flat"
-			>
-				{transferType === 0
-					? t('futures.market.trade.margin.modal.deposit.button')
-					: t('futures.market.trade.margin.modal.withdraw.button')}
-			</Button>
+			{!isSmartMargin && (
+				<Button
+					data-testid="futures-market-trade-deposit-margin-button"
+					disabled={isDisabled}
+					fullWidth
+					onClick={transferType === 0 ? onDeposit : onWithdraw}
+					variant="flat"
+				>
+					{transferType === 0
+						? t('futures.market.trade.margin.modal.deposit.button')
+						: t('futures.market.trade.margin.modal.withdraw.button')}
+				</Button>
+			)}
 			{txError && (
 				<Error containerStyle={{ margin: '16px 0 0 0' }} message={txError} formatter="revert" />
 			)}
@@ -238,7 +246,7 @@ export const MaxButton = styled.button`
 
 const MinimumAmountDisclaimer = styled.div`
 	font-size: 12px;
-	margin: 10px 0;
+	margin: 20px 0 10px;
 	color: ${(props) => props.theme.colors.selectedTheme.button.text.primary};
 	text-align: center;
 `;

--- a/sections/futures/Trade/TransferIsolatedMarginModal.tsx
+++ b/sections/futures/Trade/TransferIsolatedMarginModal.tsx
@@ -29,6 +29,7 @@ import { formatDollars, zeroBN } from 'utils/formatters/number';
 type Props = {
 	onDismiss(): void;
 	defaultTab: 'deposit' | 'withdraw';
+	onlyDeposits?: boolean;
 };
 
 type BalanceStatus = 'low_balance' | 'no_balance' | 'high_balance';
@@ -39,7 +40,11 @@ const SocketBridge = dynamic(() => import('../../../components/SocketBridge'), {
 
 const PLACEHOLDER = '$0.00';
 
-const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, defaultTab }) => {
+const TransferIsolatedMarginModal: React.FC<Props> = ({
+	onDismiss,
+	defaultTab,
+	onlyDeposits = false,
+}) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
 
@@ -133,7 +138,7 @@ const TransferIsolatedMarginModal: React.FC<Props> = ({ onDismiss, defaultTab })
 		>
 			{balanceStatus === 'high_balance' ? (
 				<StyledSegmentedControl
-					values={['Deposit', 'Withdraw']}
+					values={onlyDeposits ? ['Deposit'] : ['Deposit', 'Withdraw']}
 					selectedIndex={transferType}
 					onChange={onChangeTab}
 				/>

--- a/state/app/types.ts
+++ b/state/app/types.ts
@@ -13,6 +13,7 @@ export type ModalType =
 	| 'futures_confirm_isolated_margin_trade'
 	| 'futures_withdraw_keeper_balance'
 	| 'futures_smart_margin_onboard'
+	| 'futures_smart_margin_socket'
 	| null;
 
 export type FuturesPositionModalType =

--- a/translations/en.json
+++ b/translations/en.json
@@ -864,7 +864,7 @@
 							"deposit": "Deposit"
 						},
 						"bridge": {
-							"title": "Bridge",
+							"title": "Bridge & Swap",
 							"low-balance": "Your sUSD balance is low. You can bridge more assets from another network below.",
 							"no-balance": "To get started, you need sUSD to trade on Kwenta. You can bridge assets from another network into sUSD below."
 						}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The PR fixed the following issues:

1. In the following scenario, both `Get sUSD` and` Manage` are visible: 
  - smart margin account, 
  - wallet balance + idle margin in markets + free margin < 50 sUSD 
  - idle margin in markets + free margin >= 0 sUSD
 Expected result: Only show one button in any case.

2. When the user clicks the `Get sUSD` button, both the `Deposit` and `Withdraw` tabs show in modal.
Expected result: only show `Deposit` tab, hide the Input & "Deposit Margin" part

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
case 1:
if wallet balance = 30 & withdrawable = 0, then show `Get sUSD` button

case 2:
if wallet balance = 60 & withdrawable = 10, then show `Manage` button

case 3:
if wallet balance = 40 & withdrawable =10, then show `Manage` button

case 4:
if wallet balance = 10 &withdrawable = 30, then show `Manage` button

case 5:
if wallet balance = 0 & withdrawable = 60, then show `Manage` button

## Screenshots (if appropriate):
