### PR TITLE
A better fix to the max price impact issue

### DIFF
--- a/sdk/constants/futures.ts
+++ b/sdk/constants/futures.ts
@@ -19,7 +19,7 @@ export const KWENTA_TRACKING_CODE = formatBytes32String('KWENTA');
 export const DEFAULT_NUMBER_OF_TRADES = 32;
 
 export const DEFAULT_PRICE_IMPACT_DELTA_PERCENT = {
-	MARKET: '4',
+	MARKET: '1',
 	STOP: '4',
 	LIMIT: '4',
 	STOP_LOSS: '5',

--- a/sdk/constants/futures.ts
+++ b/sdk/constants/futures.ts
@@ -20,8 +20,8 @@ export const DEFAULT_NUMBER_OF_TRADES = 32;
 
 export const DEFAULT_PRICE_IMPACT_DELTA_PERCENT = {
 	MARKET: '4',
-	STOP: '2',
-	LIMIT: '2',
+	STOP: '4',
+	LIMIT: '4',
 	STOP_LOSS: '5',
 	TAKE_PROFIT: '5',
 };

--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -1256,8 +1256,8 @@ export const modifyIsolatedPosition = createAsyncThunk<void, void, ThunkConfig>(
 	async (_, { getState, dispatch, extra: { sdk } }) => {
 		const account = selectFuturesAccount(getState());
 		const marketInfo = selectMarketInfo(getState());
-		const tradePreview = selectTradePreview(getState());
-		const desiredFillPrice = tradePreview?.desiredFillPrice ?? wei(0);
+		const editPreview = selectEditPositionPreview(getState());
+		const desiredFillPrice = editPreview?.desiredFillPrice ?? wei(0);
 		const { nativeSizeDelta } = selectTradeSizeInputs(getState());
 		try {
 			if (!marketInfo) throw new Error('Market info not found');
@@ -1341,8 +1341,8 @@ export const closeIsolatedMarginPosition = createAsyncThunk<void, void, ThunkCon
 	'futures/closeIsolatedMarginPosition',
 	async (_, { getState, dispatch, extra: { sdk } }) => {
 		const marketInfo = selectMarketInfo(getState());
-		const tradePreview = selectTradePreview(getState());
-		const desiredFillPrice = tradePreview?.desiredFillPrice ?? wei(0);
+		const closePreview = selectClosePositionPreview(getState());
+		const desiredFillPrice = closePreview?.desiredFillPrice ?? wei(0);
 		if (!marketInfo) throw new Error('Market info not found');
 		try {
 			dispatch(

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -906,9 +906,8 @@ export const selectTradePreview = createSelector(
 					? unserialized.notionalValue.div(unserialized.margin).abs()
 					: wei(0),
 			};
-		} else {
-			return null;
 		}
+		return null;
 	}
 );
 
@@ -933,9 +932,8 @@ export const selectEditPositionPreview = createSelector(
 					? unserialized.notionalValue.div(unserialized.margin).abs()
 					: wei(0),
 			};
-		} else {
-			return null;
 		}
+		return null;
 	}
 );
 
@@ -963,9 +961,8 @@ export const selectClosePositionPreview = createSelector(
 					? unserialized.notionalValue.div(unserialized.margin).abs()
 					: wei(0),
 			};
-		} else {
-			return null;
 		}
+		return null;
 	}
 );
 

--- a/state/futures/selectors.ts
+++ b/state/futures/selectors.ts
@@ -966,21 +966,6 @@ export const selectClosePositionPreview = createSelector(
 	}
 );
 
-export const selectDesiredTradeFillPrice = createSelector(
-	selectTradePreview,
-	(tradePreview) => tradePreview?.desiredFillPrice ?? wei(0)
-);
-
-export const selectEditPosDesiredFillPrice = createSelector(
-	selectEditPositionPreview,
-	(editPreview) => editPreview?.desiredFillPrice ?? wei(0)
-);
-
-export const selectClosePosDesiredFillPrice = createSelector(
-	selectClosePositionPreview,
-	(closePreview) => closePreview?.desiredFillPrice ?? wei(0)
-);
-
 export const selectIsolatedMarginLeverage = createSelector(
 	selectPosition,
 	selectIsolatedMarginTradeInputs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Update the desired fill price selectors to use `preview.price` instead of `marketPrice` for trade, edit, close.
2. Increase the limit / stop buffers to 4 from 2

## Related issue
A better version of #2435

## Motivation and Context
After implementing #2435, the users will only be warned about price impact if above 4%, so most could go unnoticed on larger trades. This should be a better fix without too many changes. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
