### PR TITLE
Fix: Correct the vestable amount in escrow table

### DIFF
--- a/packages/app/src/sections/dashboard/Stake/EscrowTable.tsx
+++ b/packages/app/src/sections/dashboard/Stake/EscrowTable.tsx
@@ -231,7 +231,7 @@ const EscrowTable = () => {
 							),
 							cell: (cellProps) => (
 								<TableCell>
-									{formatNumber(cellProps.row.original.amount, { minDecimals: 4 })}
+									{formatNumber(cellProps.row.original.vestable, { minDecimals: 4 })}
 								</TableCell>
 							),
 							accessorKey: 'immediatelyVestable',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `immediately vestable amount` is now showing the same number as the `total amount`.
![image](https://github.com/Kwenta/kwenta/assets/4819006/6d31b99a-14e6-45f6-9869-5be3b4881cc9)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Kwenta/kwenta/assets/4819006/c3895524-51ac-4031-9ceb-62963e37976c)
