### PR TITLE
🎨 Add colors to uPnL $ value in dashboard

### DIFF
--- a/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
+++ b/sections/dashboard/FuturesPositionsTable/FuturesPositionsTable.tsx
@@ -209,7 +209,7 @@ const FuturesPositionsTable: FC<FuturesPositionTableProps> = ({
 										<PnlContainer>
 											<ChangePercent value={cellProps.row.original.position.pnlPct} />
 											<div>
-												<Currency.Price price={cellProps.row.original.position.pnl} />
+												<Currency.Price price={cellProps.row.original.position.pnl} colored />
 											</div>
 										</PnlContainer>
 									);


### PR DESCRIPTION
Add colors prop to uPnL $ value in dashboard

## Description
The uPnL $ values on the dashboard now be red/green instead of white

## Related issue
Resolve #2507 

## How Has This Been Tested?
Visual testing

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/20267733/185860d9-f2f7-4592-aa52-27d17e1aeb66)
![image](https://github.com/Kwenta/kwenta/assets/20267733/27875d08-363a-4a1c-b817-7e1143845acc)
