### PR TITLE
Fix: Display all trade history table rows

### DIFF
--- a/packages/app/src/components/Tab.tsx
+++ b/packages/app/src/components/Tab.tsx
@@ -37,5 +37,6 @@ const TabPanelContainer = styled.div<{ $fullHeight?: boolean }>`
 		props.$fullHeight &&
 		css`
 			height: 100%;
+			overflow: auto;
 		`}
 `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Traders cannot see the last row of the trade history table, as the footer covers it.

## Related issue
Closes #2644

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Connect the wallet
2. Go to the market page and switch to the trades tab
3. The user can see all the rows of the table clearly

## Screenshots (if appropriate):
<img width="1026" alt="截屏2023-07-24 23 01 05" src="https://github.com/Kwenta/kwenta/assets/4819006/8916533a-0afe-41e9-b1cc-527ba32c7ed9">
