### PR TITLE
Fix: Display OI data when connecting to L1

### DIFF
--- a/packages/app/src/hooks/useStatsData.ts
+++ b/packages/app/src/hooks/useStatsData.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { UseQueryResult } from 'react-query'
 
 import useGetFile from 'queries/files/useGetFile'
-import { selectMarkPrices, selectMarkets } from 'state/futures/selectors'
+import { selectOptimismMarkPrices, selectOptimismMarkets } from 'state/futures/selectors'
 import { useAppSelector } from 'state/hooks'
 import { selectMinTimestamp } from 'state/stats/selectors'
 
@@ -20,8 +20,8 @@ export type DailyStat = {
 }
 
 const useStatsData = () => {
-	const futuresMarkets = useAppSelector(selectMarkets)
-	const prices = useAppSelector(selectMarkPrices)
+	const futuresMarkets = useAppSelector(selectOptimismMarkets)
+	const prices = useAppSelector(selectOptimismMarkPrices)
 	const minTimestamp = useAppSelector(selectMinTimestamp)
 
 	const { data: dailyStatsData, isLoading: dailyStatsIsLoading }: UseQueryResult<DailyStat[]> =

--- a/packages/app/src/state/futures/selectors.ts
+++ b/packages/app/src/state/futures/selectors.ts
@@ -150,6 +150,11 @@ export const selectMarkets = createSelector(
 		futures.markets[network] ? unserializeMarkets(futures.markets[network]) : []
 )
 
+export const selectOptimismMarkets = createSelector(
+	(state: RootState) => state.futures,
+	(futures) => (futures.markets[10] ? unserializeMarkets(futures.markets[10]) : [])
+)
+
 export const selectMarketVolumes = createSelector(
 	(state: RootState) => state.futures.dailyMarketVolumes,
 	(dailyMarketVolumes) => unserializeFuturesVolumes(dailyMarketVolumes)
@@ -256,6 +261,23 @@ export const selectMarkPrices = createSelector(selectMarkets, selectPrices, (mar
 		}
 	}, markPrices)
 })
+
+export const selectOptimismMarkPrices = createSelector(
+	selectOptimismMarkets,
+	selectPrices,
+	(optimismMarkets, prices) => {
+		const markPrices: MarkPrices = {}
+		return optimismMarkets.reduce((acc, market) => {
+			const price = prices[market.asset]?.offChain ?? wei(0)
+			return {
+				...acc,
+				[market.marketKey]: wei(price).mul(
+					wei(market.marketSkew).div(market.settings.skewScale).add(1)
+				),
+			}
+		}, markPrices)
+	}
+)
 
 export const selectMarkPriceInfos = createSelector(
 	selectMarkets,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The missing OI data on the stats page is due to the selectMarkets selector in useStatsData, which filters the data based on the wallet network.

- If the network is not in the supported list, Optimism is used by default. In most cases, this works fine.
- If the network is in the supported list, it is selected as-is, which caused the issue when the wallets connected to the Ethereum mainnet.

## Related issue
#2658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
#### Case 1. Visiting the stats page without a wallet connection
1. Open the landing page and go to the stats page directly
2. The stats data are displayed normally.

#### Case 2. Visiting the stats page on optimism
1. Open the landing page and go to the markets page 
2. Connect the wallet and choose optimism as the network
3. Go to the stats page.
4. The data are displayed normally.

#### Case 3. Visiting the stats page on arbitrum
1. Open the landing page and go to the markets page 
2. Connect the wallet and choose arbitrum as the network
3. Go to the stats page.
4. The data are displayed normally.

#### Case 4. Visiting the stats page on ethereum 

***Note: This is the key change of the PR. The OI data are missing without this fix.***
1. Open the landing page and go to the markets page 
2. Connect the wallet and choose ethereum as the network
3. Go to the stats page.
4. The data are displayed normally.

## Screenshots (if appropriate):
