### PR TITLE
Fixed the spacing issue of Staking V2 boxes

### DIFF
--- a/packages/app/src/components/StakeCard.tsx
+++ b/packages/app/src/components/StakeCard.tsx
@@ -1,4 +1,4 @@
-import { toWei, truncateNumbers } from '@kwenta/sdk/utils'
+import { formatNumber, toWei, truncateNumbers } from '@kwenta/sdk/utils'
 import Wei from '@synthetixio/wei'
 import { FC, memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -8,7 +8,7 @@ import Button from 'components/Button'
 import NumericInput from 'components/Input/NumericInput'
 import { FlexDivCol, FlexDivRowCentered } from 'components/layout/flex'
 import SegmentedControl from 'components/SegmentedControl'
-import { DEFAULT_CRYPTO_DECIMALS, DEFAULT_TOKEN_DECIMALS } from 'constants/defaults'
+import { DEFAULT_TOKEN_DECIMALS } from 'constants/defaults'
 import { StakingCard } from 'sections/dashboard/Stake/card'
 import media from 'styles/media'
 
@@ -76,7 +76,7 @@ const StakeCard: FC<StakeCardProps> = memo(
 		}, [activeTab, isStakeEnabled, isUnstakeEnabled])
 
 		const balanceString = useMemo(() => {
-			return truncateNumbers(balance, DEFAULT_CRYPTO_DECIMALS)
+			return formatNumber(balance, { suggestDecimals: true })
 		}, [balance])
 
 		const isLoading = useMemo(() => {

--- a/packages/app/src/components/Table/StakingPagination.tsx
+++ b/packages/app/src/components/Table/StakingPagination.tsx
@@ -40,7 +40,7 @@ const StakingPagination: FC<PaginationProps> = React.memo(
 
 		return (
 			<PaginationContainer>
-				<PageInfoContainer compact={compact}>
+				<PageInfoContainer>
 					<FlexDivRowCentered columnGap="15px">
 						<FlexDivRowCentered columnGap="5px">
 							<ArrowButton onClick={firstPage} disabled={!canPreviousPage}>
@@ -87,9 +87,8 @@ const PageInfo = styled.span`
 	font-size: 13px;
 `
 
-const PageInfoContainer = styled(GridDivCenteredCol)<{ compact: boolean }>`
+const PageInfoContainer = styled(GridDivCenteredCol)`
 	grid-template-columns: auto 1fr auto;
-	padding: ${(props) => (props.compact ? '10px' : '15px')} 12px;
 	border-bottom-left-radius: 4px;
 	border-bottom-right-radius: 4px;
 `

--- a/packages/app/src/pages/dashboard/staking.tsx
+++ b/packages/app/src/pages/dashboard/staking.tsx
@@ -289,7 +289,7 @@ const StakingPage: StakingComponent = () => {
 }
 
 const TableContainer = styled.div`
-	margin-top: 30px;
+	margin-top: 15px;
 	${media.lessThan('lg')`
 		margin-top: 0px;
 		padding: 15px;

--- a/packages/app/src/pages/dashboard/staking.tsx
+++ b/packages/app/src/pages/dashboard/staking.tsx
@@ -1,4 +1,4 @@
-import { formatTruncatedDuration, truncateNumbers } from '@kwenta/sdk/utils'
+import { formatNumber, formatTruncatedDuration } from '@kwenta/sdk/utils'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
@@ -95,12 +95,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'balance-liquid',
 						title: t('dashboard.stake.portfolio.balance.liquid'),
-						value: truncateNumbers(kwentaBalance, 2),
+						value: formatNumber(kwentaBalance, { suggestDecimals: true }),
 					},
 					{
 						key: 'balance-staked',
 						title: t('dashboard.stake.portfolio.balance.staked'),
-						value: truncateNumbers(stakedKwentaBalanceV2, 2),
+						value: formatNumber(stakedKwentaBalanceV2, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -111,12 +111,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'escrow-staked',
 						title: t('dashboard.stake.portfolio.escrow.staked'),
-						value: truncateNumbers(stakedEscrowedKwentaBalanceV2, 2),
+						value: formatNumber(stakedEscrowedKwentaBalanceV2, { suggestDecimals: true }),
 					},
 					{
 						key: 'escrow-vestable',
 						title: t('dashboard.stake.portfolio.escrow.vestable'),
-						value: truncateNumbers(totalVestableV2, 2),
+						value: formatNumber(totalVestableV2, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -127,12 +127,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'rewards-claimable',
 						title: t('dashboard.stake.portfolio.rewards.claimable'),
-						value: truncateNumbers(claimableBalanceV2, 2),
+						value: formatNumber(claimableBalanceV2, { suggestDecimals: true }),
 					},
 					{
 						key: 'rewards-trading',
 						title: t('dashboard.stake.portfolio.rewards.trading'),
-						value: truncateNumbers(kwentaRewards, 2),
+						value: formatNumber(kwentaRewards, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -183,12 +183,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'balance-liquid',
 						title: t('dashboard.stake.portfolio.balance.liquid'),
-						value: truncateNumbers(kwentaBalance, 2),
+						value: formatNumber(kwentaBalance, { suggestDecimals: true }),
 					},
 					{
 						key: 'balance-staked',
 						title: t('dashboard.stake.portfolio.balance.staked-v1'),
-						value: truncateNumbers(stakedKwentaBalance, 2),
+						value: formatNumber(stakedKwentaBalance, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -198,12 +198,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'rewards-claimable',
 						title: t('dashboard.stake.portfolio.rewards.staking-v1'),
-						value: truncateNumbers(claimableBalance, 2),
+						value: formatNumber(claimableBalance, { suggestDecimals: true }),
 					},
 					{
 						key: 'rewards-trading',
 						title: t('dashboard.stake.portfolio.rewards.trading'),
-						value: truncateNumbers(kwentaRewards, 4),
+						value: formatNumber(kwentaRewards, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -213,12 +213,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'escrow-staked',
 						title: t('dashboard.stake.portfolio.escrow.staked'),
-						value: truncateNumbers(stakedEscrowedKwentaBalanceV2, 2),
+						value: formatNumber(stakedEscrowedKwentaBalanceV2, { suggestDecimals: true }),
 					},
 					{
 						key: 'escrow-vestable',
 						title: t('dashboard.stake.portfolio.escrow.vestable'),
-						value: truncateNumbers(totalVestableV2, 2),
+						value: formatNumber(totalVestableV2, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -228,12 +228,12 @@ const StakingPage: StakingComponent = () => {
 					{
 						key: 'escrow-staked',
 						title: t('dashboard.stake.portfolio.escrow.staked'),
-						value: truncateNumbers(stakedEscrowedKwentaBalance, 2),
+						value: formatNumber(stakedEscrowedKwentaBalance, { suggestDecimals: true }),
 					},
 					{
 						key: 'escrow-vestable',
 						title: t('dashboard.stake.portfolio.escrow.vestable'),
-						value: truncateNumbers(totalVestable, 2),
+						value: formatNumber(totalVestable, { suggestDecimals: true }),
 					},
 				],
 			},

--- a/packages/app/src/sections/dashboard/Stake/EscrowTab.tsx
+++ b/packages/app/src/sections/dashboard/Stake/EscrowTab.tsx
@@ -1,4 +1,4 @@
-import { formatPercent, truncateNumbers } from '@kwenta/sdk/utils'
+import { formatNumber, formatPercent } from '@kwenta/sdk/utils'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -37,7 +37,7 @@ const EscrowTab = () => {
 					{
 						key: 'overview-staked',
 						title: t('dashboard.stake.portfolio.escrow.staked'),
-						value: truncateNumbers(stakedEscrowedKwentaBalanceV2, 2),
+						value: formatNumber(stakedEscrowedKwentaBalanceV2, { suggestDecimals: true }),
 					},
 					{
 						key: 'overview-apr',
@@ -47,7 +47,7 @@ const EscrowTab = () => {
 					{
 						key: 'overview-vestable',
 						title: t('dashboard.stake.portfolio.escrow.vestable'),
-						value: truncateNumbers(totalVestableV2, 2),
+						value: formatNumber(totalVestableV2, { suggestDecimals: true }),
 					},
 				],
 			},
@@ -57,7 +57,7 @@ const EscrowTab = () => {
 					{
 						key: 'staking-v1-staked',
 						title: t('dashboard.stake.portfolio.escrow.staked'),
-						value: truncateNumbers(stakedEscrowedKwentaBalance, 2),
+						value: formatNumber(stakedEscrowedKwentaBalance, { suggestDecimals: true }),
 					},
 					{
 						key: 'staking-v1-apr',
@@ -67,7 +67,7 @@ const EscrowTab = () => {
 					{
 						key: 'staking-v1-vestable',
 						title: t('dashboard.stake.portfolio.escrow.vestable'),
-						value: truncateNumbers(totalVestable, 2),
+						value: formatNumber(totalVestable, { suggestDecimals: true }),
 					},
 				],
 			},

--- a/packages/app/src/sections/dashboard/Stake/MigrationSteps.tsx
+++ b/packages/app/src/sections/dashboard/Stake/MigrationSteps.tsx
@@ -133,7 +133,7 @@ const MigrationSteps: FC = memo(() => {
 })
 
 const StepsContainer = styled(FlexDivRowCentered)`
-	margin: 30px 0;
+	margin: 30px 0 15px;
 	${media.lessThan('lg')`
 		flex-direction: column;
 		row-gap: 25px;

--- a/packages/app/src/sections/dashboard/Stake/MigrationSteps.tsx
+++ b/packages/app/src/sections/dashboard/Stake/MigrationSteps.tsx
@@ -1,4 +1,4 @@
-import { truncateNumbers } from '@kwenta/sdk/utils'
+import { formatNumber } from '@kwenta/sdk/utils'
 import { wei } from '@synthetixio/wei'
 import { useMemo, useCallback, FC, memo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -49,7 +49,7 @@ const MigrationSteps: FC = memo(() => {
 				key: 'step-1',
 				copy: t('dashboard.stake.tabs.migrate.step-1-copy'),
 				label: t('dashboard.stake.tabs.migrate.rewards'),
-				value: truncateNumbers(claimableBalance, 2),
+				value: formatNumber(claimableBalance, { suggestDecimals: true }),
 				buttonLabel: t('dashboard.stake.tabs.migrate.claim'),
 				onClick: handleGetReward,
 				active: claimableBalance.gt(0),
@@ -59,7 +59,7 @@ const MigrationSteps: FC = memo(() => {
 				key: 'step-2',
 				copy: t('dashboard.stake.tabs.migrate.step-2-copy'),
 				label: t('dashboard.stake.tabs.migrate.staked'),
-				value: truncateNumbers(stakedKwentaBalance, 2),
+				value: formatNumber(stakedKwentaBalance, { suggestDecimals: true }),
 				buttonLabel: t('dashboard.stake.tabs.migrate.unstake'),
 				onClick: handleUnstakeKwenta,
 				active: claimableBalance.lte(0) && stakedKwentaBalance.gt(0),
@@ -69,7 +69,7 @@ const MigrationSteps: FC = memo(() => {
 				key: 'step-3',
 				copy: t('dashboard.stake.tabs.migrate.step-3-copy'),
 				label: t('dashboard.stake.tabs.migrate.staked'),
-				value: truncateNumbers(stakedKwentaBalanceV2, 2),
+				value: formatNumber(stakedKwentaBalanceV2, { suggestDecimals: true }),
 				buttonLabel: t('dashboard.stake.tabs.migrate.visit-v2'),
 				onClick: handleDismiss,
 				active: claimableBalance.lte(0) && stakedKwentaBalance.lte(0),

--- a/packages/app/src/sections/dashboard/Stake/StakingTab.tsx
+++ b/packages/app/src/sections/dashboard/Stake/StakingTab.tsx
@@ -1,4 +1,4 @@
-import { formatPercent, truncateNumbers } from '@kwenta/sdk/utils'
+import { formatNumber, formatPercent } from '@kwenta/sdk/utils'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -51,7 +51,7 @@ const StakingTab = () => {
 					{
 						key: 'staking-staked',
 						title: t('dashboard.stake.portfolio.balance.staked'),
-						value: truncateNumbers(stakedKwentaBalance, 2),
+						value: formatNumber(stakedKwentaBalance, { suggestDecimals: true }),
 					},
 					{
 						key: 'staking-apr',
@@ -67,7 +67,7 @@ const StakingTab = () => {
 					{
 						key: 'rewards-claimable',
 						title: t('dashboard.stake.portfolio.rewards.claimable'),
-						value: truncateNumbers(claimableBalance, 2),
+						value: formatNumber(claimableBalance, { suggestDecimals: true }),
 					},
 				],
 				flex: 0.5,

--- a/packages/app/src/sections/dashboard/Stake/VestConfirmationModal.tsx
+++ b/packages/app/src/sections/dashboard/Stake/VestConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import { truncateNumbers } from '@kwenta/sdk/utils'
+import { formatNumber } from '@kwenta/sdk/utils'
 import Wei from '@synthetixio/wei'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -50,7 +50,7 @@ const VestConfirmationModal: React.FC<Props> = ({ onDismiss, totalFee, handleVes
 				<BalanceText>
 					<Trans
 						i18nKey="dashboard.stake.tabs.escrow.modal.confirm-text"
-						values={{ totalFee: truncateNumbers(totalFee, 4) }}
+						values={{ totalFee: formatNumber(totalFee, { suggestDecimals: true }) }}
 						components={[<b />]}
 					/>
 				</BalanceText>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the unnecessary padding from `StakingPagination`
![image](https://github.com/Kwenta/kwenta/assets/4819006/4f476c92-738b-4fe5-b9d5-7f11ab4d2265)


## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/54a5a3cd-02e8-4875-aaa5-ad091ba80a94)
