### PR TITLE
[Pending] Disable 1inch exchange

### DIFF
--- a/sections/shared/modals/SelectCurrencyModal.tsx
+++ b/sections/shared/modals/SelectCurrencyModal.tsx
@@ -51,7 +51,7 @@ export const SelectCurrencyModal: FC<SelectCurrencyModalProps> = ({
 	const [page, setPage] = useState(1);
 
 	// Only available on Optimism mainnet
-	const oneInchEnabled = network === 10;
+	const oneInchEnabled = false;
 
 	const allSynths = useMemo(() => getSynthsListForNetwork(network as NetworkId), [network]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
According to reliable sources, the 1inch public API may be discontinued in a few days, so we need to stop using the 1inch public API for swaps. 
![image](https://github.com/Kwenta/kwenta/assets/4819006/8c4317eb-b7f1-4328-8c3a-ae955c5c7a03)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/035555e1-ceb6-4ff0-9ec0-ea6a8950178e)
