### PR TITLE
Fix: slider steps per max value & code clean

### DIFF
--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -45,7 +45,7 @@ export const getStep = (maxValue: number) => {
 	if (maxValue < 10) return 0.01;
 	if (maxValue < 100) return 1;
 	if (maxValue < 10000) return 10;
-	return Math.pow(10, Math.floor(Math.log10(maxValue)) - 1);
+	return Math.pow(10, Math.floor(Math.log10(maxValue)) - 3);
 };
 
 const styledMarkLabel = css`

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -45,8 +45,7 @@ export const getStep = (maxValue: number) => {
 	if (maxValue < 10) return 0.01;
 	if (maxValue < 100) return 1;
 	if (maxValue < 10000) return 10;
-	if (maxValue < 100000) return 1000;
-	return 10000;
+	return Math.pow(10, Math.floor(Math.log10(maxValue)) - 2);
 };
 
 const styledMarkLabel = css`

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -45,7 +45,7 @@ export const getStep = (maxValue: number) => {
 	if (maxValue < 10) return 0.01;
 	if (maxValue < 100) return 1;
 	if (maxValue < 10000) return 10;
-	return Math.pow(10, Math.floor(Math.log10(maxValue)) - 2);
+	return Math.pow(10, Math.floor(Math.log10(maxValue)) - 1);
 };
 
 const styledMarkLabel = css`

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -45,7 +45,8 @@ export const getStep = (maxValue: number) => {
 	if (maxValue < 10) return 0.01;
 	if (maxValue < 100) return 1;
 	if (maxValue < 10000) return 10;
-	return 100;
+	if (maxValue < 100000) return 1000;
+	return 10000;
 };
 
 const styledMarkLabel = css`

--- a/sdk/constants/futures.ts
+++ b/sdk/constants/futures.ts
@@ -19,7 +19,7 @@ export const KWENTA_TRACKING_CODE = formatBytes32String('KWENTA');
 export const DEFAULT_NUMBER_OF_TRADES = 32;
 
 export const DEFAULT_PRICE_IMPACT_DELTA_PERCENT = {
-	MARKET: '4',
+	MARKET: '1',
 	STOP: '4',
 	LIMIT: '4',
 	STOP_LOSS: '5',

--- a/sections/futures/EditPositionModal/EditPositionSizeModal.tsx
+++ b/sections/futures/EditPositionModal/EditPositionSizeModal.tsx
@@ -76,15 +76,6 @@ export default function EditPositionSizeModal() {
 		return preview.size.mul(marketPrice).div(position.remainingMargin).abs();
 	}, [preview, position, marketPrice]);
 
-	// preview.size: [1447139.934800000000000000]
-	// marketPrice: [0.526526310000000000]
-	// position.remainingMargin: [111331.155585285113635000]
-	// resultingLeverage 6.84
-
-	// preview.size: [317139.934800000000000000]
-	// marketPrice: [0.526720000000000000]
-	// position.remainingMargin: [111331.171586255460927209]
-	// resultingLeverage 1.50
 	const maxNativeIncreaseValue = useMemo(() => {
 		if (!marketPrice || marketPrice.eq(0)) return ZERO_WEI;
 		const totalMax = position?.remainingMargin.mul(maxLeverage) ?? ZERO_WEI;

--- a/sections/futures/EditPositionModal/EditPositionSizeModal.tsx
+++ b/sections/futures/EditPositionModal/EditPositionSizeModal.tsx
@@ -76,6 +76,15 @@ export default function EditPositionSizeModal() {
 		return preview.size.mul(marketPrice).div(position.remainingMargin).abs();
 	}, [preview, position, marketPrice]);
 
+	// preview.size: [1447139.934800000000000000]
+	// marketPrice: [0.526526310000000000]
+	// position.remainingMargin: [111331.155585285113635000]
+	// resultingLeverage 6.84
+
+	// preview.size: [317139.934800000000000000]
+	// marketPrice: [0.526720000000000000]
+	// position.remainingMargin: [111331.171586255460927209]
+	// resultingLeverage 1.50
 	const maxNativeIncreaseValue = useMemo(() => {
 		if (!marketPrice || marketPrice.eq(0)) return ZERO_WEI;
 		const totalMax = position?.remainingMargin.mul(maxLeverage) ?? ZERO_WEI;

--- a/sections/futures/MarketInfo/MarketHead.tsx
+++ b/sections/futures/MarketInfo/MarketHead.tsx
@@ -2,12 +2,10 @@ import Head from 'next/head';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DEFAULT_CRYPTO_DECIMALS } from 'constants/defaults';
 import { getDisplayAsset } from 'sdk/utils/futures';
 import { formatCurrency } from 'sdk/utils/number';
 import { selectMarketAsset, selectSkewAdjustedPrice } from 'state/futures/selectors';
 import { useAppSelector } from 'state/hooks';
-import { isDecimalFour } from 'utils/futures';
 
 const MarketHead: FC = () => {
 	const { t } = useTranslation();

--- a/sections/futures/Trade/ShowPercentage.tsx
+++ b/sections/futures/Trade/ShowPercentage.tsx
@@ -21,10 +21,6 @@ const ShowPercentage: React.FC<ShowPercentageProps> = ({
 	leverageWei,
 }) => {
 	const calculatePercentage = useMemo(() => {
-		// eslint-disable-next-line no-console
-		console.log(
-			`targetPrice: ${targetPrice}, currentPrice: ${currentPrice}, leverageSide: ${leverageSide}`
-		);
 		if (!targetPrice || !currentPrice || !leverageSide) return '';
 		const priceWei = wei(targetPrice);
 		const diff =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Set the `step` dynamically, which is close to 0.1% of the max value, e.g. when the max value is 95000 (less than 100000), the step is supposed to be set as 1000 (#2456)
2. Lower the price impact of the market order to 1% again (#2451)
3. Fix the lint warning in `MarketHead` (#2445) 
4. Remove the unnecessary `console.log` in `ShowPercent` (#2433)

## Related issue
#2456 (laggy issue)
#2445
#2433
#2451 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
