### PR TITLE
Fix: vertical scroll of the leaderboard on small screens

### DIFF
--- a/sections/leaderboard/AllTime.tsx
+++ b/sections/leaderboard/AllTime.tsx
@@ -258,7 +258,7 @@ const AllTime: FC<AllTimeProps> = ({
 
 const StyledTable = styled(Table)<{ compact: boolean | undefined; height?: number }>`
 	margin-top: ${({ compact }) => (compact ? '0' : '15px')};
-	height: ${({ height }) => height}px;
+	height: ${({ height }) => (height ? height + 'px' : 'auto')};
 	max-height: 665px;
 
 	${TableCell} {

--- a/sections/leaderboard/AllTime.tsx
+++ b/sections/leaderboard/AllTime.tsx
@@ -7,11 +7,15 @@ import Currency from 'components/Currency';
 import { MobileHiddenView, MobileOnlyView } from 'components/Media';
 import Table, { TableHeader } from 'components/Table';
 import { TableCell } from 'components/Table/TableBodyRow';
+import { BANNER_HEIGHT_DESKTOP } from 'constants/announcement';
 import { DEFAULT_LEADERBOARD_ROWS } from 'constants/defaults';
-import Connector from 'containers/Connector';
 import useENSAvatar from 'hooks/useENSAvatar';
 import { AccountStat } from 'queries/futures/types';
 import { StyledTrader } from 'sections/leaderboard/trader';
+import { selectShowBanner } from 'state/app/selectors';
+import { useAppSelector } from 'state/hooks';
+import { selectWallet } from 'state/wallet/selectors';
+import { FOOTER_HEIGHT } from 'styles/common';
 import media from 'styles/media';
 import { getMedal } from 'utils/competition';
 import { staticMainnetProvider } from 'utils/network';
@@ -34,7 +38,8 @@ const AllTime: FC<AllTimeProps> = ({
 	activeTab,
 }) => {
 	const { t } = useTranslation();
-	const { walletAddress } = Connector.useContainer();
+	const walletAddress = useAppSelector(selectWallet);
+	const showBanner = useAppSelector(selectShowBanner);
 
 	if (compact) {
 		const ownPosition = stats.findIndex((i) => {
@@ -54,10 +59,16 @@ const AllTime: FC<AllTimeProps> = ({
 		return [...pinRow, ...stats];
 	}, [stats, pinRow]);
 
+	const tableHeight = useMemo(
+		() => window.innerHeight - FOOTER_HEIGHT - 161 - Number(showBanner) * BANNER_HEIGHT_DESKTOP,
+		[showBanner]
+	);
+
 	return (
 		<>
 			<MobileHiddenView>
 				<StyledTable
+					height={tableHeight}
 					compact={compact}
 					showPagination
 					isLoading={isLoading}
@@ -245,12 +256,20 @@ const AllTime: FC<AllTimeProps> = ({
 	);
 };
 
-const StyledTable = styled(Table)<{ compact: boolean | undefined }>`
+const StyledTable = styled(Table)<{ compact: boolean | undefined; height?: number }>`
 	margin-top: ${({ compact }) => (compact ? '0' : '15px')};
+	height: ${({ height }) => height}px;
+	max-height: 665px;
+
 	${TableCell} {
 		padding-top: 8px;
 		padding-bottom: 8px;
 	}
+
+	${media.lessThan('lg')`
+		max-height: 600px;
+	`}
+
 	${media.lessThan('md')`
 		margin-bottom: 150px;
 	`}

--- a/sections/leaderboard/TraderHistory.tsx
+++ b/sections/leaderboard/TraderHistory.tsx
@@ -12,8 +12,10 @@ import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 import FuturesIcon from 'components/Nav/FuturesIcon';
 import Table, { TableHeader } from 'components/Table';
 import { Body } from 'components/Text';
+import { BANNER_HEIGHT_DESKTOP } from 'constants/announcement';
 import ROUTES from 'constants/routes';
 import TimeDisplay from 'sections/futures/Trades/TimeDisplay';
+import { selectShowBanner } from 'state/app/selectors';
 import { fetchPositionHistoryForTrader } from 'state/futures/actions';
 import {
 	selectFuturesPositions,
@@ -22,7 +24,8 @@ import {
 } from 'state/futures/selectors';
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { FetchStatus } from 'state/types';
-import { ExternalLink } from 'styles/common';
+import { ExternalLink, FOOTER_HEIGHT } from 'styles/common';
+import media from 'styles/media';
 import { zeroBN } from 'utils/formatters/number';
 import { getMarketName } from 'utils/futures';
 
@@ -40,6 +43,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 		const dispatch = useAppDispatch();
 		const positionHistory = useAppSelector(selectPositionHistoryForSelectedTrader);
 		const positions = useAppSelector(selectFuturesPositions);
+		const showBanner = useAppSelector(selectShowBanner);
 		const { selectedTraderPositionHistory: queryStatus } = useAppSelector(selectQueryStatuses);
 		const traderENSName = useMemo(() => ensInfo[trader] ?? null, [trader, ensInfo]);
 
@@ -85,10 +89,16 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 				);
 		}, [positionHistory, positions, searchTerm]);
 
+		const tableHeight = useMemo(
+			() => window.innerHeight - FOOTER_HEIGHT - 161 - Number(showBanner) * BANNER_HEIGHT_DESKTOP,
+			[showBanner]
+		);
+
 		return (
 			<>
 				<DesktopOnlyView>
 					<StyledTable
+						height={tableHeight}
 						compact={compact}
 						showPagination
 						pageSize={10}
@@ -129,8 +139,6 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 												</StyledCell>
 											);
 										},
-										sortType: 'basic',
-										sortable: true,
 										width: compact ? 40 : 100,
 									},
 									{
@@ -165,8 +173,6 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 										),
 										accessor: 'trades',
 										width: compact ? 40 : 100,
-										sortType: 'basic',
-										sortable: true,
 									},
 									{
 										Header: (
@@ -179,8 +185,6 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 											<Currency.Price price={cellProps.row.original.totalVolume} />
 										),
 										width: compact ? 40 : 100,
-										sortType: 'basic',
-										sortable: true,
 									},
 									{
 										Header: (
@@ -196,8 +200,6 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 											</PnlContainer>
 										),
 										width: compact ? 40 : 100,
-										sortType: 'basic',
-										sortable: true,
 									},
 								],
 							},
@@ -273,8 +275,6 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 											</PnlContainer>
 										),
 										width: 40,
-										sortType: 'basic',
-										sortable: true,
 									},
 								],
 							},
@@ -286,8 +286,17 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 	}
 );
 
-const StyledTable = styled(Table)<{ compact?: boolean }>`
+const StyledTable = styled(Table)<{ compact?: boolean; height?: number }>`
 	margin-top: ${({ compact }) => (compact ? '0' : '15px')};
+	height: ${({ height }) => (height ? height + 'px' : 'auto')};
+	max-height: 665px;
+	${media.lessThan('lg')`
+		max-height: 600px;
+	`}
+
+	${media.lessThan('md')`
+		margin-bottom: 150px;
+	`}
 `;
 
 const TableTitle = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the vertical scroll of the leaderboard/trader history on small screens

## Related issue
#2389
#2399

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/a6ad2bdf-aebe-4484-8a29-d40fb1076a4f)
![image](https://github.com/Kwenta/kwenta/assets/4819006/d11a6d45-ebc6-47d7-bcda-6a70284ea685)
