### PR TITLE
Fix: Leaderboard pagination

### DIFF
--- a/packages/app/src/components/Table/Table.tsx
+++ b/packages/app/src/components/Table/Table.tsx
@@ -73,6 +73,7 @@ type TableProps<T> = {
 	noBottom?: boolean
 	columnVisibility?: VisibilityState
 	columnsDeps?: DependencyList
+	autoResetPageIndex?: boolean
 	paginationExtra?: React.ReactNode
 	CustomPagination?: FC<PaginationProps>
 }
@@ -95,6 +96,7 @@ const Table = <T,>({
 	rounded = true,
 	noBottom = false,
 	columnVisibility,
+	autoResetPageIndex = true,
 	columnsDeps = [],
 	paginationExtra,
 	CustomPagination,
@@ -116,6 +118,7 @@ const Table = <T,>({
 		columns: memoizedColumns,
 		data,
 		enableHiding: true,
+		autoResetPageIndex,
 		state: { sorting, columnVisibility, pagination },
 		onSortingChange: setSorting,
 		onPaginationChange: setPagination,

--- a/packages/app/src/sections/leaderboard/AllTime.tsx
+++ b/packages/app/src/sections/leaderboard/AllTime.tsx
@@ -92,6 +92,7 @@ const AllTime: FC<AllTimeProps> = ({
 								</TableTitle>
 							),
 							accessorKey: 'title',
+							enableSorting: false,
 							columns: [
 								{
 									header: () => (
@@ -180,6 +181,7 @@ const AllTime: FC<AllTimeProps> = ({
 						{
 							header: () => <TableHeader>{t('leaderboard.leaderboard.table.rank')}</TableHeader>,
 							accessorKey: 'rank',
+							enableSorting: false,
 							cell: (cellProps) => (
 								<StyledOrderType>{cellProps.row.original.rankText}</StyledOrderType>
 							),

--- a/packages/app/src/sections/leaderboard/TraderHistory.tsx
+++ b/packages/app/src/sections/leaderboard/TraderHistory.tsx
@@ -122,6 +122,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 									</TableTitle>
 								),
 								accessorKey: 'title',
+								enableSorting: false,
 								columns: [
 									{
 										header: () => (
@@ -234,6 +235,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 									</TableTitle>
 								),
 								accessorKey: 'title',
+								enableSorting: false,
 								columns: [
 									{
 										header: () => (

--- a/packages/app/src/sections/leaderboard/TraderHistory.tsx
+++ b/packages/app/src/sections/leaderboard/TraderHistory.tsx
@@ -104,6 +104,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 						isLoading={queryStatus.status === FetchStatus.Loading}
 						data={data}
 						hideHeaders={compact}
+						autoResetPageIndex={false}
 						columns={[
 							{
 								header: () => (
@@ -210,6 +211,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 						isLoading={false}
 						showPagination
 						pageSize={10}
+						autoResetPageIndex={false}
 						columns={[
 							{
 								header: () => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The pagination of the trader position history is reset to the first page because of the updated data.
In this PR, the `autoResetPageIndex` is set to `false` to disable the page auto-reset.

## Related issue
Closes #2642 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Go to the leaderboard
2. Select a trader to inspect the position history
3. Click on the "Next Page" button to page 2. The page won't reset to page 1 after clicking

## Screenshots (if appropriate):
