### PR TITLE
Fix: Hide step 2 if the user has no escrowed entries

### DIFF
--- a/packages/app/src/constants/announcement.ts
+++ b/packages/app/src/constants/announcement.ts
@@ -5,9 +5,9 @@ export const BANNER_ENABLED = true
 // Sets the link destination for the banner component, or renders the banner as
 // plain, un-clickable text if set to a falsey value (`false`, `null`, '', etc...)
 export const BANNER_LINK_URL =
-	'https://mirror.xyz/kwenta.eth/jCT9MCu_NpylWOQHUuzz25sbMFvR9W8RI_y_5mYYOhY'
+	'https://mirror.xyz/kwenta.eth/xFomD0VE0H7o2sQ9zGeLyYPwCmtp8tLMXNTGtWy2UOQ'
 // Sets the text displayed on the home page banner
-export const BANNER_TEXT = 'StakingV2 - Migration Postponed'
+export const BANNER_TEXT = 'Staking V2 - Reverse Migration'
 // Sets the height of the banner component on desktop
 export const BANNER_HEIGHT_DESKTOP = 50
 // Sets the height of the banner component on mobile

--- a/packages/app/src/sections/dashboard/Stake/MigrationSteps.tsx
+++ b/packages/app/src/sections/dashboard/Stake/MigrationSteps.tsx
@@ -50,6 +50,7 @@ const MigrationSteps: FC = memo(() => {
 				onClick: handleUnstakeKwenta,
 				active: stakedKwentaBalanceV2.gt(0),
 				loading: isUnstakingKwenta,
+				visible: true,
 			},
 			{
 				key: 'step-2',
@@ -60,6 +61,7 @@ const MigrationSteps: FC = memo(() => {
 				onClick: handleVest,
 				active: stakedKwentaBalanceV2.eq(0) && totalVestableV2.gt(0),
 				loading: isVestingEscrowedRewards,
+				visible: totalVestableV2.gt(0),
 			},
 		],
 		[
@@ -75,8 +77,9 @@ const MigrationSteps: FC = memo(() => {
 
 	return (
 		<StepsContainer columnGap="15px">
-			{migrationSteps.map(
-				({ key, copy, label, value, buttonLabel, active, onClick, loading }, i) => (
+			{migrationSteps
+				.filter(({ visible }) => visible)
+				.map(({ key, copy, label, value, buttonLabel, active, onClick, loading }, i) => (
 					<StyledStakingCard key={key} $active={active}>
 						<StyledHeading variant="h4">
 							<Trans
@@ -111,8 +114,7 @@ const MigrationSteps: FC = memo(() => {
 							</Button>
 						</FlexDivRowCentered>
 					</StyledStakingCard>
-				)
-			)}
+				))}
 		</StepsContainer>
 	)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Hide the step 2 in the reverse migration if the user has no escrowed entries.
2. Update the banner link to [Staking V2 Reverse Migration](https://mirror.xyz/kwenta.eth/xFomD0VE0H7o2sQ9zGeLyYPwCmtp8tLMXNTGtWy2UOQ)

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Case 1: The migrated user has escrowed entries will see two steps
<img width="1235" alt="截屏2023-07-18 00 11 12" src="https://github.com/Kwenta/kwenta/assets/4819006/ab26cce0-4c00-4f13-85c5-8f9cb60c4ae2">

 
Case 2: The migrated user has no escrowed entries will see one step
<img width="1381" alt="截屏2023-07-18 00 10 00" src="https://github.com/Kwenta/kwenta/assets/4819006/d44d2602-4391-4374-9c63-6b680a7f99fd">

## Screenshots (if appropriate):
