### PR TITLE
chore: pyth-based conditional orders

### DIFF
--- a/packages/app/src/sections/futures/UserInfo/ConditionalOrdersWarning.tsx
+++ b/packages/app/src/sections/futures/UserInfo/ConditionalOrdersWarning.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import styled from 'styled-components'
 
 type Props = {
@@ -7,8 +8,14 @@ type Props = {
 export default function ConditionalOrdersWarning({ mobile }: Props) {
 	return (
 		<OrdersWarning mobile={mobile}>
-			Conditional orders are executed based on the onchain Chainlink price which can differ from the
-			offchain prices displayed above.
+			Conditional orders are executed based on the onchain Pyth or Chainlink price. See the{' '}
+			<Link
+				href="https://mirror.xyz/kwenta.eth/kzfQhQL-53VhVttQcIvjWAZxgLO-DgIRWqL6ln1xYJ0"
+				target="_blank"
+			>
+				blog post
+			</Link>{' '}
+			for more details.
 		</OrdersWarning>
 	)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the copy for conditional orders to inform users that either the enchain Pyth price or the Chainlink price is used for execution. Also includes a link to the relevant blog post with further information.

## Screenshots (if appropriate):
![Screenshot_2023-06-22_at_17 18 06](https://github.com/Kwenta/kwenta/assets/548702/ba6289c6-21b0-4f8d-aa96-7e7eba548087)
