### PR TITLE
Fix: Position table column width and data source

### DIFF
--- a/sections/futures/UserInfo/PositionsTable.tsx
+++ b/sections/futures/UserInfo/PositionsTable.tsx
@@ -74,6 +74,7 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 				const markPrice = markPrices[market?.marketKey!] ?? ZERO_WEI;
 				return {
 					market: market!,
+					remainingMargin: position.remainingMargin,
 					position: position.position!,
 					avgEntryPrice: thisPositionHistory?.avgEntryPrice,
 					stopLoss: position.stopLoss?.targetPrice,
@@ -205,7 +206,7 @@ const PositionsTable: FC<FuturesPositionTableProps> = () => {
 						<PositionCell>
 							<FlexDivCol>
 								<FlexDivRow justifyContent="flex-start" columnGap="5px">
-									<NumericValue value={row.position.initialMargin} />
+									<NumericValue value={row.remainingMargin} />
 									{accountType === 'cross_margin' && (
 										<EditPositionButton
 											modalType={'futures_edit_position_margin'}
@@ -303,7 +304,7 @@ const TableContainer = styled.div`
 
 const PositionRowDesktop = styled.div`
 	display: grid;
-	grid-template-columns: 75px 60px 200px 1fr 1fr 1.3fr 1fr 1fr 1fr 64px;
+	grid-template-columns: 75px 60px 1fr 1fr 1fr 1.3fr 1fr 1fr 1fr 64px;
 	grid-gap: 10px;
 	height: 100%;
 	height: 54px;

--- a/sections/futures/UserInfo/PositionsTable.tsx
+++ b/sections/futures/UserInfo/PositionsTable.tsx
@@ -303,7 +303,7 @@ const TableContainer = styled.div`
 
 const PositionRowDesktop = styled.div`
 	display: grid;
-	grid-template-columns: 75px 60px 110px 1fr 1fr 1.3fr 1fr 1fr 1fr 64px;
+	grid-template-columns: 75px 60px 200px 1fr 1fr 1.3fr 1fr 1fr 1fr 64px;
 	grid-gap: 10px;
 	height: 100%;
 	height: 54px;

--- a/sections/futures/UserInfo/PositionsTable.tsx
+++ b/sections/futures/UserInfo/PositionsTable.tsx
@@ -304,7 +304,7 @@ const TableContainer = styled.div`
 
 const PositionRowDesktop = styled.div`
 	display: grid;
-	grid-template-columns: 75px 60px 1fr 1fr 1fr 1.3fr 1fr 1fr 1fr 64px;
+	grid-template-columns: 75px 60px minmax(130px, 1fr) 1fr 1fr 1.3fr 1fr 1fr 1fr 64px;
 	grid-gap: 10px;
 	height: 100%;
 	height: 54px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Increase the column width in the position table to handle the large position size
2. Update data source for `market margin`: switch from `initial margin` to `remaining margin`

## Related issue
closes #2460 
closes #2465

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/5e26ae23-86d2-48e6-9236-d0d22c8955c8)
![image](https://github.com/Kwenta/kwenta/assets/4819006/641df008-9b31-45cc-888c-1496ce084cc1)
![image](https://github.com/Kwenta/kwenta/assets/4819006/853dcbbc-f46c-40e7-822f-228dc441b19e)

