### PR TITLE
Fix: More decimal places to show PEPE price

### DIFF
--- a/packages/sdk/src/utils/number.ts
+++ b/packages/sdk/src/utils/number.ts
@@ -223,7 +223,8 @@ export const suggestedDecimals = (value: WeiSource) => {
 	if (value >= 0.01) return 5
 	if (value >= 0.001) return 6
 	if (value >= 0.0001) return 7
-	return 8
+	if (value >= 0.00001) return 8
+	return 9
 }
 
 export const floorNumber = (num: WeiSource, decimals?: number) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, there needs to be a larger number of decimal places displayed for PEPE, making it difficult to monitor price movements.

In this PR, `suggestedDecimals` function is updated to include higher precision.

## Related issue
Closes #2621 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
#### Market Details
<img width="498" alt="截屏2023-07-25 01 49 13" src="https://github.com/Kwenta/kwenta/assets/4819006/3f34f0cc-8041-474f-a4ba-4acc74513859">

#### Market Dropdown
<img width="469" alt="截屏2023-07-25 01 49 23" src="https://github.com/Kwenta/kwenta/assets/4819006/dce014a4-cdb3-4f90-bb1c-ee1f511f175c">

