### PR TITLE
UI: funding chart update

### DIFF
--- a/sections/futures/FundingChart.tsx
+++ b/sections/futures/FundingChart.tsx
@@ -52,7 +52,11 @@ const FundingChart: FC<FundingChartProps> = ({ display = true }) => {
 					minTickGap={75}
 					domain={['dataMin', 'dataMax']}
 				/>
-				<Tooltip content={<FundingChartTooltip />} formatter={(x) => formatFundingRate(x as any)} />
+				<Tooltip
+					content={<FundingChartTooltip />}
+					formatter={(x) => formatFundingRate(x as any)}
+					isAnimationActive={false}
+				/>
 				<ReferenceLine y={0} stroke={theme.colors.selectedTheme.text.body} />
 				<Line
 					type="monotone"

--- a/sections/futures/FundingChart.tsx
+++ b/sections/futures/FundingChart.tsx
@@ -1,12 +1,20 @@
 import { FC } from 'react';
-import { LineChart, XAxis, Line, ResponsiveContainer, YAxis, Tooltip } from 'recharts';
+import {
+	LineChart,
+	XAxis,
+	Line,
+	ResponsiveContainer,
+	YAxis,
+	Tooltip,
+	ReferenceLine,
+} from 'recharts';
 import styled, { css } from 'styled-components';
 import { useTheme } from 'styled-components';
 
+import { formatChartTime } from 'sdk/utils/date';
 import { fetchFundingRatesHistory } from 'state/futures/actions';
 import { selectMarketAsset } from 'state/futures/selectors';
 import { useAppSelector, usePollAction } from 'state/hooks';
-import { formatChartTime } from 'sdk/utils/date';
 
 import FundingChartTooltip, { formatFundingRate } from './FundingChartTooltip';
 
@@ -26,7 +34,15 @@ const FundingChart: FC<FundingChartProps> = ({ display = true }) => {
 
 	return (
 		<FundingChartContainer $display={display}>
-			<LineChart data={historicalFundingRates[marketAsset]}>
+			<LineChart
+				data={historicalFundingRates[marketAsset]}
+				margin={{
+					top: 30,
+					right: 50,
+					left: 30,
+					bottom: 15,
+				}}
+			>
 				<YAxis dataKey="fundingRate" domain={['auto', 0]} tickFormatter={formatFundingRate} />
 				<XAxis
 					dataKey="timestamp"
@@ -37,11 +53,12 @@ const FundingChart: FC<FundingChartProps> = ({ display = true }) => {
 					domain={['dataMin', 'dataMax']}
 				/>
 				<Tooltip content={<FundingChartTooltip />} formatter={(x) => formatFundingRate(x as any)} />
+				<ReferenceLine y={0} stroke={theme.colors.selectedTheme.text.body} />
 				<Line
 					type="monotone"
 					dataKey="fundingRate"
 					stroke={theme.colors.selectedTheme.text.value}
-					strokeWidth={2}
+					strokeWidth={1}
 					strokeLinecap="square"
 					dot={false}
 					isAnimationActive={false}

--- a/styles/theme/colors/light.ts
+++ b/styles/theme/colors/light.ts
@@ -177,7 +177,7 @@ const newTheme = {
 	},
 	fundingChart: {
 		tooltip: {
-			background: common.palette.neutral.n40,
+			background: common.palette.neutral.n10,
 			border: common.palette.neutral.n50,
 		},
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- [X] Add some left, right, and top padding to the funding chart
- [X] Make the line on the line chart 1 pixel
- [X] Add a reference line
- [X] Disable the animation of the tooltip
- [X] Update the background of the tooltip in light mode

## Related issue
closes #2400
closes #2412 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/bf6824dc-799c-4dbf-aeab-bf27a568b09b)
![image](https://github.com/Kwenta/kwenta/assets/4819006/19f44ddf-3ff9-457e-9448-18e3609f61b7)


