### PR TITLE
Update the pyth trading view endpoint

### DIFF
--- a/packages/app/src/queries/rates/constants.ts
+++ b/packages/app/src/queries/rates/constants.ts
@@ -3,4 +3,5 @@ export const COMMODITIES_BASE_API_URL =
 
 export const FOREX_BASE_API_URL = 'https://api.exchangerate.host/latest'
 
-export const DEFAULT_PYTH_TV_ENDPOINT = 'https://pyth-api.vintage-orange-muffin.com/v2/history'
+export const DEFAULT_PYTH_TV_ENDPOINT =
+	'https://benchmarks.pyth.network/v1/shims/tradingview/history'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current pyth historical data api is broken [https://pyth-api.vintage-orange-muffin.com/v2/](https://pyth-api.vintage-orange-muffin.com/v2/history?from=1689133979&to=1689403979&symbol=AVAX%2FUSD&resolution=15)
After contacing with the pyth team, we decided to apply a new endpoint: [https://benchmarks.pyth.network/v1/shims/tradingview/](https://benchmarks.pyth.network/v1/shims/tradingview/history?symbol=ARB%2FUSD&resolution=15&from=1689097844&to=1689393944)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
