### PR TITLE
Truncate M values in Trading History

### DIFF
--- a/components/Currency/CurrencyPrice/CurrencyPrice.tsx
+++ b/components/Currency/CurrencyPrice/CurrencyPrice.tsx
@@ -16,7 +16,6 @@ type CurrencyPriceProps = {
 	change?: number;
 	conversionRate?: WeiSource;
 	formatOptions?: FormatCurrencyOptions;
-	truncate?: boolean;
 	colorType?: 'secondary' | 'positive' | 'negative' | 'preview';
 	colored?: boolean;
 };
@@ -31,7 +30,6 @@ export const CurrencyPrice: FC<CurrencyPriceProps> = memo(
 		currencyKey = 'sUSD',
 		conversionRate = 1,
 		showCurrencyKey = false,
-		truncate = false,
 		colored = false,
 		...rest
 	}) => {
@@ -48,7 +46,6 @@ export const CurrencyPrice: FC<CurrencyPriceProps> = memo(
 					{formatCurrency(currencyKey, cleanPrice.div(conversionRate), {
 						sign: currencyKey === 'sUSD' ? '$' : sign,
 						currencyKey: showCurrencyKey ? currencyKey : undefined,
-						truncate,
 						...formatOptions,
 					})}
 				</NumericValue>

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -217,6 +217,7 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 											<Currency.Price
 												price={cellProps.row.original.longInterest}
 												colorType="positive"
+												formatOptions={{ truncateOver: 1e3 }}
 											/>
 											<Currency.Price
 												price={cellProps.row.original.shortInterest}

--- a/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
+++ b/sections/dashboard/FuturesMarketsTable/FuturesMarketsTable.tsx
@@ -216,13 +216,12 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 										<OpenInterestContainer>
 											<Currency.Price
 												price={cellProps.row.original.longInterest}
-												truncate
 												colorType="positive"
 											/>
 											<Currency.Price
 												price={cellProps.row.original.shortInterest}
-												truncate
 												colorType="negative"
+												formatOptions={{ truncateOver: 1e3 }}
 											/>
 										</OpenInterestContainer>
 									);
@@ -248,7 +247,12 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 								),
 								accessor: 'dailyVolume',
 								Cell: (cellProps: CellProps<typeof data[number]>) => {
-									return <Currency.Price price={cellProps.row.original.volume} truncate />;
+									return (
+										<Currency.Price
+											price={cellProps.row.original.volume}
+											formatOptions={{ truncateOver: 1e3 }}
+										/>
+									);
 								},
 								width: 125,
 								sortable: true,
@@ -320,7 +324,10 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 							Cell: (cellProps: CellProps<typeof data[number]>) => {
 								return (
 									<div>
-										<Currency.Price price={cellProps.row.original.openInterest} truncate />
+										<Currency.Price
+											price={cellProps.row.original.openInterest}
+											formatOptions={{ truncateOver: 1e3 }}
+										/>
 										<div>
 											<ChangePercent
 												showArrow={false}
@@ -357,7 +364,10 @@ const FuturesMarketsTable: React.FC<FuturesMarketsTableProps> = ({ search }) => 
 											/>
 										</div>
 										<div>
-											<Currency.Price price={cellProps.row.original.volume ?? 0} truncate />
+											<Currency.Price
+												price={cellProps.row.original.volume ?? 0}
+												formatOptions={{ truncateOver: 1e3 }}
+											/>
 										</div>
 									</div>
 								);

--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -148,14 +148,10 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 								),
 								accessor: 'notionalValue',
 								Cell: (cellProps: CellProps<any>) => {
-									const formatOptions = cellProps.row.original.position.notionalValue.gte(1e6)
-										? { truncate: true }
-										: {};
-
 									return (
 										<Currency.Price
 											price={cellProps.row.original.position.notionalValue}
-											formatOptions={formatOptions}
+											formatOptions={{ truncateOver: 1e6 }}
 										/>
 									);
 								},

--- a/sections/futures/MarketDetails/MarketDetails.tsx
+++ b/sections/futures/MarketDetails/MarketDetails.tsx
@@ -201,11 +201,11 @@ const MarketSkew: React.FC<MarketDetailsProps> = memo(({ mobile }) => {
 const OpenInterestDetail: React.FC<OpenInterestDetailProps> = memo(({ mobile, isLong }) => {
 	const marketInfo = useAppSelector(selectMarketInfo);
 	const oiCap = marketInfo?.marketLimitUsd
-		? formatDollars(marketInfo?.marketLimitUsd, { truncate: true })
+		? formatDollars(marketInfo?.marketLimitUsd, { truncateOver: 1e3 })
 		: null;
 	const openInterestType = isLong ? 'longUSD' : 'shortUSD';
 	const formattedUSD = marketInfo?.openInterest[openInterestType]
-		? formatDollars(marketInfo?.openInterest[openInterestType], { truncate: true })
+		? formatDollars(marketInfo?.openInterest[openInterestType], { truncateOver: 1e3 })
 		: NO_VALUE;
 
 	const mobileValue = (

--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -153,7 +153,7 @@ const PositionsTab = () => {
 								<Spacer width={5} />
 								<Currency.Price
 									price={row.position.notionalValue}
-									formatOptions={row.position.notionalValue.gte(1e6) ? { truncate: true } : {}}
+									formatOptions={{ truncateOver: 1e6 }}
 									colorType="secondary"
 								/>
 								{accountType === 'cross_margin' && (

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -126,8 +126,7 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 										{cellProps.row.original.amount !== NO_VALUE
 											? `${formatNumber(numValue, {
 													minDecimals: numDecimals,
-													truncate: true,
-													truncateOverM: true,
+													truncateOver: 1e6,
 											  })} ${normal ? '💀' : ''}`
 											: NO_VALUE}
 									</DirectionalValue>

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -126,6 +126,7 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 										{cellProps.row.original.amount !== NO_VALUE
 											? `${formatNumber(numValue, {
 													minDecimals: numDecimals,
+													truncate: true,
 											  })} ${normal ? '💀' : ''}`
 											: NO_VALUE}
 									</DirectionalValue>

--- a/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -127,6 +127,7 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile }) => {
 											? `${formatNumber(numValue, {
 													minDecimals: numDecimals,
 													truncate: true,
+													truncateOverM: true,
 											  })} ${normal ? '💀' : ''}`
 											: NO_VALUE}
 									</DirectionalValue>

--- a/sections/futures/UserInfo/PositionsTable.tsx
+++ b/sections/futures/UserInfo/PositionsTable.tsx
@@ -166,10 +166,6 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 							),
 							accessor: 'notionalValue',
 							Cell: (cellProps: CellProps<typeof data[number]>) => {
-								const formatOptions = cellProps.row.original.position.notionalValue.gte(1e6)
-									? { truncate: true }
-									: {};
-
 								return (
 									<ColWithButton>
 										<div>
@@ -181,8 +177,8 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 											</div>
 											<Currency.Price
 												price={cellProps.row.original.position.notionalValue}
-												formatOptions={formatOptions}
 												colorType="secondary"
+												formatOptions={{ truncateOver: 1e6 }}
 											/>
 										</div>
 										<Spacer width={10} />

--- a/sections/stats/charts/OpenInterest.tsx
+++ b/sections/stats/charts/OpenInterest.tsx
@@ -107,7 +107,7 @@ export const OpenInterest: FC<OpenInterestProps> = ({ mobile }) => {
 					},
 				},
 				axisLabel: {
-					formatter: (value: WeiSource) => formatDollars(value, { truncate: true }),
+					formatter: (value: WeiSource) => formatDollars(value, { truncateOver: 1e3 }),
 				},
 				position: 'right',
 			},

--- a/sections/stats/charts/Volume.tsx
+++ b/sections/stats/charts/Volume.tsx
@@ -57,7 +57,7 @@ export const Volume = () => {
 					position: 'right',
 					axisLabel: {
 						formatter: (value: WeiSource) =>
-							formatDollars(value, { truncate: true, maxDecimals: 0 }),
+							formatDollars(value, { truncateOver: 1e3, maxDecimals: 0 }),
 					},
 				},
 			],

--- a/utils/__tests__/number.test.ts
+++ b/utils/__tests__/number.test.ts
@@ -19,11 +19,11 @@ describe('number utils', () => {
 		expect(weiVal.toNumber()).toEqual(0.1);
 	});
 	test('should truncate millions correctly', () => {
-		const formatted = formatDollars('3251764', { truncate: true });
+		const formatted = formatDollars('3251764', { truncateOver: 1e6 });
 		expect(formatted).toEqual('$3.25M');
 	});
 	test('should truncate thousands correctly', () => {
-		const formatted = formatDollars('325764.27345', { truncate: true });
+		const formatted = formatDollars('325764.27345', { truncateOver: 1e3 });
 		expect(formatted).toEqual('$326K');
 	});
 	test('should strip traling zeros correctly', () => {

--- a/utils/__tests__/number.test.ts
+++ b/utils/__tests__/number.test.ts
@@ -19,7 +19,7 @@ describe('number utils', () => {
 		expect(weiVal.toNumber()).toEqual(0.1);
 	});
 	test('should truncate millions correctly', () => {
-		const formatted = formatDollars('3251764', { truncateOver: 1e6 });
+		const formatted = formatDollars('3251764', { truncateOver: 1e3 });
 		expect(formatted).toEqual('$3.25M');
 	});
 	test('should truncate thousands correctly', () => {

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -15,6 +15,7 @@ type WeiSource = Wei | number | string | ethers.BigNumber;
 
 type TruncatedOptions = {
 	truncate?: boolean;
+	truncateOverM?: boolean;
 	truncation?: {
 		// Maybe remove manual truncation params
 		unit: string;
@@ -86,6 +87,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 	const prefix = options?.prefix;
 	const suffix = options?.suffix;
 	const shouldTruncate = options?.truncate;
+	const shouldTruncateOverM = options?.truncateOverM;
 	const suggestDecimals = options?.suggestDecimals;
 	let truncation = options?.truncation;
 
@@ -109,7 +111,7 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 	if (shouldTruncate && !truncation) {
 		if (weiValue.gt(1e6)) {
 			truncation = { divisor: 1e6, unit: 'M', decimals: 2 };
-		} else if (weiValue.gt(1e3)) {
+		} else if (weiValue.gt(1e3) && !shouldTruncateOverM) {
 			truncation = { divisor: 1e3, unit: 'K', decimals: 0 };
 		}
 	}

--- a/utils/formatters/number.ts
+++ b/utils/formatters/number.ts
@@ -25,6 +25,13 @@ type TruncatedOptions = {
 	};
 };
 
+const thresholds = [
+	{ value: 1e12, divisor: 1e12, unit: 'T', decimals: 2 },
+	{ value: 1e9, divisor: 1e9, unit: 'B', decimals: 2 },
+	{ value: 1e6, divisor: 1e6, unit: 'M', decimals: 2 },
+	{ value: 1e3, divisor: 1e3, unit: 'K', decimals: 0 },
+];
+
 export type FormatNumberOptions = {
 	minDecimals?: number;
 	maxDecimals?: number;
@@ -87,7 +94,7 @@ export const commifyAndPadDecimals = (value: string, decimals: number) => {
 export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) => {
 	const prefix = options?.prefix;
 	const suffix = options?.suffix;
-	const truncateThreshold = options?.truncateOver;
+	const truncateThreshold = options?.truncateOver ?? 0;
 	const suggestDecimals = options?.suggestDecimals;
 	let truncation = options?.truncation;
 
@@ -108,22 +115,12 @@ export const formatNumber = (value: WeiSource, options?: FormatNumberOptions) =>
 	}
 
 	// specified truncation params overrides universal truncate
-	if (truncateThreshold && !truncation && weiValue.gt(truncateThreshold)) {
-		switch (truncateThreshold) {
-			case 1e12:
-				truncation = { divisor: 1e12, unit: 'T', decimals: 2 };
+	if (truncateThreshold && !truncation) {
+		for (const threshold of thresholds) {
+			if (weiValue.gt(threshold.value) && weiValue.gte(truncateThreshold)) {
+				truncation = threshold;
 				break;
-			case 1e9:
-				truncation = { divisor: 1e9, unit: 'B', decimals: 2 };
-				break;
-			case 1e6:
-				truncation = { divisor: 1e6, unit: 'M', decimals: 2 };
-				break;
-			case 1e3:
-				truncation = { divisor: 1e3, unit: 'K', decimals: 0 };
-				break;
-			default:
-				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We should truncate values over >1.000.000 to 1.00M in the trading history so that the trading history is readable.

## Related issue
closes #2357

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the futures page and check the truncated value of trade history table

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/4b8c47b3-8ce4-4fcf-a1da-0fb9de7c442d)
