### PR TITLE
Remove the bottom border of the navigation

### DIFF
--- a/pages/market.tsx
+++ b/pages/market.tsx
@@ -178,6 +178,7 @@ Market.getLayout = (page) => <AppLayout>{page}</AppLayout>;
 export default Market;
 
 const StyledFullHeightContainer = styled.div`
+	border-top: ${(props) => props.theme.colors.selectedTheme.border};
 	display: grid;
 	grid-gap: 0;
 	flex: 1;
@@ -196,6 +197,7 @@ const LoaderContainer = styled.div`
 `;
 
 const TabletContainer = styled.div`
+	border-top: ${(props) => props.theme.colors.selectedTheme.border};
 	display: grid;
 	grid-template-columns: ${TRADE_PANEL_WIDTH_MD}px 1fr;
 	height: 100%;

--- a/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -27,7 +27,6 @@ const Container = styled.header`
 	display: flex;
 	justify-content: space-between;
 	padding: 15px;
-	border-bottom: ${(props) => props.theme.colors.selectedTheme.border};
 `;
 
 const LogoNav = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the bottom border of the navigation
![image](https://github.com/Kwenta/kwenta/assets/4819006/56f7ec85-c0d2-4d1c-b2bd-eac9733c7877)

## Related issue
reverted the change in #2413 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Open the page and didn't see the bottom border of the navigation.

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/a030e3d5-c5b7-4c17-b6e8-d99d17d7863a)
