### PR TITLE
Fixed the past price of pepe from frontend

### DIFF
--- a/sdk/services/prices.ts
+++ b/sdk/services/prices.ts
@@ -186,7 +186,12 @@ export default class PricesService {
 			}
 		);
 		const prices = (response ? Object.values(response).flat() : []) as SynthPrice[];
-		return prices;
+
+		return prices.map((price) =>
+			price.synth === MarketAssetByKey[FuturesMarketKey.sPEPEPERP]
+				? { ...price, rate: wei(price.rate.toString()).div(1e10) }
+				: price
+		);
 	}
 
 	public async getPythPriceUpdateData(marketKey: FuturesMarketKey) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the pepe's  `24h hour price change` by dividing the past price by 1e10.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/5e0a1f5b-e441-4a35-8362-b291bdfffe69)
![image](https://github.com/Kwenta/kwenta/assets/4819006/72805108-2ffe-40d4-a7d2-f2d85a0c03c9)
![image](https://github.com/Kwenta/kwenta/assets/4819006/6fde917e-7b2d-4a62-be85-3e8e1f07d685)
