### PR TITLE
chore: enable chat

### DIFF
--- a/sections/shared/Layout/AppLayout/Footer.tsx
+++ b/sections/shared/Layout/AppLayout/Footer.tsx
@@ -1,6 +1,7 @@
 import router from 'next/router';
 import styled from 'styled-components';
 
+import ChatRoom from 'components/ChatRoom/ChatRoom';
 import { Body } from 'components/Text';
 import { EXTERNAL_LINKS } from 'constants/links';
 import ROUTES from 'constants/routes';
@@ -15,6 +16,7 @@ const Footer = () => {
 			<OperationStatus />
 			<GitHashID />
 			<RightContainer>
+				<ChatRoom />
 				<FooterLinkInternal onClick={() => router.push(ROUTES.Stats.Home)}>
 					<Body color="secondary">Stats</Body>
 				</FooterLinkInternal>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enable WidgetBot chat

## Related issue
WidgetBot chat was disabled due to WidgetBots emerald instance not setting the `cross-origin `header, which resulted in Chrome blocking the third party integration. This should be fixed now.

## How Has This Been Tested?
The issue was due to strict eth.limo header settings, so the only way to find out is pushing this to `dev.kwenta.eth.limo` and see if it works.