### PR TITLE
Fix the vertical scroll of conditional order table

### DIFF
--- a/components/Text/CustomFontLabel.tsx
+++ b/components/Text/CustomFontLabel.tsx
@@ -1,0 +1,22 @@
+type Props = {
+	text: string;
+};
+
+export const CustomFontLabel: React.FC<Props> = ({ text }) => {
+	const chars = text.split('');
+
+	return (
+		<div>
+			{chars.map((char, index) => {
+				const isNumber = !isNaN(Number(char));
+				const fontFamily = isNumber ? 'AkkuratMonoLLWeb-Regular' : 'AkkuratLLWeb-Regular';
+
+				return (
+					<span key={index} style={{ fontFamily }}>
+						{char}
+					</span>
+				);
+			})}
+		</div>
+	);
+};

--- a/sections/futures/UserInfo/ConditionalOrdersTable.tsx
+++ b/sections/futures/UserInfo/ConditionalOrdersTable.tsx
@@ -56,7 +56,7 @@ export default function ConditionalOrdersTable() {
 		<Container>
 			<ConditionalOrdersWarning />
 			<Table
-				data={rows}
+				data={[...rows, ...rows]}
 				highlightRowsOnHover
 				noBottom={true}
 				rounded={false}
@@ -211,7 +211,7 @@ export default function ConditionalOrdersTable() {
 }
 
 const Container = styled.div`
-	height: 100%;
+	height: calc(100% - 40px);
 	overflow: scroll;
 `;
 

--- a/sections/futures/UserInfo/ConditionalOrdersTable.tsx
+++ b/sections/futures/UserInfo/ConditionalOrdersTable.tsx
@@ -8,6 +8,8 @@ import ColoredPrice from 'components/ColoredPrice';
 import Currency from 'components/Currency';
 import Pill from 'components/Pill';
 import Table, { TableHeader, TableNoResults } from 'components/Table';
+import { Body } from 'components/Text';
+import { CustomFontLabel } from 'components/Text/CustomFontLabel';
 import { NO_VALUE } from 'constants/placeholder';
 import useIsL2 from 'hooks/useIsL2';
 import useNetworkSwitcher from 'hooks/useNetworkSwitcher';
@@ -56,7 +58,7 @@ export default function ConditionalOrdersTable() {
 		<Container>
 			<ConditionalOrdersWarning />
 			<Table
-				data={[...rows, ...rows]}
+				data={rows}
 				highlightRowsOnHover
 				noBottom={true}
 				rounded={false}
@@ -108,7 +110,7 @@ export default function ConditionalOrdersTable() {
 						Header: <TableHeader>{t('futures.market.user.open-orders.table.type')}</TableHeader>,
 						accessor: 'type',
 						Cell: (cellProps: CellProps<any>) => {
-							return <div>{cellProps.row.original.orderTypeDisplay}</div>;
+							return <Body>{cellProps.row.original.orderTypeDisplay}</Body>;
 						},
 						sortable: true,
 						width: 50,
@@ -119,7 +121,7 @@ export default function ConditionalOrdersTable() {
 						),
 						accessor: 'reduceOnly',
 						Cell: (cellProps: CellProps<any>) => {
-							return <div>{cellProps.row.original.reduceOnly ? 'yes' : 'no'}</div>;
+							return <Body>{cellProps.row.original.reduceOnly ? 'Yes' : 'No'}</Body>;
 						},
 						sortable: true,
 						width: 50,
@@ -128,7 +130,7 @@ export default function ConditionalOrdersTable() {
 						Header: <TableHeader>{t('futures.market.user.open-orders.table.size')}</TableHeader>,
 						accessor: 'size',
 						Cell: (cellProps: CellProps<any>) => {
-							return <div>{cellProps.row.original.sizeTxt}</div>;
+							return <CustomFontLabel text={cellProps.row.original.sizeTxt} />;
 						},
 						sortable: true,
 						width: 50,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- [X] Fix the vertical scroll of the conditional order table
- [X] Update the font family of the columns

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Use wallet address: 0xC2ecD777d06FFDF8B3179286BEabF52B67E9d991
2. Scroll the conditional order table vertically

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/715fdc9f-9296-4d90-8774-33db607911a1)
