### PR TITLE
Increased the timeout to 10s

### DIFF
--- a/packages/sdk/src/utils/files.ts
+++ b/packages/sdk/src/utils/files.ts
@@ -4,5 +4,5 @@ import { FLEEK_BASE_URL, FLEEK_STORAGE_BUCKET } from '../constants/files'
 
 export const client = axios.create({
 	baseURL: `${FLEEK_BASE_URL}/${FLEEK_STORAGE_BUCKET}/data/`,
-	timeout: 5000,
+	timeout: 10000,
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We faced the timeout issue of fetching the files from fleek storage. To resolve this issue, the timeout limit is increased to 10s.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Test some random address
0x0328c8b74fC29943b1c6BE6CBa3f94119366e9B7
0x080A035dD0632c22349ae3dd061900A10F31c0aF


## Screenshots (if appropriate):
<img width="620" alt="截屏2023-07-19 11 33 42" src="https://github.com/Kwenta/kwenta/assets/4819006/a5b27b11-bfd8-44ab-8390-78c820a47979">
<img width="1135" alt="截屏2023-07-19 11 33 47" src="https://github.com/Kwenta/kwenta/assets/4819006/55e4ef11-2011-4c82-a8cb-d2db147a7254">

