### PR TITLE
fix: icons on homepage

### DIFF
--- a/utils/icons.ts
+++ b/utils/icons.ts
@@ -35,11 +35,11 @@ import LINKIcon from 'assets/png/currencies/sLINK.png';
 import LTCIcon from 'assets/png/currencies/sLTC.png';
 import MATICIcon from 'assets/png/currencies/sMATIC.png';
 import NEARIcon from 'assets/png/currencies/sNEAR.png';
+import SNXIcon from 'assets/png/currencies/SNX.png';
 import OILIcon from 'assets/png/currencies/sOIL.png';
 import OPIcon from 'assets/png/currencies/sOP.png';
 import PEPEIcon from 'assets/png/currencies/sPEPE.png';
 import SHIBIcon from 'assets/png/currencies/sSHIB.png';
-import SNXIcon from 'assets/png/currencies/SNX.png';
 import SOLIcon from 'assets/png/currencies/sSOL.png';
 import SUIIcon from 'assets/png/currencies/sSUI.png';
 import TRXIcon from 'assets/png/currencies/sTRX.png';
@@ -105,6 +105,7 @@ export const SYNTH_ICONS: Record<FuturesMarketKey | SynthsName | string, any> = 
 	sAVAX: AVAXIcon,
 	sAXS: AXSIcon,
 	sBCH: BCHIcon,
+	sBLUR: BLURIcon,
 	sBNB: BNBIcon,
 	sBTC: BTCIcon,
 	sCHF: CHFIcon,
@@ -116,10 +117,12 @@ export const SYNTH_ICONS: Record<FuturesMarketKey | SynthsName | string, any> = 
 	sETHBTC: ETHBTCIcon,
 	sEUR: EURIcon,
 	sFIL: FILIcon,
+	sFLOKI: FLOKIIcon,
 	sFLOW: FLOWIcon,
 	sFTM: FTMIcon,
 	sGBP: GBPIcon,
 	sGMX: GMXIcon,
+	sINJ: INJIcon,
 	sINR: INRIcon,
 	sJPY: JPYIcon,
 	sKRW: KRWIcon,
@@ -129,14 +132,18 @@ export const SYNTH_ICONS: Record<FuturesMarketKey | SynthsName | string, any> = 
 	sMATIC: MATICIcon,
 	sNEAR: NEARIcon,
 	sOP: OPIcon,
+	sPEPE: PEPEIcon,
 	sSHIB: SHIBIcon,
 	sSOL: SOLIcon,
+	sSUI: SUIIcon,
+	sTRX: TRXIcon,
 	sUNI: UNIIcon,
 	sUSD: USDIcon,
 	sWTI: OILIcon,
 	sXAU: XAUIcon,
 	sXAG: XAGIcon,
 	sXMR: XMRIcon,
+	sXRP: XRPIcon,
 	KWENTA: KWENTAIcon,
 	[CRYPTO_CURRENCY_MAP.SNX]: SNXIcon,
 	WBTC: WBTCIcon,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Icons for new markets are missing on the landing page, this fixes it.

## Screenshots

<img width="948" alt="Screenshot 2023-05-23 at 11 25 40" src="https://github.com/Kwenta/kwenta/assets/548702/17576119-dbb0-4ac2-bf6a-1ec0624c2978">


## Notes

Layout for PEPE is currently out of order due to 24H Change being messed up, this *should* fix itself once the value normalizes