### PR TITLE
Added no results message in escrow table

### DIFF
--- a/packages/app/src/sections/dashboard/Stake/EscrowTable.tsx
+++ b/packages/app/src/sections/dashboard/Stake/EscrowTable.tsx
@@ -10,7 +10,7 @@ import Button from 'components/Button'
 import { Checkbox } from 'components/Checkbox'
 import { FlexDivCol, FlexDivRow, FlexDivRowCentered } from 'components/layout/flex'
 import { DesktopLargeOnlyView, DesktopSmallOnlyView } from 'components/Media'
-import Table from 'components/Table'
+import Table, { TableNoResults } from 'components/Table'
 import { TableCellHead, TableHeader } from 'components/Table'
 import StakingPagination from 'components/Table/StakingPagination'
 import { Body } from 'components/Text'
@@ -160,6 +160,9 @@ const EscrowTable = () => {
 					columnsDeps={columnsDeps}
 					CustomPagination={StakingPagination}
 					paginationExtra={<EscrowStatsContainer />}
+					noResultsMessage={
+						<TableNoResults>{t('dashboard.stake.tabs.escrow.no-entries')}</TableNoResults>
+					}
 					columns={[
 						{
 							header: () => (

--- a/packages/app/src/translations/en.json
+++ b/packages/app/src/translations/en.json
@@ -648,6 +648,7 @@
 					"vest-v2": "VEST V2",					
 					"transfer": "TRANSFER",
 					"delegate": "DELEGATE",
+					"no-entries": "You have no escrowed entries.",
 					"v1": "V1",
 					"v2": "V2",
 					"modal": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Show "No entries" message when the escrow table is empty.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/a3586cdf-a9fd-4fce-b177-357d3c940402)
