### PR TITLE
Increase the default price impact to 4%

### DIFF
--- a/sdk/constants/futures.ts
+++ b/sdk/constants/futures.ts
@@ -19,7 +19,7 @@ export const KWENTA_TRACKING_CODE = formatBytes32String('KWENTA');
 export const DEFAULT_NUMBER_OF_TRADES = 32;
 
 export const DEFAULT_PRICE_IMPACT_DELTA_PERCENT = {
-	MARKET: '1',
+	MARKET: '4',
 	STOP: '4',
 	LIMIT: '4',
 	STOP_LOSS: '5',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The keepers are complaining a lot of `maxImpact` reverts. So we have to increase the default price impact to 4% as a short-term solution.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
