### PR TITLE
Fixes a bug where limit / stop was being set as market when closing

### DIFF
--- a/state/futures/actions.ts
+++ b/state/futures/actions.ts
@@ -1607,19 +1607,20 @@ export const submitSmartMarginReducePositionOrder = createAsyncThunk<void, boole
 				orderInputs.keeperEthDeposit = keeperEthDeposit;
 			}
 
-			const tx = isClosing
-				? await sdk.futures.closeCrossMarginPosition(
-						{ address: market.market, key: market.marketKey },
-						account,
-						preview.desiredFillPrice
-				  )
-				: await sdk.futures.submitCrossMarginOrder(
-						{ address: market.market, key: market.marketKey },
-						wallet,
-						account,
-						orderInputs,
-						{ cancelPendingReduceOrders: isClosing }
-				  );
+			const tx =
+				isClosing && orderType === 'market'
+					? await sdk.futures.closeCrossMarginPosition(
+							{ address: market.market, key: market.marketKey },
+							account,
+							preview.desiredFillPrice
+					  )
+					: await sdk.futures.submitCrossMarginOrder(
+							{ address: market.market, key: market.marketKey },
+							wallet,
+							account,
+							orderInputs,
+							{ cancelPendingReduceOrders: isClosing }
+					  );
 
 			await monitorAndAwaitTransaction(dispatch, tx);
 			dispatch(setOpenModal(null));


### PR DESCRIPTION
## Description

When the direct close function was implemented to support close only during bedrock upgrade it introduced a bug where limit / stop orders on closing positions were being executed as market.

This adds a fix to only call direct close function when the order type is market.

In a follow up PR we should add support for limit / stop in the sdk close function.
