### PR TITLE
Adjusted the height of the price chart after deselecting trading history

### DIFF
--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -16,7 +16,7 @@ const MarketInfo: React.FC = React.memo(() => {
 });
 
 const Container = styled.div`
-	height: 100%;
+	height: 100vh;
 	width: 100%;
 	overflow: hidden;
 	display: grid;

--- a/sections/futures/MarketInfo/MarketInfo.tsx
+++ b/sections/futures/MarketInfo/MarketInfo.tsx
@@ -16,7 +16,7 @@ const MarketInfo: React.FC = React.memo(() => {
 });
 
 const Container = styled.div`
-	height: 100vh;
+	height: 100%;
 	width: 100%;
 	overflow: hidden;
 	display: grid;

--- a/sections/futures/PositionChart/PositionChart.tsx
+++ b/sections/futures/PositionChart/PositionChart.tsx
@@ -11,6 +11,7 @@ import {
 	selectTradePreview,
 } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
+import media from 'styles/media';
 import { zeroBN } from 'utils/formatters/number';
 
 type PositionChartProps = {
@@ -73,7 +74,12 @@ export default function PositionChart({ display = true }: PositionChartProps) {
 
 const Container = styled(FlexDiv)<{ $visible: boolean; $display?: boolean }>`
 	flex: 1;
-	height: 100%;
+	${media.greaterThan('mdUp')`
+		height: calc(100vh - 480px);
+	`}
+	${media.lessThan('md')`
+		height: 100%;
+	`}
 	width: 100%;
 	visibility: ${(props) => (props.$visible ? 'visible' : 'hidden')};
 	${(props) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the legacy futures, after deselecting the trading history box, the height of the price chart is not working as expected.

Reverted the following change in #2316 

![image](https://github.com/Kwenta/kwenta/assets/4819006/312e1d93-ec9d-4029-a63e-9e9fc8b41f33)

Ref: https://github.com/Kwenta/kwenta/pull/2316/files#diff-75b78545b9e3fae40ffbea8e525c3b600e8a0c65dfbee2dd939021e19a3404caL83-L88

## Related issue
#2316 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
