### PR TITLE
Fix the flip effect of the caret icon when the area is expanded

### DIFF
--- a/sections/futures/MarketDetails/HoursToggle.tsx
+++ b/sections/futures/MarketDetails/HoursToggle.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
-import CaretDownIcon from 'assets/svg/app/caret-down.svg';
+import { StyledCaretDownIcon } from 'components/Select/Select';
 import { HOURS_TOGGLE_HEIGHT, HOURS_TOGGLE_WIDTH, zIndex } from 'constants/ui';
 import { FUNDING_RATE_PERIODS } from 'sdk/constants/period';
 import { setSelectedInputFundingRateHour } from 'state/futures/reducer';
@@ -29,7 +29,7 @@ const HoursToggle: React.FC = () => {
 					onClick={() => setOpen(!open)}
 				>
 					{getLabelByValue(fundingHours)}
-					<CaretDownIcon width={12} />
+					<StyledCaretDownIcon width={12} $flip={open} />
 				</ToggleTableHeader>
 				{open && (
 					<ToggleTableRows>

--- a/sections/futures/Trade/MarketsDropdown.tsx
+++ b/sections/futures/Trade/MarketsDropdown.tsx
@@ -173,6 +173,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 		<SelectContainer mobile={mobile} ref={ref} accountType={accountType}>
 			<MarketsDropdownSelector
 				onClick={() => setOpen(!open)}
+				expanded={open}
 				mobile={mobile}
 				asset={marketAsset}
 				label={getMarketName(marketAsset)}

--- a/sections/futures/Trade/MarketsDropdownSelector.tsx
+++ b/sections/futures/Trade/MarketsDropdownSelector.tsx
@@ -31,6 +31,7 @@ type Props = {
 		priceInfo?: PricesInfo;
 	};
 	onClick: () => void;
+	expanded: boolean;
 };
 
 const MarketsDropdownSelector: FC<Props> = (props) => (
@@ -48,7 +49,7 @@ const MarketsDropdownSelector: FC<Props> = (props) => (
 						/>
 					</CurrencyLabel>
 				</div>
-				{props.mobile && <StyledCaretDownIcon />}
+				{props.mobile && <StyledCaretDownIcon $flip={props.expanded} />}
 			</LeftContainer>
 			{props.mobile && (
 				<MobileRightContainer>
@@ -63,7 +64,7 @@ const MarketsDropdownSelector: FC<Props> = (props) => (
 				</MobileRightContainer>
 			)}
 
-			{!props.mobile && <StyledCaretDownIcon />}
+			{!props.mobile && <StyledCaretDownIcon $flip={props.expanded} />}
 		</ContentContainer>
 	</Container>
 );

--- a/sections/futures/Trade/TradeBalance.tsx
+++ b/sections/futures/Trade/TradeBalance.tsx
@@ -2,11 +2,11 @@ import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import CaretDownIcon from 'assets/svg/app/caret-down-gray.svg';
 import HelpIcon from 'assets/svg/app/question-mark.svg';
 import Button from 'components/Button';
 import { FlexDivCol, FlexDivRow, FlexDivRowCentered } from 'components/layout/flex';
 import Pill from 'components/Pill';
+import { StyledCaretDownIcon } from 'components/Select/Select';
 import { Body, NumericValue } from 'components/Text';
 import Tooltip from 'components/Tooltip/Tooltip';
 import { MIN_MARGIN_AMOUNT } from 'constants/futures';
@@ -56,10 +56,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 
 	return (
 		<Container>
-			<BalanceContainer
-				clickable={accountType === 'cross_margin'}
-				onClick={!isMobile ? onClickContainer : undefined}
-			>
+			<BalanceContainer clickable={accountType === 'cross_margin'} onClick={onClickContainer}>
 				{accountType === 'cross_margin' && isDepositRequired ? (
 					<DepositContainer>
 						<FlexDivCol>
@@ -67,7 +64,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 								<Body size={isMobile ? 'small' : 'medium'} color="secondary">
 									{t('futures.market.trade.trade-balance.no-available-margin')}
 								</Body>
-								{expanded ? <HideIcon /> : <ExpandIcon />}
+								<StyledCaretDownIcon $flip={expanded} />
 							</FlexDivRow>
 							<Body size={isMobile ? 'small' : 'medium'} color="preview">
 								{t('futures.market.trade.trade-balance.min-margin')}
@@ -157,25 +154,20 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 						<PencilButton
 							width={16}
 							height={16}
-							onClick={() =>
+							onClick={(e) => {
+								e.stopPropagation();
 								dispatch(
 									setOpenModal(
 										accountType === 'isolated_margin'
 											? 'futures_isolated_transfer'
 											: 'futures_cross_withdraw'
 									)
-								)
-							}
+								);
+							}}
 						/>
-						{expanded ? (
-							<Pill roundedCorner={false} onClick={onClickContainer}>
-								<HideIcon />
-							</Pill>
-						) : (
-							<Pill roundedCorner={false} onClick={onClickContainer}>
-								<ExpandIcon />
-							</Pill>
-						)}
+						<Pill roundedCorner={false} onClick={onClickContainer}>
+							<StyledCaretDownIcon $flip={expanded} style={{ marginTop: '1.5px' }} />
+						</Pill>
 					</FlexDivRowCentered>
 				)}
 			</BalanceContainer>
@@ -215,13 +207,6 @@ const BalanceContainer = styled(FlexDivRowCentered)<{ clickable: boolean }>`
 
 const DetailsContainer = styled.div`
 	margin-top: 15px;
-`;
-
-const ExpandIcon = styled(CaretDownIcon)``;
-
-const HideIcon = styled(CaretDownIcon)`
-	transform: scaleY(-1);
-	margin-top: 4px;
 `;
 
 export default TradeBalance;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The carets used here should be consistent and flip when the section is expanded.

## Related issue
#2392 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
