### PR TITLE
Align with subgraph rates decimal fixes

### DIFF
--- a/packages/sdk/src/services/prices.ts
+++ b/packages/sdk/src/services/prices.ts
@@ -172,14 +172,7 @@ export default class PricesService {
 				minTimestamp: minTimestamp,
 			}
 		)
-		const prices = (response ? Object.values(response).flat() : []) as SynthPrice[]
-
-		//TODO: remove this once the rates are fixed
-		return prices.map((price) =>
-			price.synth === MarketAssetByKey[FuturesMarketKey.sPEPEPERP]
-				? { ...price, rate: wei(price.rate.toString()).div(1e10).toString() }
-				: price
-		) as SynthPrice[]
+		return (response ? Object.values(response).flat() : []) as SynthPrice[]
 	}
 
 	public async getPythPriceUpdateData(marketKey: FuturesMarketKey) {

--- a/packages/sdk/src/utils/prices.ts
+++ b/packages/sdk/src/utils/prices.ts
@@ -1,7 +1,6 @@
 export const RATES_ENDPOINT_OP_MAINNET = `https://subgraph.satsuma-prod.com/${process.env.NEXT_PUBLIC_SATSUMA_API_KEY}/kwenta/optimism-latest-rates/api`
 
-export const RATES_ENDPOINT_OP_GOERLI =
-	'https://api.thegraph.com/subgraphs/name/kwenta/optimism-goerli-latest-rates'
+export const RATES_ENDPOINT_OP_GOERLI = `https://subgraph.satsuma-prod.com/${process.env.NEXT_PUBLIC_SATSUMA_API_KEY}/kwenta/optimism-goerli-latest-rates/api`
 
 export const RATES_ENDPOINT_GOERLI = 'https://api.thegraph.com/subgraphs/name/kwenta/goerli-main'
 


### PR DESCRIPTION
## Description

The subgraph is now updated to properly handle assets with varying decimal places, which means we can remove the hack to handle PEPE 24hr change.

closes #2581

### THIS CHANGE NEEDS TO BE DEPLOYED IN SYNC WITH THE RATES SUBGRAPH GOING LIVE 

