### PR TITLE
Fix: Show correct amount in the live trade history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kwenta",
-	"version": "7.4.6",
+	"version": "7.4.7",
 	"description": "Kwenta",
 	"main": "index.js",
 	"scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kwenta/app",
-	"version": "7.4.6",
+	"version": "7.4.7",
 	"scripts": {
 		"dev": "next",
 		"build": "next build",

--- a/packages/app/src/sections/futures/TradingHistory/TradesHistoryTable.tsx
+++ b/packages/app/src/sections/futures/TradingHistory/TradesHistoryTable.tsx
@@ -42,7 +42,7 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile, display }) =>
 						.map((trade) => {
 							return {
 								value: Number(trade?.price),
-								amount: Number(trade?.size),
+								amount: trade?.size,
 								time: Number(trade?.timestamp),
 								id: trade?.txnHash,
 								orderType: trade?.orderType,
@@ -118,16 +118,13 @@ const TradesHistoryTable: FC<TradesHistoryTableProps> = ({ mobile, display }) =>
 						header: () => <TableHeader>{t('futures.market.history.amount-label')}</TableHeader>,
 						accessorKey: TableColumnAccessor.Amount,
 						cell: (cellProps) => {
-							const numValue = Math.abs(cellProps.row.original.amount / 1e18)
-							const numDecimals = numValue === 0 ? 2 : numValue < 1 ? 4 : numValue >= 100000 ? 0 : 2
-
 							const normal = cellProps.row.original.orderType === 'Liquidation'
-							const negative = cellProps.row.original.amount > 0
+							const negative = cellProps.getValue() > 0
 
 							return (
 								<DirectionalValue negative={negative} normal={normal}>
-									{formatNumber(numValue, {
-										minDecimals: numDecimals,
+									{formatNumber(cellProps.getValue().abs(), {
+										suggestDecimals: true,
 										truncateOver: 1e6,
 									})}{' '}
 									{normal ? '💀' : ''}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After #2540  change, the `amount` shows `0.0000` in the live trade history because of the data type change.
<img width="342" alt="截屏2023-07-21 21 53 08" src="https://github.com/Kwenta/kwenta/assets/4819006/5b0ea73c-4c4a-42f6-a79b-02dd3584e098">

## Related issue
#2540 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Uploading 截屏2023-07-21 21.58.50.png…]()
