### PR TITLE
fix: check for empty data in TVChart

### DIFF
--- a/packages/app/src/components/TVChart/TVChart.tsx
+++ b/packages/app/src/components/TVChart/TVChart.tsx
@@ -8,7 +8,6 @@ import {
 	TimeFrameItem,
 	widget,
 } from 'charting_library/charting_library'
-import { isEmpty } from 'lodash/fp'
 import { useRouter } from 'next/router'
 import { useRef, useContext, useEffect, useCallback, useMemo } from 'react'
 import { ThemeContext } from 'styled-components'
@@ -199,7 +198,7 @@ export function TVChart({
 				{ text: '30D', resolution: '1H', description: '30 Days' },
 				{ text: '3M', resolution: '1H', description: '3 Months' },
 			] as TimeFrameItem[],
-			saved_data: isEmpty(chartData) ? undefined : chartData,
+			saved_data: chartData,
 		}
 
 		const clearExistingWidget = () => {

--- a/packages/app/src/components/TVChart/TVChart.tsx
+++ b/packages/app/src/components/TVChart/TVChart.tsx
@@ -8,6 +8,7 @@ import {
 	TimeFrameItem,
 	widget,
 } from 'charting_library/charting_library'
+import { isEmpty } from 'lodash/fp'
 import { useRouter } from 'next/router'
 import { useRef, useContext, useEffect, useCallback, useMemo } from 'react'
 import { ThemeContext } from 'styled-components'
@@ -198,7 +199,7 @@ export function TVChart({
 				{ text: '30D', resolution: '1H', description: '30 Days' },
 				{ text: '3M', resolution: '1H', description: '3 Months' },
 			] as TimeFrameItem[],
-			saved_data: chartData,
+			saved_data: isEmpty(chartData) ? undefined : chartData,
 		}
 
 		const clearExistingWidget = () => {

--- a/packages/app/src/components/TVChart/utils.ts
+++ b/packages/app/src/components/TVChart/utils.ts
@@ -35,5 +35,5 @@ export const saveChartState = (state: object) => {
 
 export const loadChartState = () => {
 	const rawChartData = window.localStorage.getItem(TV_CHART_STATE)
-	return rawChartData ? JSON.parse(rawChartData) : {}
+	return rawChartData ? JSON.parse(rawChartData) : undefined
 }


### PR DESCRIPTION
## Description
Fix issue, when chart loading with empty object (crash chart)

## Related issue

## Motivation and Context

## How Has This Been Tested?
1. Open application in incognito mode (with disabled localStorage)
2. Check TV Chart. It's works.