### PR TITLE
Feat: show % in TP/SL input

### DIFF
--- a/sections/futures/EditPositionModal/EditStopLossAndTakeProfitInput.tsx
+++ b/sections/futures/EditPositionModal/EditStopLossAndTakeProfitInput.tsx
@@ -13,10 +13,11 @@ type Props = {
 	invalid: boolean;
 	currentPrice: string;
 	onChange: (_: ChangeEvent<HTMLInputElement>, v: string) => void;
+	right?: React.ReactNode;
 };
 
 const EditStopLossAndTakeProfitInput: React.FC<Props> = memo(
-	({ isMobile, type, value, invalid, currentPrice, onChange }) => {
+	({ isMobile, type, value, invalid, currentPrice, onChange, right }) => {
 		const { t } = useTranslation();
 
 		return (
@@ -40,6 +41,7 @@ const EditStopLossAndTakeProfitInput: React.FC<Props> = memo(
 							? t('futures.market.trade.edit-sl-tp.no-tp')
 							: t('futures.market.trade.edit-sl-tp.no-sl')
 					}
+					right={right}
 				/>
 			</div>
 		);

--- a/sections/futures/EditPositionModal/EditStopLossAndTakeProfitModal.tsx
+++ b/sections/futures/EditPositionModal/EditStopLossAndTakeProfitModal.tsx
@@ -30,6 +30,7 @@ import { useAppDispatch, useAppSelector } from 'state/hooks';
 import { KeeperDepositRow } from '../FeeInfoBox/FeesRow';
 import PositionType from '../PositionType';
 import OrderAcknowledgement from '../Trade/OrderAcknowledgement';
+import ShowPercentage from '../Trade/ShowPercentage';
 import EditStopLossAndTakeProfitInput from './EditStopLossAndTakeProfitInput';
 
 const TP_OPTIONS = ['none', '5%', '10%', '25%', '50%', '100%'];
@@ -226,6 +227,7 @@ export default function EditStopLossAndTakeProfitModal() {
 						}
 						value={takeProfitPrice}
 						onChange={onChangeTakeProfit}
+						right={<ShowPercentage targetPrice={takeProfitPrice} />}
 					/>
 
 					<SelectorButtons
@@ -244,6 +246,7 @@ export default function EditStopLossAndTakeProfitModal() {
 						}
 						value={stopLossPrice}
 						onChange={onChangeStopLoss}
+						right={<ShowPercentage targetPrice={stopLossPrice} isStopLoss={true} />}
 					/>
 
 					<SelectorButtons

--- a/sections/futures/EditPositionModal/EditStopLossAndTakeProfitModal.tsx
+++ b/sections/futures/EditPositionModal/EditStopLossAndTakeProfitModal.tsx
@@ -15,7 +15,11 @@ import { ConditionalOrderTypeEnum, PositionSide } from 'sdk/types/futures';
 import { formatDollars, stripZeros, suggestedDecimals } from 'sdk/utils/number';
 import { setShowPositionModal } from 'state/app/reducer';
 import { selectAckedOrdersWarning, selectTransaction } from 'state/app/selectors';
-import { calculateKeeperDeposit, updateStopLossAndTakeProfit } from 'state/futures/actions';
+import {
+	calculateKeeperDeposit,
+	clearTradeInputs,
+	updateStopLossAndTakeProfit,
+} from 'state/futures/actions';
 import { setSLTPModalStopLoss, setSLTPModalTakeProfit } from 'state/futures/reducer';
 import {
 	selectAllSLTPOrders,
@@ -126,6 +130,8 @@ export default function EditStopLossAndTakeProfitModal() {
 		const existingTP = exsistingSLTPOrders.find(
 			(o) => o.marketKey === market?.marketKey && o.orderType === ConditionalOrderTypeEnum.LIMIT
 		);
+		dispatch(clearTradeInputs());
+
 		dispatch(
 			setSLTPModalStopLoss(
 				existingSL?.targetPrice ? stripZeros(existingSL.targetPrice.toString()) : ''
@@ -227,7 +233,14 @@ export default function EditStopLossAndTakeProfitModal() {
 						}
 						value={takeProfitPrice}
 						onChange={onChangeTakeProfit}
-						right={<ShowPercentage targetPrice={takeProfitPrice} />}
+						right={
+							<ShowPercentage
+								targetPrice={takeProfitPrice}
+								currentPrice={marketPrice}
+								leverageSide={position?.position?.side}
+								leverageWei={leverageWei}
+							/>
+						}
 					/>
 
 					<SelectorButtons
@@ -246,7 +259,15 @@ export default function EditStopLossAndTakeProfitModal() {
 						}
 						value={stopLossPrice}
 						onChange={onChangeStopLoss}
-						right={<ShowPercentage targetPrice={stopLossPrice} isStopLoss={true} />}
+						right={
+							<ShowPercentage
+								targetPrice={stopLossPrice}
+								isStopLoss={true}
+								currentPrice={marketPrice}
+								leverageSide={position?.position?.side}
+								leverageWei={leverageWei}
+							/>
+						}
 					/>
 
 					<SelectorButtons

--- a/sections/futures/Trade/SLTPInputs.tsx
+++ b/sections/futures/Trade/SLTPInputs.tsx
@@ -22,6 +22,7 @@ import {
 import { useAppDispatch, useAppSelector } from 'state/hooks';
 
 import OrderAcknowledgement from './OrderAcknowledgement';
+import ShowPercentage from './ShowPercentage';
 
 const TP_OPTIONS = ['5%', '10%', '25%', '50%', '100%'];
 const SL_OPTIONS = ['2%', '5%', '10%', '20%', '50%'];
@@ -145,8 +146,10 @@ export default function SLTPInputs() {
 							value={stopLossPrice}
 							placeholder={'0.00'}
 							onChange={onChangeStopLoss}
+							right={
+								<ShowPercentage targetPrice={stopLossPrice} isStopLoss={true} isTradePanel={true} />
+							}
 						/>
-
 						<Spacer height={12} />
 
 						<InputHeaderRow
@@ -160,6 +163,7 @@ export default function SLTPInputs() {
 							value={takeProfitPrice}
 							placeholder={'0.00'}
 							onChange={onChangeTakeProfit}
+							right={<ShowPercentage targetPrice={takeProfitPrice} isTradePanel={true} />}
 						/>
 					</InputsContainer>
 				)

--- a/sections/futures/Trade/SLTPInputs.tsx
+++ b/sections/futures/Trade/SLTPInputs.tsx
@@ -147,7 +147,13 @@ export default function SLTPInputs() {
 							placeholder={'0.00'}
 							onChange={onChangeStopLoss}
 							right={
-								<ShowPercentage targetPrice={stopLossPrice} isStopLoss={true} isTradePanel={true} />
+								<ShowPercentage
+									targetPrice={stopLossPrice}
+									isStopLoss={true}
+									currentPrice={currentPrice}
+									leverageSide={leverageSide}
+									leverageWei={leverageWei}
+								/>
 							}
 						/>
 						<Spacer height={12} />
@@ -163,7 +169,14 @@ export default function SLTPInputs() {
 							value={takeProfitPrice}
 							placeholder={'0.00'}
 							onChange={onChangeTakeProfit}
-							right={<ShowPercentage targetPrice={takeProfitPrice} isTradePanel={true} />}
+							right={
+								<ShowPercentage
+									targetPrice={takeProfitPrice}
+									currentPrice={currentPrice}
+									leverageSide={leverageSide}
+									leverageWei={leverageWei}
+								/>
+							}
 						/>
 					</InputsContainer>
 				)

--- a/sections/futures/Trade/ShowPercentage.tsx
+++ b/sections/futures/Trade/ShowPercentage.tsx
@@ -1,0 +1,50 @@
+import { wei } from '@synthetixio/wei';
+import { useMemo } from 'react';
+
+import { Body } from 'components/Text';
+import { formatPercent } from 'sdk/utils/number';
+import { selectEditPositionModalInfo, selectMarketPrice } from 'state/futures/selectors';
+import { useAppSelector } from 'state/hooks';
+
+type ShowPercentageProps = {
+	targetPrice: string;
+	isStopLoss?: boolean;
+	isTradePanel?: boolean;
+};
+
+const ShowPercentage: React.FC<ShowPercentageProps> = ({
+	targetPrice,
+	isStopLoss = false,
+	isTradePanel = false,
+}) => {
+	const { marketPrice, position } = useAppSelector(selectEditPositionModalInfo);
+	const price = useAppSelector(selectMarketPrice);
+	const currentPrice = isTradePanel ? price : marketPrice;
+	const leverageSide = position?.position?.side;
+
+	const leverageWei = useMemo(() => {
+		return position?.position?.leverage.gt(0) ? wei(position.position.leverage) : wei(1);
+	}, [position?.position?.leverage]);
+
+	const calculatePercentage = () => {
+		if (!targetPrice || !currentPrice) return '';
+		const priceWei = wei(targetPrice);
+		const diff =
+			leverageSide === 'short'
+				? isStopLoss
+					? priceWei.sub(currentPrice)
+					: currentPrice.sub(priceWei)
+				: isStopLoss
+				? currentPrice.sub(priceWei)
+				: priceWei.sub(currentPrice);
+
+		return formatPercent(diff.div(currentPrice).mul(leverageWei));
+	};
+	return (
+		<Body size="large" mono>
+			{calculatePercentage()}
+		</Body>
+	);
+};
+
+export default ShowPercentage;

--- a/sections/futures/Trade/ShowPercentage.tsx
+++ b/sections/futures/Trade/ShowPercentage.tsx
@@ -1,33 +1,31 @@
-import { wei } from '@synthetixio/wei';
+import Wei, { wei } from '@synthetixio/wei';
 import { useMemo } from 'react';
 
 import { Body } from 'components/Text';
+import { PositionSide } from 'sdk/types/futures';
 import { formatPercent } from 'sdk/utils/number';
-import { selectEditPositionModalInfo, selectMarketPrice } from 'state/futures/selectors';
-import { useAppSelector } from 'state/hooks';
 
 type ShowPercentageProps = {
 	targetPrice: string;
 	isStopLoss?: boolean;
-	isTradePanel?: boolean;
+	currentPrice: Wei;
+	leverageSide: PositionSide | string | undefined;
+	leverageWei: Wei;
 };
 
 const ShowPercentage: React.FC<ShowPercentageProps> = ({
 	targetPrice,
 	isStopLoss = false,
-	isTradePanel = false,
+	currentPrice,
+	leverageSide,
+	leverageWei,
 }) => {
-	const { marketPrice, position } = useAppSelector(selectEditPositionModalInfo);
-	const price = useAppSelector(selectMarketPrice);
-	const currentPrice = isTradePanel ? price : marketPrice;
-	const leverageSide = position?.position?.side;
-
-	const leverageWei = useMemo(() => {
-		return position?.position?.leverage.gt(0) ? wei(position.position.leverage) : wei(1);
-	}, [position?.position?.leverage]);
-
-	const calculatePercentage = () => {
-		if (!targetPrice || !currentPrice) return '';
+	const calculatePercentage = useMemo(() => {
+		// eslint-disable-next-line no-console
+		console.log(
+			`targetPrice: ${targetPrice}, currentPrice: ${currentPrice}, leverageSide: ${leverageSide}`
+		);
+		if (!targetPrice || !currentPrice || !leverageSide) return '';
 		const priceWei = wei(targetPrice);
 		const diff =
 			leverageSide === 'short'
@@ -39,10 +37,11 @@ const ShowPercentage: React.FC<ShowPercentageProps> = ({
 				: priceWei.sub(currentPrice);
 
 		return formatPercent(diff.div(currentPrice).mul(leverageWei));
-	};
+	}, [currentPrice, isStopLoss, leverageSide, leverageWei, targetPrice]);
+
 	return (
 		<Body size="large" mono>
-			{calculatePercentage()}
+			{calculatePercentage}
 		</Body>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Show the % on the right side of the TP/SL input from both position table and trade panel

## Related issue
closes #2368 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Trade Panel: 
1. Type different tp/sl prices and see the percentage

Position table:
1. Pick an open position and click on the tp/sl update icon
2. Update the tp/sl prices and see the percentage

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/ffd82ba1-c7b0-4c26-953d-98f8cb562fec)
![image](https://github.com/Kwenta/kwenta/assets/4819006/155d739b-f98e-430c-82e2-94cbcfd52c72)
