### PR TITLE
Reduces the stop loss restriction to 1%

### DIFF
--- a/packages/app/src/__tests__/pages/market.test.tsx
+++ b/packages/app/src/__tests__/pages/market.test.tsx
@@ -248,7 +248,7 @@ describe('Futures market page - stop loss validation', () => {
 		fireEvent.change(stopLossInput, { target: { value: '1700' } })
 
 		// Min / Max SL is shown when invalid
-		const slMinMaxLabel = await findByText('Min: 1,735.52')
+		const slMinMaxLabel = await findByText('Min: 1,701.82')
 		expect(slMinMaxLabel).toBeTruthy()
 		expect(submitButton).toBeDisabled()
 
@@ -295,11 +295,11 @@ describe('Futures market page - stop loss validation', () => {
 		fireEvent.click(approveButton)
 
 		const stopLossInput = await findByTestId('trade-panel-stop-loss-input')
-		fireEvent.change(stopLossInput, { target: { value: '2150' } })
+		fireEvent.change(stopLossInput, { target: { value: '2160' } })
 
 		// Min / Max SL is shown when invalid
-		// Liqudation price is 2,172.46 and stop is limited to 2,100.07
-		const slMinMaxLabel = await findByText('Max: 2,107.29')
+		// Liqudation price is 2,172.46 and stop is limited to 2,172.29
+		const slMinMaxLabel = await findByText('Max: 2,150.74')
 		expect(slMinMaxLabel).toBeTruthy()
 
 		expect(submitButton).toBeDisabled()
@@ -320,16 +320,16 @@ describe('Futures market page - stop loss validation', () => {
 		sdk.futures.getCrossMarginTradePreview = () =>
 			Promise.resolve({
 				...MOCK_TRADE_PREVIEW,
-				liqPrice: wei('1760'),
+				liqPrice: wei('1795'),
 				size: wei('1.1'),
-				leverage: wei('20'),
+				leverage: wei('40'),
 			})
 
 		const marginInput = await findByTestId('set-order-margin-susd-desktop')
 		fireEvent.change(marginInput, { target: { value: '100' } })
 
 		const sizeInput = await findByTestId('set-order-size-amount-susd-desktop')
-		fireEvent.change(sizeInput, { target: { value: '2000' } })
+		fireEvent.change(sizeInput, { target: { value: '4000' } })
 
 		const fees = await findByText('$1.69')
 		expect(fees).toBeTruthy()

--- a/packages/app/src/utils/__tests__/futures.test.ts
+++ b/packages/app/src/utils/__tests__/futures.test.ts
@@ -7,12 +7,12 @@ describe('futures utils', () => {
 	test('correct stop loss limitation when LONG', () => {
 		// Traders can place stop losses at 3% above liquidation price
 		const minStopLoss = minMaxSLPrice(wei(1800), PositionSide.LONG)
-		expect(minStopLoss?.toNumber()).toEqual(1854)
+		expect(minStopLoss?.toNumber()).toEqual(1818)
 	})
 
 	test('correct stop loss limitation when SHORT', () => {
 		// Traders can place stop losses at 3% below liquidation price
 		const minStopLoss = minMaxSLPrice(wei(2200), PositionSide.SHORT)
-		expect(minStopLoss?.toNumber()).toEqual(2134)
+		expect(minStopLoss?.toNumber()).toEqual(2178)
 	})
 })

--- a/packages/app/src/utils/futures.ts
+++ b/packages/app/src/utils/futures.ts
@@ -410,8 +410,8 @@ export const formatDelayedOrders = (orders: DelayedOrder[], markets: FuturesMark
 		}, [] as DelayedOrderWithDetails[])
 }
 
-// Disable stop loss when it is within 3% of the liquidation price
-const SL_LIQ_DISABLED_PERCENT = 0.03
+// Disable stop loss when it is within 1% of the liquidation price
+const SL_LIQ_DISABLED_PERCENT = 0.01
 
 // Warn users when their stop loss is within 7.5% of their liquidation price
 const SL_LIQ_PERCENT_WARN = 0.075


### PR DESCRIPTION
## Description

Since users were complaining the stop loss restriction was too harsh we have reduced the hard cut off to 1% of liq price and kept the warning when price is within 7.5% of the liq price. 