### PR TITLE
Revert exact liquidation price changes

### DIFF
--- a/sdk/contracts/PerpsV2MarketInternalV2.ts
+++ b/sdk/contracts/PerpsV2MarketInternalV2.ts
@@ -159,8 +159,8 @@ class FuturesMarketInternal {
 		);
 
 		const liqPrice = await this._approxLiquidationPrice(newPos, newPos.lastPrice);
-		const exactLiqPrice = await this._exactLiquidationPrice(newPos, liqPrice);
-		return { ...newPos, liqPrice: exactLiqPrice, fee, price: newPos.lastPrice, status: status };
+
+		return { ...newPos, liqPrice: liqPrice, fee, price: newPos.lastPrice, status: status };
 	};
 
 	_postTradeDetails = async (
@@ -265,18 +265,6 @@ class FuturesMarketInternal {
 		const liqPremiumMultiplier = await this._getSetting('liquidationPremiumMultiplier');
 		const skewedSize = divideDecimal(positionSize.abs(), skewScale);
 		const value = multiplyDecimal(skewedSize, notional);
-		return multiplyDecimal(value, liqPremiumMultiplier);
-	};
-
-	_exactLiquidationPremium = async (positionSize: BigNumber, currentPrice: BigNumber) => {
-		if (positionSize.eq(0)) {
-			return 0;
-		}
-
-		const skewScale = await this._getSetting('skewScale');
-		const liqPremiumMultiplier = await this._getSetting('liquidationPremiumMultiplier');
-		const skewedSize = divideDecimal(positionSize.pow(2).div(UNIT_BIG_NUM).abs(), skewScale);
-		const value = multiplyDecimal(skewedSize, currentPrice);
 		return multiplyDecimal(value, liqPremiumMultiplier);
 	};
 
@@ -417,50 +405,6 @@ class FuturesMarketInternal {
 			.add(divideDecimal(liqMargin.sub(position.margin.sub(liqPremium)), position.size))
 			.sub(fundingPerUnit);
 		return result.lt(0) ? BigNumber.from(0) : result;
-	};
-
-	_exactLiquidationPrice = async (position: Position, approxLiquidationPrice: BigNumber) => {
-		if (position.size.isZero()) {
-			return BigNumber.from('0');
-		}
-
-		const prices = Array.from(Array(1001).keys()).map((x) =>
-			wei(approxLiquidationPrice)
-				.mul(1 + (x - 500) / 1000)
-				.toBN()
-		);
-
-		// get settings once to avoid synchronous calls
-		await this._batchGetSettings();
-
-		// start with initial margin
-		const margins = await Promise.all(
-			prices.map((price) => this._marginPlusProfitFunding(position, price))
-		);
-
-		const liqMargins = await Promise.all(
-			prices.map((price) => this._exactLiquidationMargin(position.size, price))
-		);
-		const liqPremiums = await Promise.all(
-			prices.map((price) => this._exactLiquidationPremium(position.size, price))
-		);
-
-		const validPrices = prices.filter((price, i) => {
-			const margin = margins[i];
-			const liqMargin = liqMargins[i];
-			const liqPremium = liqPremiums[i];
-			return margin.sub(liqMargin).sub(liqPremium).lt(0);
-		});
-
-		let exactLiqPrice;
-		if (validPrices.length > 0) {
-			exactLiqPrice = position.size.gt(0)
-				? validPrices.reduce((max, current) => (max.gt(current) ? max : current))
-				: validPrices.reduce((min, current) => (min.lt(current) ? min : current));
-		} else {
-			exactLiqPrice = BigNumber.from(0);
-		}
-		return exactLiqPrice;
 	};
 
 	_exactLiquidationMargin = async (positionSize: BigNumber, price: BigNumber) => {

--- a/sdk/services/futures.ts
+++ b/sdk/services/futures.ts
@@ -256,18 +256,10 @@ export default class FuturesService {
 		const positions = await Promise.all(
 			positionDetails.map(async (position, ind) => {
 				const canLiquidate = canLiquidateState[ind];
-				const marketAddress = futuresMarkets[ind].address;
 				const marketKey = futuresMarkets[ind].marketKey;
 				const asset = futuresMarkets[ind].asset;
-				const liquidationPrice = position.position.size.abs().gt(0)
-					? await this.sdk.futures.getExactLiquidationPrice(marketKey, marketAddress, position)
-					: position.liquidationPrice;
-				return mapFuturesPosition(
-					{ ...position, liquidationPrice },
-					canLiquidate,
-					asset,
-					marketKey
-				);
+
+				return mapFuturesPosition(position, canLiquidate, asset, marketKey);
 			})
 		);
 
@@ -542,27 +534,6 @@ export default class FuturesService {
 			inputs.sizeDelta,
 			inputs.leverageSide
 		);
-	}
-
-	public async getExactLiquidationPrice(
-		marketKey: FuturesMarketKey,
-		marketAddress: string,
-		positionDetails: PositionDetail
-	) {
-		const marketInternal = this.getInternalFuturesMarket(marketAddress, marketKey);
-		const internalPosition = {
-			id: '0',
-			size: positionDetails.position.size,
-			margin: positionDetails.position.margin,
-			lastFundingIndex: positionDetails.position.fundingIndex,
-			lastPrice: positionDetails.position.lastPrice,
-		};
-		const approxLiquidationPrice = positionDetails.liquidationPrice;
-		const exactLiqPrice = await marketInternal._exactLiquidationPrice(
-			internalPosition,
-			approxLiquidationPrice
-		);
-		return exactLiqPrice;
 	}
 
 	public async getCrossMarginTradePreview(


### PR DESCRIPTION
## Description

Remove the exact liquidation calculation and instead use the original values from the contract.

