### PR TITLE
fix: output

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -11,6 +11,7 @@ const transpile = require('next-transpile-modules')
 const withTM = [transpile(['echarts', 'zrender'])]
 
 const baseConfig = {
+	output: 'export',
 	env: {
 		GIT_HASH_ID: gitRevision,
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enable static export according to next warning when deploying:

```
2:42:22 PM 07/10/2023: > next export
2:42:22 PM 07/10/2023: - warn "next export" is deprecated in favor of "output: export" in next.config.js https://nextjs.org/docs/advanced-features/static-html-export
```
