### PR TITLE
Fix the height of the market dropdown when the banner is visible

### DIFF
--- a/constants/announcement.ts
+++ b/constants/announcement.ts
@@ -7,3 +7,7 @@ export const BANNER_LINK_URL =
 // Sets the text displayed on the home page banner
 export const BANNER_TEXT =
 	'Optimism Bedrock upgrade planned for 16:00 UTC on June 6, 2023. Kwenta will be unavailable during the upgrade, and positions will be close-only for 48h prior to the upgrade. See the blog for details.';
+// Sets the height of the banner component on desktop
+export const BANNER_HEIGHT_DESKTOP = 50;
+// Set the height of the banner component on mobile
+export const BANNER_HEIGHT_MOBILE = 70;

--- a/constants/announcement.ts
+++ b/constants/announcement.ts
@@ -1,3 +1,5 @@
+import { MILLISECONDS_PER_DAY } from 'sdk/constants/period';
+
 // Shows or hides the home page banner entirely when set to true/false
 export const BANNER_ENABLED = true;
 // Sets the link destination for the banner component, or renders the banner as
@@ -9,5 +11,7 @@ export const BANNER_TEXT =
 	'Optimism Bedrock upgrade planned for 16:00 UTC on June 6, 2023. Kwenta will be unavailable during the upgrade, and positions will be close-only for 48h prior to the upgrade. See the blog for details.';
 // Sets the height of the banner component on desktop
 export const BANNER_HEIGHT_DESKTOP = 50;
-// Set the height of the banner component on mobile
+// Sets the height of the banner component on mobile
 export const BANNER_HEIGHT_MOBILE = 70;
+// Sets the waiting time of the banner component before it is reactive
+export const BANNER_WAITING_TIME = 2 * MILLISECONDS_PER_DAY;

--- a/pages/dashboard/markets.tsx
+++ b/pages/dashboard/markets.tsx
@@ -21,10 +21,10 @@ const MarketsPage: MarketsProps = () => {
 
 	return (
 		<>
-			<Spacer height={15} />
 			<Head>
 				<title>{t('dashboard-markets.page-title')}</title>
 			</Head>
+			<Spacer height={15} />
 			<SearchBarContainer>
 				<Search autoFocus value={search} onChange={setSearch} disabled={false} />
 			</SearchBarContainer>

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -15,17 +15,13 @@ import Table, { TableHeader, TableNoResults } from 'components/Table';
 import Search from 'components/Table/Search';
 import { Body } from 'components/Text';
 import NumericValue from 'components/Text/NumericValue';
-import {
-	BANNER_ENABLED,
-	BANNER_HEIGHT_DESKTOP,
-	BANNER_HEIGHT_MOBILE,
-} from 'constants/announcement';
+import { BANNER_HEIGHT_DESKTOP, BANNER_HEIGHT_MOBILE } from 'constants/announcement';
 import ROUTES from 'constants/routes';
 import useClickOutside from 'hooks/useClickOutside';
 import useLocalStorage from 'hooks/useLocalStorage';
-import { MILLISECONDS_PER_DAY } from 'sdk/constants/period';
 import { FuturesMarketAsset } from 'sdk/types/futures';
 import { getDisplayAsset } from 'sdk/utils/futures';
+import { selectShowBanner } from 'state/app/selectors';
 import {
 	selectMarketAsset,
 	selectMarkets,
@@ -45,7 +41,6 @@ import {
 	getSynthDescription,
 	MarketKeyByAsset,
 } from 'utils/futures';
-import localStore from 'utils/localStore';
 
 import { TRADE_PANEL_WIDTH_LG, TRADE_PANEL_WIDTH_MD } from '../styles';
 import MarketsDropdownSelector, { MARKET_SELECTOR_HEIGHT_MOBILE } from './MarketsDropdownSelector';
@@ -55,8 +50,6 @@ type MarketsDropdownProps = {
 };
 
 const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
-	const currentTime = new Date().getTime();
-	const storedTime: number = localStore.get('bannerIsClicked') || 0;
 	const markPrices = useAppSelector(selectMarkPriceInfos);
 	const pastPrices = useAppSelector(selectPreviousDayPrices);
 	const accountType = useAppSelector(selectFuturesType);
@@ -68,11 +61,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState('');
 	const [favMarkets, setFavMarkets] = useLocalStorage<string[]>('favorite-markets', []);
-	const showBanner = useMemo(
-		() => currentTime - storedTime >= 2 * MILLISECONDS_PER_DAY && BANNER_ENABLED,
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[storedTime]
-	);
+	const showBanner = useAppSelector(selectShowBanner);
 
 	const { ref } = useClickOutside(() => setOpen(false));
 

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -162,17 +162,12 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	}, [search, futuresMarkets, favMarkets, getPastPrice, getBasePriceRateInfo, t]);
 
 	const isFetching = !futuresMarkets.length && marketsQueryStatus.status === FetchStatus.Loading;
-	const tableHeight: number = useMemo(
-		() =>
-			Math.max(
-				window.innerHeight -
-					(mobile
-						? 159 + Number(showBanner) * BANNER_HEIGHT_MOBILE
-						: 205 + Number(showBanner) * BANNER_HEIGHT_DESKTOP),
-				300
-			),
-		[mobile, showBanner]
-	);
+
+	const tableHeight: number = useMemo(() => {
+		const BANNER_HEIGHT = mobile ? BANNER_HEIGHT_MOBILE : BANNER_HEIGHT_DESKTOP;
+		const OFFSET = mobile ? 159 : 205;
+		return Math.max(window.innerHeight - OFFSET - Number(showBanner) * BANNER_HEIGHT, 300);
+	}, [mobile, showBanner]);
 
 	return (
 		<SelectContainer mobile={mobile} ref={ref} accountType={accountType}>

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -15,7 +15,11 @@ import Table, { TableHeader, TableNoResults } from 'components/Table';
 import Search from 'components/Table/Search';
 import { Body } from 'components/Text';
 import NumericValue from 'components/Text/NumericValue';
-import { BANNER_ENABLED } from 'constants/announcement';
+import {
+	BANNER_ENABLED,
+	BANNER_HEIGHT_DESKTOP,
+	BANNER_HEIGHT_MOBILE,
+} from 'constants/announcement';
 import ROUTES from 'constants/routes';
 import useClickOutside from 'hooks/useClickOutside';
 import useLocalStorage from 'hooks/useLocalStorage';
@@ -64,8 +68,10 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState('');
 	const [favMarkets, setFavMarkets] = useLocalStorage<string[]>('favorite-markets', []);
-	const [showBanner] = useState(
-		currentTime - storedTime >= 3 * MILLISECONDS_PER_DAY && BANNER_ENABLED
+	const showBanner = useMemo(
+		() => currentTime - storedTime >= 2 * MILLISECONDS_PER_DAY && BANNER_ENABLED,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[storedTime]
 	);
 
 	const { ref } = useClickOutside(() => setOpen(false));
@@ -168,9 +174,17 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 
 	const isFetching = !futuresMarkets.length && marketsQueryStatus.status === FetchStatus.Loading;
 	const tableHeight: number = useMemo(
-		() => Math.max(window.innerHeight - (mobile ? 159 : 205) - (showBanner ? 50 : 0), 300),
+		() =>
+			Math.max(
+				window.innerHeight -
+					(mobile
+						? 159 + Number(showBanner) * BANNER_HEIGHT_MOBILE
+						: 205 + Number(showBanner) * BANNER_HEIGHT_DESKTOP),
+				300
+			),
 		[mobile, showBanner]
 	);
+
 	return (
 		<SelectContainer mobile={mobile} ref={ref} accountType={accountType}>
 			<MarketsDropdownSelector

--- a/sections/futures/Trade/MarketsDropdownSelector.tsx
+++ b/sections/futures/Trade/MarketsDropdownSelector.tsx
@@ -87,14 +87,12 @@ export const ContentContainer = styled(FlexDivCentered)<{ mobile?: boolean }>`
 		flex: 1;
 		margin-left: 12px;
 	}
-	width: ${(props) => (props.mobile ? '100%' : TRADE_PANEL_WIDTH_MD + 'px')};
+
 	border-right: ${(props) => props.theme.colors.selectedTheme.border};
 	border-bottom: ${(props) => props.theme.colors.selectedTheme.border};
 	${media.greaterThan('xxl')`
 		width: ${TRADE_PANEL_WIDTH_LG + 0.5}px;
 	`}
-
-	width: ${TRADE_PANEL_WIDTH_LG}px;
 
 	${media.lessThan('xxl')`
 		width: ${TRADE_PANEL_WIDTH_MD + 0.5}px;

--- a/sections/leaderboard/AllTime.tsx
+++ b/sections/leaderboard/AllTime.tsx
@@ -12,6 +12,7 @@ import Connector from 'containers/Connector';
 import useENSAvatar from 'hooks/useENSAvatar';
 import { AccountStat } from 'queries/futures/types';
 import { StyledTrader } from 'sections/leaderboard/trader';
+import media from 'styles/media';
 import { getMedal } from 'utils/competition';
 import { staticMainnetProvider } from 'utils/network';
 
@@ -250,6 +251,9 @@ const StyledTable = styled(Table)<{ compact: boolean | undefined }>`
 		padding-top: 8px;
 		padding-bottom: 8px;
 	}
+	${media.lessThan('md')`
+		margin-bottom: 150px;
+	`}
 `;
 
 const TableTitle = styled.div`

--- a/sections/shared/Layout/HomeLayout/Banner.tsx
+++ b/sections/shared/Layout/HomeLayout/Banner.tsx
@@ -2,7 +2,13 @@ import { memo, useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
-import { BANNER_ENABLED, BANNER_LINK_URL, BANNER_TEXT } from 'constants/announcement';
+import {
+	BANNER_ENABLED,
+	BANNER_HEIGHT_DESKTOP,
+	BANNER_HEIGHT_MOBILE,
+	BANNER_LINK_URL,
+	BANNER_TEXT,
+} from 'constants/announcement';
 import { MILLISECONDS_PER_DAY } from 'sdk/constants/period';
 import CloseIconWithHover from 'sections/shared/components/CloseIconWithHover';
 import media from 'styles/media';
@@ -11,7 +17,7 @@ import localStore from 'utils/localStore';
 const Banner = memo(() => {
 	const currentTime = new Date().getTime();
 	const storedTime: number = localStore.get('bannerIsClicked') || 0;
-	const [isClicked, setIsClicked] = useState(currentTime - storedTime < 3 * MILLISECONDS_PER_DAY);
+	const [isClicked, setIsClicked] = useState(currentTime - storedTime < 2 * MILLISECONDS_PER_DAY);
 
 	const handleDismiss = useCallback((e) => {
 		setIsClicked(true);
@@ -70,7 +76,7 @@ const FuturesLink = styled.div`
 `;
 
 const FuturesBannerContainer = styled.div<{ $compact?: boolean }>`
-	height: 50px;
+	height: ${BANNER_HEIGHT_DESKTOP}px;
 	width: 100%;
 	display: flex;
 	align-items: center;
@@ -88,7 +94,7 @@ const FuturesBannerContainer = styled.div<{ $compact?: boolean }>`
 		padding: 12px 10px;
 		border-radius: 0px;
 		gap: 5px;
-		height: 70px;
+		height: ${BANNER_HEIGHT_MOBILE}px;
 	`}
 `;
 

--- a/sections/shared/Layout/HomeLayout/Banner.tsx
+++ b/sections/shared/Layout/HomeLayout/Banner.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
+import { Body } from 'components/Text';
 import {
 	BANNER_ENABLED,
 	BANNER_HEIGHT_DESKTOP,
@@ -17,14 +18,39 @@ import { useAppDispatch, useAppSelector } from 'state/hooks';
 import media from 'styles/media';
 import localStore from 'utils/localStore';
 
+type BannerViewProps = {
+	mode: 'mobile' | 'desktop';
+	onDismiss: (e: any) => void;
+	onDetails: () => void;
+};
+
+const BannerView: React.FC<BannerViewProps> = ({ mode, onDismiss, onDetails }) => {
+	const isMobile = mode === 'mobile';
+	const closeIconStyle = isMobile ? { flex: '0.08', marginTop: '5px' } : { marginTop: '3px' };
+	const closeIconProps = isMobile ? { width: 12, height: 12 } : {};
+	const linkSize = isMobile ? 'small' : 'medium';
+
+	return (
+		<FuturesBannerContainer onClick={onDetails}>
+			<FuturesBannerLinkWrapper>
+				<FuturesLink size={linkSize}>
+					<strong>Important: </strong>
+					{BANNER_TEXT}
+				</FuturesLink>
+				<CloseIconWithHover onClick={onDismiss} style={closeIconStyle} {...closeIconProps} />
+			</FuturesBannerLinkWrapper>
+		</FuturesBannerContainer>
+	);
+};
+
 const Banner = memo(() => {
 	const dispatch = useAppDispatch();
 	const showBanner = useAppSelector(selectShowBanner);
-	const currentTime = new Date().getTime();
 	const storedTime: number = localStore.get('bannerIsClicked') || 0;
 
 	useEffect(
 		() => {
+			const currentTime = new Date().getTime();
 			dispatch(setShowBanner(currentTime - storedTime >= BANNER_WAITING_TIME));
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -34,7 +60,7 @@ const Banner = memo(() => {
 	const handleDismiss = useCallback(
 		(e) => {
 			dispatch(setShowBanner(false));
-			localStore.set('bannerIsClicked', currentTime);
+			localStore.set('bannerIsClicked', new Date().getTime());
 			e.stopPropagation();
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -51,35 +77,16 @@ const Banner = memo(() => {
 	return (
 		<>
 			<DesktopOnlyView>
-				<FuturesBannerContainer onClick={openDetails}>
-					<FuturesBannerLinkWrapper>
-						<FuturesLink>
-							<strong>Important: </strong>
-							{BANNER_TEXT}
-						</FuturesLink>
-						<CloseIconWithHover onClick={handleDismiss} style={{ marginTop: '3px' }} />
-					</FuturesBannerLinkWrapper>
-				</FuturesBannerContainer>
+				<BannerView mode="desktop" onDismiss={handleDismiss} onDetails={openDetails} />
 			</DesktopOnlyView>
 			<MobileOrTabletView>
-				<FuturesBannerContainer onClick={openDetails}>
-					<FuturesLink>
-						<strong>Important: </strong>
-						{BANNER_TEXT}
-					</FuturesLink>
-					<CloseIconWithHover
-						width={12}
-						height={12}
-						onClick={handleDismiss}
-						style={{ flex: '0.08', marginTop: '5px' }}
-					/>
-				</FuturesBannerContainer>
+				<BannerView mode="mobile" onDismiss={handleDismiss} onDetails={openDetails} />
 			</MobileOrTabletView>
 		</>
 	);
 });
 
-const FuturesLink = styled.div`
+const FuturesLink = styled(Body)`
 	margin-right: 5px;
 	padding: 4px 9px;
 	border-radius: 20px;
@@ -122,6 +129,7 @@ const FuturesBannerLinkWrapper = styled.div`
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	padding: 0 10px;
 `;
 
 export default Banner;

--- a/sections/shared/Layout/HomeLayout/Banner.tsx
+++ b/sections/shared/Layout/HomeLayout/Banner.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
@@ -13,15 +13,11 @@ const Banner = memo(() => {
 	const storedTime: number = localStore.get('bannerIsClicked') || 0;
 	const [isClicked, setIsClicked] = useState(currentTime - storedTime < 3 * MILLISECONDS_PER_DAY);
 
-	useEffect(() => {
-		if (isClicked) {
-			localStore.set('bannerIsClicked', currentTime);
-		}
-	}, [isClicked, currentTime]);
-
 	const handleDismiss = useCallback((e) => {
 		setIsClicked(true);
+		localStore.set('bannerIsClicked', currentTime);
 		e.stopPropagation();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const openDetails = useCallback(

--- a/state/app/reducer.ts
+++ b/state/app/reducer.ts
@@ -25,6 +25,7 @@ export const APP_INITIAL_STATE: AppState = {
 		lastUpdatedAt: undefined,
 	},
 	acknowledgedOrdersWarning: false,
+	showBanner: true,
 };
 
 const appSlice = createSlice({
@@ -76,6 +77,9 @@ const appSlice = createSlice({
 		setAcknowledgedOrdersWarning: (state, action: PayloadAction<boolean>) => {
 			state.acknowledgedOrdersWarning = action.payload;
 		},
+		setShowBanner: (state, action: PayloadAction<boolean>) => {
+			state.showBanner = action.payload;
+		},
 	},
 	extraReducers: (builder) => {
 		builder.addCase(checkSynthetixStatus.fulfilled, (state, action) => {
@@ -96,6 +100,7 @@ export const {
 	updateTransactionStatus,
 	updateTransactionHash,
 	setAcknowledgedOrdersWarning,
+	setShowBanner,
 } = appSlice.actions;
 
 export default appSlice.reducer;

--- a/state/app/selectors.ts
+++ b/state/app/selectors.ts
@@ -12,3 +12,5 @@ export const selectGasPrice = (state: RootState) => unserializeGasPrice(state.ap
 export const selectTransaction = (state: RootState) => state.app.transaction;
 
 export const selectAckedOrdersWarning = (state: RootState) => state.app.acknowledgedOrdersWarning;
+
+export const selectShowBanner = (state: RootState) => state.app.showBanner;

--- a/state/app/types.ts
+++ b/state/app/types.ts
@@ -49,4 +49,5 @@ export type AppState = {
 	synthetixOnMaintenance: boolean;
 	kwentaStatus: KwentaStatus;
 	acknowledgedOrdersWarning: boolean;
+	showBanner: boolean;
 };

--- a/state/migrations.ts
+++ b/state/migrations.ts
@@ -86,6 +86,12 @@ export const migrations = {
 			futures: FUTURES_INITIAL_STATE,
 		};
 	},
+	31: (state: any) => {
+		return {
+			...state,
+			app: APP_INITIAL_STATE,
+		};
+	},
 };
 
 export default migrations;

--- a/state/store.ts
+++ b/state/store.ts
@@ -34,7 +34,7 @@ const LOG_REDUX = false;
 const persistConfig = {
 	key: 'root1',
 	storage,
-	version: 30,
+	version: 31,
 	blacklist: ['app', 'wallet'],
 	migrate: createMigrate(migrations, { debug: true }),
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. The banner caused the market dropdown to not scroll to the bottom any more (e.g., not able to select PEPE). The height of the dropdown table is hardcoded based on the window height, which needs to be adjusted when there is a new component.
2. Reducing the cooldown period of the banner from 3 days to 2day.
3. The leaderboard is not scrolling on a smaller screen. This is unrelated to last week's release, but adding the bottom margin is a simple fix.

## Related issue
#2384 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Case 1. On a smaller or mobile, scroll down to the bottom of the market dropdown list when the banner is visible.
Case 2. On a smaller or mobile, scroll down to the bottom of the market dropdown list when the banner is hidden.
Case 3. On a smaller or mobile, scroll down to the bottom of the leaderboard and switch to the next page by the navigation.

We can delete the local storage value to test the visibility of the banner
![image](https://github.com/Kwenta/kwenta/assets/4819006/4c19ef53-1c1e-4768-bcbc-fd536e4b578d)

## Screenshots (if appropriate):
