### PR TITLE
Fix: Enforce size based max leverage

### DIFF
--- a/sdk/contracts/PerpsV2MarketInternalV2.ts
+++ b/sdk/contracts/PerpsV2MarketInternalV2.ts
@@ -595,7 +595,7 @@ class FuturesMarketInternal {
 		const skewScaleWei = wei(skewScale);
 
 		return liqBuffer
-			.div(wei(size).abs().div(skewScaleWei).mul(liqPremMultiplierWei.add(liqBufferRatioWei)))
+			.div(wei(size).abs().div(skewScaleWei).mul(liqPremMultiplierWei).add(liqBufferRatioWei))
 			.toBN();
 	};
 

--- a/sdk/contracts/PerpsV2MarketInternalV2.ts
+++ b/sdk/contracts/PerpsV2MarketInternalV2.ts
@@ -223,7 +223,6 @@ class FuturesMarketInternal {
 			return { newPos, fee: ZERO_BIG_NUM, status: PotentialTradeStatus.CAN_LIQUIDATE };
 		}
 		const maxLeverage = await this._getSetting('maxLeverage');
-
 		const maxLeverageForSize = await this._maxLeverageForSize(newPos.size);
 
 		const leverage = divideDecimal(
@@ -233,7 +232,7 @@ class FuturesMarketInternal {
 
 		if (
 			maxLeverage.add(UNIT_BIG_NUM.div(100)).lt(leverage.abs()) ||
-			leverage.gt(maxLeverageForSize)
+			leverage.abs().gt(maxLeverageForSize)
 		) {
 			return {
 				newPos: oldPos,
@@ -596,7 +595,7 @@ class FuturesMarketInternal {
 		const skewScaleWei = wei(skewScale);
 
 		return liqBuffer
-			.div(wei(size).div(skewScaleWei).mul(liqPremMultiplierWei.add(liqBufferRatioWei)))
+			.div(wei(size).abs().div(skewScaleWei).mul(liqPremMultiplierWei.add(liqBufferRatioWei)))
 			.toBN();
 	};
 

--- a/sdk/utils/futures.ts
+++ b/sdk/utils/futures.ts
@@ -399,7 +399,7 @@ export const POTENTIAL_TRADE_STATUS_TO_MESSAGE: { [key: string]: string } = {
 	CAN_LIQUIDATE: 'Position can be liquidated',
 	CANNOT_LIQUIDATE: 'Position cannot be liquidated',
 	MAX_MARKET_SIZE_EXCEEDED: 'Open interest limit exceeded',
-	MAX_LEVERAGE_EXCEEDED: 'Max leverage exceeded',
+	MAX_LEVERAGE_EXCEEDED: 'Max leverage exceeded (larger positions have lower max leverage)',
 	INSUFFICIENT_MARGIN: 'Insufficient margin',
 	NOT_PERMITTED: 'Not permitted by this address',
 	NO_POSITION_OPEN: 'No position open',

--- a/utils/formatters/error.ts
+++ b/utils/formatters/error.ts
@@ -6,7 +6,7 @@ const KNOWN_ERROR_PATTERNS: Record<string, string> = {
 	'executability not reached': 'Cannot execute yet, try again in a few seconds',
 	'cannot cancel yet': 'Cannot cancel order yet',
 	'Insufficient margin': 'Insufficient margin',
-	'Max leverage exceeded': 'Max leverage exceeded',
+	'Max leverage exceeded': 'Max leverage exceeded (larger positions have lower max leverage)',
 };
 
 export const formatRevert = (revertMsg: string) => {


### PR DESCRIPTION
## Description

Adds max leverage validation for larger trade sizes and displays an error when invalid.

## Screenshots (if appropriate):
<img width="316" alt="Screenshot 2023-06-02 at 13 27 56" src="https://github.com/Kwenta/kwenta/assets/3802342/21a9a922-ed71-43e8-87c4-a41c034f5214">
