### PR TITLE
Fix: Blank space under banner after network switching and V1 staked escrowed balance

### DIFF
--- a/packages/app/src/sections/dashboard/Stake/EscrowTab.tsx
+++ b/packages/app/src/sections/dashboard/Stake/EscrowTab.tsx
@@ -12,6 +12,7 @@ import {
 	selectStakedEscrowedKwentaBalanceV2,
 	selectTotalVestable,
 	selectTotalVestableV2,
+	selectUnstakedEscrowedKwentaBalance,
 } from 'state/staking/selectors'
 import media from 'styles/media'
 
@@ -24,6 +25,7 @@ const EscrowTab = () => {
 	const apyV2 = useAppSelector(selectAPYV2)
 	const stakedEscrowedKwentaBalance = useAppSelector(selectStakedEscrowedKwentaBalance)
 	const stakedEscrowedKwentaBalanceV2 = useAppSelector(selectStakedEscrowedKwentaBalanceV2)
+	const unstakedEscrowedKwentaBalance = useAppSelector(selectUnstakedEscrowedKwentaBalance)
 	const totalVestable = useAppSelector(selectTotalVestable)
 	const totalVestableV2 = useAppSelector(selectTotalVestableV2)
 
@@ -58,6 +60,11 @@ const EscrowTab = () => {
 						value: formatNumber(stakedEscrowedKwentaBalance, { suggestDecimals: true }),
 					},
 					{
+						key: 'staking-v1-staked',
+						title: t('dashboard.stake.portfolio.escrow.unstaked'),
+						value: formatNumber(unstakedEscrowedKwentaBalance, { suggestDecimals: true }),
+					},
+					{
 						key: 'staking-v1-vestable',
 						title: t('dashboard.stake.portfolio.escrow.vestable'),
 						value: formatNumber(totalVestable, { suggestDecimals: true }),
@@ -72,6 +79,7 @@ const EscrowTab = () => {
 			t,
 			totalVestable,
 			totalVestableV2,
+			unstakedEscrowedKwentaBalance,
 		]
 	)
 

--- a/packages/app/src/sections/shared/Layout/AppLayout/Header/Header.tsx
+++ b/packages/app/src/sections/shared/Layout/AppLayout/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import styled from 'styled-components'
 
+import { FlexDivCol } from 'components/layout/flex'
 import { MobileHiddenView } from 'components/Media'
 
 import Banner from '../../HomeLayout/Banner'
@@ -12,14 +13,16 @@ import WalletButtons from './WalletButtons'
 const Header: FC = () => {
 	return (
 		<MobileHiddenView>
-			<Container>
-				<LogoNav>
-					<Logo />
-					<Nav />
-				</LogoNav>
-				<WalletButtons />
-			</Container>
-			<Banner />
+			<FlexDivCol>
+				<Container>
+					<LogoNav>
+						<Logo />
+						<Nav />
+					</LogoNav>
+					<WalletButtons />
+				</Container>
+				<Banner />
+			</FlexDivCol>
 		</MobileHiddenView>
 	)
 }

--- a/packages/app/src/translations/en.json
+++ b/packages/app/src/translations/en.json
@@ -566,6 +566,7 @@
 					"title-v2": "Escrow V2",
 					"title-v1": "Escrow V1",
 					"staked": "Staked",
+					"unstaked": "Unstaked",
 					"vestable": "Vestable"
 				},
 				"rewards": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. This is a bug found in yesterday's test: a blank space may appear between the banner and the page content if the page content does not fill the screen (e.g. migration page and escrow tab, staking tab is unaffected) after switching the network. 
![image](https://github.com/Kwenta/kwenta/assets/4819006/8d420a7b-4c75-40d4-b6a2-e8c3c5c228e7)
- The root cause is unclear, but it seems to be related to how the `<Header />` component is rendered. After the network is switched, the `<Container />` and `<Banner />` components are processed as two separate items in the grid layout, which causes `DesktopGridContainer` (`grid-template: auto 1fr auto / 100%;`) to display an unexpected layout.

2. Add V1 staked escrowed balance into the Escrow tab info box
![image](https://github.com/Kwenta/kwenta/assets/4819006/ece8b73f-c7e8-4723-873a-accdad1325b3)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
No blank space after network switching
![image](https://github.com/Kwenta/kwenta/assets/4819006/aaed2d3b-2747-4e9c-b137-d557bcc1c664)

Add unstaked escrowed info for v1 balance
![image](https://github.com/Kwenta/kwenta/assets/4819006/a79bd5a3-afb9-4e49-801a-bcab9397e7cc)
