### PR TITLE
Fix: Position table on mobile

### DIFF
--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -65,6 +65,7 @@ const PositionsTab = () => {
 				const markPrice = markPrices[market?.marketKey!] ?? ZERO_WEI;
 				return {
 					market: market!,
+					remainingMargin: position.remainingMargin,
 					position: position.position!,
 					avgEntryPrice: thisPositionHistory?.avgEntryPrice,
 					stopLoss: position.stopLoss?.targetPrice,
@@ -195,7 +196,7 @@ const PositionsTab = () => {
 							<PositionCell>
 								<Body color="secondary">Market Margin</Body>
 								<FlexDivRow justifyContent="start">
-									<NumericValue value={row.position.initialMargin} />
+									<NumericValue value={row.remainingMargin} />
 									{accountType === 'cross_margin' && (
 										<>
 											<Spacer width={5} />

--- a/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
+++ b/sections/futures/MobileTrade/UserTabs/PositionsTab.tsx
@@ -216,7 +216,11 @@ const PositionsTab = () => {
 							</PositionCell>
 							<PositionCell>
 								<Body color="secondary">Liquidation</Body>
-								<Currency.Price price={row.position.liquidationPrice} colorType="preview" />
+								<Currency.Price
+									price={row.position.liquidationPrice}
+									formatOptions={{ suggestDecimals: true }}
+									colorType="preview"
+								/>
 							</PositionCell>
 							<PositionCell>
 								<Body color="secondary">Unrealized PnL</Body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Update data source for `market margin`: switch from `initial margin` to `remaining margin`
2. Use `suggestedDecimals` for the average entry price

## Related issue
#2465

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/882877b0-b3dd-49b2-93fc-a827fb8d25dd)
