### PR TITLE
Fix: Add AWS bucket support

### DIFF
--- a/packages/sdk/src/constants/files.ts
+++ b/packages/sdk/src/constants/files.ts
@@ -1,3 +1,5 @@
 export const FLEEK_STORAGE_BUCKET = '25710180-23d8-43f4-b0c9-5b7f55f63165-bucket'
 
 export const FLEEK_BASE_URL = 'https://storage.kwenta.io'
+
+export const TRADING_REWARDS_AWS_BUCKET = 'https://trading-rewards-snapshots.s3.amazonaws.com/'

--- a/packages/sdk/src/services/kwentaToken.ts
+++ b/packages/sdk/src/services/kwentaToken.ts
@@ -19,7 +19,7 @@ import {
 import { ContractName } from '../contracts'
 import { ClaimParams, EpochData, EscrowData } from '../types/kwentaToken'
 import { formatTruncatedDuration } from '../utils/date'
-import { getClient } from '../utils/files'
+import { awsClient } from '../utils/files'
 import { weiFromWei } from '../utils/number'
 import { getFuturesAggregateStats, getFuturesTrades } from '../utils/subgraph'
 import { calculateFeesForAccount, calculateTotalFees } from '../utils'
@@ -508,8 +508,7 @@ export default class KwentaTokenService {
 
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName) => {
-				const client = getClient(true)
-				const response = await client.get(fileName)
+				const response = await awsClient.get(fileName)
 				return { ...response.data }
 			})
 		)
@@ -547,8 +546,7 @@ export default class KwentaTokenService {
 
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName, index) => {
-				const client = getClient(true)
-				const response = await client.get(fileName)
+				const response = await awsClient.get(fileName)
 				const period = isOldDistributor
 					? index >= 5
 						? index >= 10
@@ -636,8 +634,7 @@ export default class KwentaTokenService {
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName, index) => {
 				try {
-					const client = getClient(true)
-					const response = await client.get(fileName)
+					const response = await awsClient.get(fileName)
 					const period = isOldDistributor
 						? index >= 5
 							? index >= 10

--- a/packages/sdk/src/services/kwentaToken.ts
+++ b/packages/sdk/src/services/kwentaToken.ts
@@ -19,7 +19,7 @@ import {
 import { ContractName } from '../contracts'
 import { ClaimParams, EpochData, EscrowData } from '../types/kwentaToken'
 import { formatTruncatedDuration } from '../utils/date'
-import { client } from '../utils/files'
+import { getClient } from '../utils/files'
 import { weiFromWei } from '../utils/number'
 import { getFuturesAggregateStats, getFuturesTrades } from '../utils/subgraph'
 import { calculateFeesForAccount, calculateTotalFees } from '../utils'
@@ -503,11 +503,12 @@ export default class KwentaTokenService {
 	public async getEstimatedRewards() {
 		const { networkId, walletAddress } = this.sdk.context
 		const fileNames = ['', '-op'].map(
-			(i) => `trading-rewards-snapshots/${networkId === 420 ? 'goerli-' : ''}epoch-current${i}.json`
+			(i) => `${networkId === 420 ? 'goerli-' : ''}epoch-current${i}.json`
 		)
 
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName) => {
+				const client = getClient(true)
 				const response = await client.get(fileName)
 				return { ...response.data }
 			})
@@ -541,14 +542,12 @@ export default class KwentaTokenService {
 			: periods.slice(TRADING_REWARDS_CUTOFF_EPOCH)
 
 		const fileNames = adjustedPeriods.map(
-			(i) =>
-				`trading-rewards-snapshots/${
-					this.sdk.context.networkId === 420 ? `goerli-` : ''
-				}epoch-${i}.json`
+			(i) => `${this.sdk.context.networkId === 420 ? `goerli-` : ''}epoch-${i}.json`
 		)
 
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName, index) => {
+				const client = getClient(true)
 				const response = await client.get(fileName)
 				const period = isOldDistributor
 					? index >= 5
@@ -629,7 +628,7 @@ export default class KwentaTokenService {
 
 		const fileNames = adjustedPeriods.map(
 			(i) =>
-				`trading-rewards-snapshots/${this.sdk.context.networkId === 420 ? `goerli-` : ''}epoch-${
+				`${this.sdk.context.networkId === 420 ? `goerli-` : ''}epoch-${
 					isSnx ? i - OP_REWARDS_CUTOFF_EPOCH : i
 				}${isOp ? (isSnx ? '-snx-op' : '-op') : ''}.json`
 		)
@@ -637,6 +636,7 @@ export default class KwentaTokenService {
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName, index) => {
 				try {
+					const client = getClient(true)
 					const response = await client.get(fileName)
 					const period = isOldDistributor
 						? index >= 5

--- a/packages/sdk/src/services/system.ts
+++ b/packages/sdk/src/services/system.ts
@@ -1,7 +1,7 @@
 import KwentaSDK from '..'
 import { UNSUPPORTED_NETWORK } from '../common/errors'
 import { KwentaStatus } from '../types/system'
-import { getClient } from '../utils/files'
+import { fleekClient } from '../utils/files'
 import { StatusMap } from '../utils/system'
 
 export default class SystemService {
@@ -27,8 +27,7 @@ export default class SystemService {
 	}
 
 	public async getKwentaStatus(): Promise<KwentaStatus> {
-		const client = getClient()
-		const response = await client.get('kwenta-status.json', {
+		const response = await fleekClient.get('kwenta-status.json', {
 			headers: { 'Cache-Control': 'no-cache' },
 		})
 

--- a/packages/sdk/src/services/system.ts
+++ b/packages/sdk/src/services/system.ts
@@ -1,7 +1,7 @@
 import KwentaSDK from '..'
 import { UNSUPPORTED_NETWORK } from '../common/errors'
 import { KwentaStatus } from '../types/system'
-import { client } from '../utils/files'
+import { getClient } from '../utils/files'
 import { StatusMap } from '../utils/system'
 
 export default class SystemService {
@@ -27,6 +27,7 @@ export default class SystemService {
 	}
 
 	public async getKwentaStatus(): Promise<KwentaStatus> {
+		const client = getClient()
 		const response = await client.get('kwenta-status.json', {
 			headers: { 'Cache-Control': 'no-cache' },
 		})

--- a/packages/sdk/src/utils/files.ts
+++ b/packages/sdk/src/utils/files.ts
@@ -1,8 +1,17 @@
 import axios from 'axios'
 
-import { FLEEK_BASE_URL, FLEEK_STORAGE_BUCKET } from '../constants/files'
+import {
+	FLEEK_BASE_URL,
+	FLEEK_STORAGE_BUCKET,
+	TRADING_REWARDS_AWS_BUCKET,
+} from '../constants/files'
 
-export const client = axios.create({
-	baseURL: `${FLEEK_BASE_URL}/${FLEEK_STORAGE_BUCKET}/data/`,
-	timeout: 10000,
-})
+export const getClient = (useAWS: boolean = false) => {
+	const baseURL = useAWS
+		? TRADING_REWARDS_AWS_BUCKET
+		: `${FLEEK_BASE_URL}/${FLEEK_STORAGE_BUCKET}/data/`
+	return axios.create({
+		baseURL,
+		timeout: 5000,
+	})
+}

--- a/packages/sdk/src/utils/files.ts
+++ b/packages/sdk/src/utils/files.ts
@@ -6,12 +6,13 @@ import {
 	TRADING_REWARDS_AWS_BUCKET,
 } from '../constants/files'
 
-export const getClient = (useAWS: boolean = false) => {
-	const baseURL = useAWS
-		? TRADING_REWARDS_AWS_BUCKET
-		: `${FLEEK_BASE_URL}/${FLEEK_STORAGE_BUCKET}/data/`
+const createClient = (baseURL: string) => {
 	return axios.create({
 		baseURL,
 		timeout: 5000,
 	})
 }
+
+export const awsClient = createClient(TRADING_REWARDS_AWS_BUCKET)
+
+export const fleekClient = createClient(`${FLEEK_BASE_URL}/${FLEEK_STORAGE_BUCKET}/data/`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support to fetch the trading rewards file from aws bucket. After this fix, we are fetching `kwenta-status.json` from fleek storage and trading rewards file from aws.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Test some random address
0x24c35D308f4771930f24ca2Ed9FC911E2785572C
0x16d1663A00d4d1a216E0baa84B0AbC69ba35C156

## Screenshots (if appropriate):
<img width="1822" alt="截屏2023-07-19 14 40 32" src="https://github.com/Kwenta/kwenta/assets/4819006/837d934a-1153-4953-9e86-82ed87e2aa9a">
<img width="1822" alt="截屏2023-07-19 14 40 32" src="https://github.com/Kwenta/kwenta/assets/4819006/27a52b96-e5fd-440b-a5cd-f3711671599e">

