### PR TITLE
Fix: Update the prefix of XAU and XAG

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kwenta",
-	"version": "7.4.9",
+	"version": "7.4.10",
 	"description": "Kwenta",
 	"main": "index.js",
 	"scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kwenta/app",
-	"version": "7.4.9",
+	"version": "7.4.10",
 	"scripts": {
 		"dev": "next",
 		"build": "next build",

--- a/packages/app/src/queries/rates/useCandlesticksQuery.ts
+++ b/packages/app/src/queries/rates/useCandlesticksQuery.ts
@@ -18,6 +18,7 @@ export const requestCandlesticks = async (
 ) => {
 	const ratesEndpoint = getRatesEndpoint(networkId)
 	const pythTvEndpoint = DEFAULT_PYTH_TV_ENDPOINT
+	const prefix = currencyKey === 'XAU' || currencyKey === 'XAG' ? 'Metal' : 'Crypto'
 
 	if (period <= 3600) {
 		const response = await axios
@@ -25,7 +26,7 @@ export const requestCandlesticks = async (
 				params: {
 					from: minTimestamp,
 					to: maxTimestamp,
-					symbol: `Crypto.${currencyKey}/USD`,
+					symbol: `${prefix}.${currencyKey}/USD`,
 					resolution: getSupportedResolution(period),
 				},
 			})

--- a/packages/app/src/queries/rates/useCandlesticksQuery.ts
+++ b/packages/app/src/queries/rates/useCandlesticksQuery.ts
@@ -18,7 +18,8 @@ export const requestCandlesticks = async (
 ) => {
 	const ratesEndpoint = getRatesEndpoint(networkId)
 	const pythTvEndpoint = DEFAULT_PYTH_TV_ENDPOINT
-	const prefix = currencyKey === 'XAU' || currencyKey === 'XAG' ? 'Metal' : 'Crypto'
+	const metalAssets = ['XAU', 'XAG']
+	const prefix = metalAssets.includes(currencyKey!) ? 'Metal' : 'Crypto'
 
 	if (period <= 3600) {
 		const response = await axios


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Updated the prefix of XAU and XAG to `Metal` instead of `Crypto`
2. Updated the package version to `7.4.10`
## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Metal.XAU
<img width="666" alt="截屏2023-07-27 11 15 08" src="https://github.com/Kwenta/kwenta/assets/4819006/c714fe94-ba5b-4b5a-a56a-e2e3797e459e">
Crypto.PEPE
<img width="738" alt="截屏2023-07-27 11 16 49" src="https://github.com/Kwenta/kwenta/assets/4819006/dde22e4b-8db3-4d14-b4aa-a8cf557b44a7">
