### PR TITLE
Fix: Fetch the estimated rewards file from fleek

### DIFF
--- a/packages/sdk/src/services/kwentaToken.ts
+++ b/packages/sdk/src/services/kwentaToken.ts
@@ -19,7 +19,7 @@ import {
 import { ContractName } from '../contracts'
 import { ClaimParams, EpochData, EscrowData } from '../types/kwentaToken'
 import { formatTruncatedDuration } from '../utils/date'
-import { awsClient } from '../utils/files'
+import { awsClient, fleekClient } from '../utils/files'
 import { weiFromWei } from '../utils/number'
 import { getFuturesAggregateStats, getFuturesTrades } from '../utils/subgraph'
 import { calculateFeesForAccount, calculateTotalFees } from '../utils'
@@ -508,7 +508,7 @@ export default class KwentaTokenService {
 
 		const responses: EpochData[] = await Promise.all(
 			fileNames.map(async (fileName) => {
-				const response = await awsClient.get(fileName)
+				const response = await fleekClient.get(fileName)
 				return { ...response.data }
 			})
 		)

--- a/packages/sdk/src/services/kwentaToken.ts
+++ b/packages/sdk/src/services/kwentaToken.ts
@@ -503,7 +503,7 @@ export default class KwentaTokenService {
 	public async getEstimatedRewards() {
 		const { networkId, walletAddress } = this.sdk.context
 		const fileNames = ['', '-op'].map(
-			(i) => `${networkId === 420 ? 'goerli-' : ''}epoch-current${i}.json`
+			(i) => `trading-rewards-snapshots/${networkId === 420 ? 'goerli-' : ''}epoch-current${i}.json`
 		)
 
 		const responses: EpochData[] = await Promise.all(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The rewards estimation file is uploaded to Fleek storage. Therefore, we need to revert the partial change of #2629 

## Related issue
#2629

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
