### PR TITLE
Fix: Remove the Trust Wallet from the list of supported wallets

### DIFF
--- a/packages/app/src/containers/Connector/config.ts
+++ b/packages/app/src/containers/Connector/config.ts
@@ -6,7 +6,6 @@ import {
 	ledgerWallet,
 	metaMaskWallet,
 	rainbowWallet,
-	trustWallet,
 	walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets'
 import { configureChains, createClient } from 'wagmi'
@@ -85,7 +84,6 @@ const connectors = connectorsForWallets([
 		wallets: [
 			ledgerWallet({ projectId, chains }),
 			braveWallet({ chains, shimDisconnect: true }),
-			trustWallet({ projectId, chains }),
 			Tally({ chains, shimDisconnect: true }),
 			Frame({ chains, shimDisconnect: true }),
 			injectedWallet({ chains, shimDisconnect: true }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Trust Wallet is not functioning properly after the WalletConnect V2 upgrade. Let's remove this wallet from the list of supported wallets until the Trust Wallet team resolves the issue.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
