### PR TITLE
chore: update to new gov frontend

### DIFF
--- a/constants/links.ts
+++ b/constants/links.ts
@@ -36,14 +36,13 @@ export const EXTERNAL_LINKS = {
 		DocsRoot: 'https://docs.kwenta.io/',
 		FeeReclamation: 'https://docs.kwenta.io/resources/fee-reclamation',
 		HowToTrade: 'https://docs.kwenta.io/products/futures',
-		Governance: 'https://github.com/Kwenta/kwenta-state-log',
-		DaoRoles: 'https://github.com/Kwenta/kwenta-state-log/blob/master/sections/2.md',
+		Governance: 'https://gov.kwenta.eth.limo',
+		DaoRoles: 'https://gov.kwenta.eth.limo/sections/2',
 		HowToUse: 'https://docs.kwenta.io/onboard/how-to-start-using-kwenta',
 		Perpetuals: 'https://docs.kwenta.io/products/futures',
 		Spot: 'https://docs.kwenta.io/products/swaps ',
 		DevDao: 'https://docs.kwenta.io/dao/contribute/devdao-contribute',
-		MarketingDao:
-			'https://github.com/Kwenta/kwenta-state-log/blob/master/sections/2.md#marketingdao-grants-council-trial',
+		MarketingDao: 'https://gov.kwenta.eth.limo/sections/2/#marketingdao-grants-council-trial',
 		Faq: 'https://docs.kwenta.io/resources/faq',
 		CrossMarginFaq: 'https://docs.kwenta.io/using-kwenta/smart-margin/trading-on-kwenta/faq',
 		Staking: 'https://docs.kwenta.io/using-kwenta/staking-kwenta',
@@ -59,7 +58,7 @@ export const EXTERNAL_LINKS = {
 		V1: 'https://v1.kwenta.eth.limo/dashboard',
 	},
 	Governance: {
-		Kips: 'https://github.com/Kwenta/kwenta-state-log',
+		Kips: 'https://gov.kwenta.eth.limo/all-kips',
 		Vote: 'https://snapshot.org/#/kwenta.eth',
 	},
 	Competition: {

--- a/sections/dashboard/DashboardLayout/DashboardLayout.tsx
+++ b/sections/dashboard/DashboardLayout/DashboardLayout.tsx
@@ -77,7 +77,7 @@ const DashboardLayout: FC = ({ children }) => {
 				name: Tab.Governance,
 				label: t('dashboard.tabs.governance'),
 				active: activeTab === Tab.Governance,
-				href: EXTERNAL_LINKS.Governance.Vote,
+				href: EXTERNAL_LINKS.Docs.Governance,
 				external: true,
 			},
 		],

--- a/translations/en.json
+++ b/translations/en.json
@@ -59,7 +59,7 @@
 			"governance": {
 				"title": "Governance",
 				"overview": "Overview",
-				"kips": "Kwenta State Log"
+				"kips": "KIPs"
 			},
 			"socials": {
 				"title": "Socials",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updates links to new governance frontend at https://gov.kwenta.eth.limo
- Fixes homepage header link to point to Overview (KSL) and KIPs
- Update Dashboard Governance link to point to KSL instead of Snapshot
