### PR TITLE
Take deposit/withdraw modal back to smart margin

### DIFF
--- a/packages/app/src/components/SocketBridge/SocketBridge.tsx
+++ b/packages/app/src/components/SocketBridge/SocketBridge.tsx
@@ -6,8 +6,7 @@ import ArrowIcon from 'assets/svg/app/arrow-down.svg'
 import Connector from 'containers/Connector'
 import { chain } from 'containers/Connector/config'
 import { fetchBalances } from 'state/balances/actions'
-import { selectFuturesType } from 'state/futures/selectors'
-import { useAppDispatch, useAppSelector } from 'state/hooks'
+import { useAppDispatch } from 'state/hooks'
 import {
 	customizeSocket,
 	socketDefaultChains,
@@ -19,7 +18,6 @@ const SocketBridge = () => {
 	const { activeChain, signer } = Connector.useContainer()
 	const dispatch = useAppDispatch()
 	const customize = customizeSocket(useTheme())
-	const accountType = useAppSelector(selectFuturesType)
 	const onBridgeSuccess = useCallback(() => {
 		dispatch(fetchBalances())
 	}, [dispatch])
@@ -42,11 +40,9 @@ const SocketBridge = () => {
 				enableSameChainSwaps={true}
 				onBridgeSuccess={onBridgeSuccess}
 			/>
-			{accountType === 'isolated_margin' && (
-				<StyledDiv>
-					<ArrowIcon />
-				</StyledDiv>
-			)}
+			<StyledDiv>
+				<ArrowIcon />
+			</StyledDiv>
 		</BridgeContainer>
 	)
 }

--- a/packages/app/src/pages/market.tsx
+++ b/packages/app/src/pages/market.tsx
@@ -153,7 +153,12 @@ function TradePanelDesktop() {
 		[accountType, isolatedPositionsCount]
 	)
 
-	if (walletAddress && !isL2 && openModal !== 'futures_smart_margin_socket') {
+	if (
+		walletAddress &&
+		!isL2 &&
+		openModal !== 'futures_smart_margin_socket' &&
+		openModal !== 'futures_isolated_transfer'
+	) {
 		return <FuturesUnsupportedNetwork />
 	}
 

--- a/packages/app/src/sections/futures/Trade/TradeBalance.tsx
+++ b/packages/app/src/sections/futures/Trade/TradeBalance.tsx
@@ -28,6 +28,7 @@ import PencilButton from '../../../components/Button/PencilButton'
 import CrossMarginInfoBox from '../TradeCrossMargin/CrossMarginInfoBox'
 
 import SmartMarginOnboardModal from './SmartMarginOnboardModal'
+import TransferIsolatedMarginModal from './TransferIsolatedMarginModal'
 
 type TradeBalanceProps = {
 	isMobile?: boolean
@@ -159,13 +160,7 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 							height={16}
 							onClick={(e) => {
 								e.stopPropagation()
-								dispatch(
-									setOpenModal(
-										accountType === 'isolated_margin'
-											? 'futures_isolated_transfer'
-											: 'futures_cross_withdraw'
-									)
-								)
+								dispatch(setOpenModal('futures_isolated_transfer'))
 							}}
 						/>
 						<Pill roundedCorner={false} onClick={onClickContainer}>
@@ -183,6 +178,12 @@ const TradeBalance: React.FC<TradeBalanceProps> = memo(({ isMobile = false }) =>
 					onDismiss={() => {
 						dispatch(setOpenModal(null))
 					}}
+				/>
+			)}
+			{openModal === 'futures_isolated_transfer' && (
+				<TransferIsolatedMarginModal
+					defaultTab="deposit"
+					onDismiss={() => dispatch(setOpenModal(null))}
 				/>
 			)}
 		</Container>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the `deposit/withdraw modal` back to the smart margin mode.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
It's easy for users to bridge more sUSD and trade more in one place.

## How Has This Been Tested?
Case 1. User has less than 50 sUSD
- Show `Get sUSD` to bridge more sUSD

Case 2. User has more than 50 sUSD
- Show `Deposit/Withdraw` modal. The user can expand `Bridge & Swap` to bridge more sUSD.

## Screenshots (if appropriate):
<img width="1182" alt="截屏2023-07-19 18 32 20" src="https://github.com/Kwenta/kwenta/assets/4819006/c3d9a3b8-7662-4b2a-8b24-8ed94a0a944e">