### PR TITLE
Fix the application error on input for increasing the short position

### DIFF
--- a/packages/app/src/state/futures/selectors.ts
+++ b/packages/app/src/state/futures/selectors.ts
@@ -920,6 +920,7 @@ export const selectEditPositionPreview = createSelector(
 	selectEditPositionInputs,
 	(state: RootState) => state.futures,
 	(type, { nativeSizeDelta }, futures) => {
+		if (isNaN(Number(nativeSizeDelta))) return null
 		const preview = futures[accountType(type)].previews.edit
 		const unserialized = preview ? unserializePotentialTrade(preview) : null
 		if (unserialized) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On the Edit Position Szie input field, the application crashes at the backslash/deletion of input.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the short position
2. Edit the size
3. Type any numbers
4. Delete all the inputs and no crash

## Screenshots (if appropriate):
