### PR TITLE
Fix: Update the prefix of forex

### DIFF
--- a/packages/app/src/queries/rates/constants.ts
+++ b/packages/app/src/queries/rates/constants.ts
@@ -1,3 +1,5 @@
+import { AssetTypes } from './types'
+
 export const COMMODITIES_BASE_API_URL =
 	'https://forex-data-feed.swissquote.com/public-quotes/bboquotes/instrument'
 
@@ -5,3 +7,8 @@ export const FOREX_BASE_API_URL = 'https://api.exchangerate.host/latest'
 
 export const DEFAULT_PYTH_TV_ENDPOINT =
 	'https://benchmarks.pyth.network/v1/shims/tradingview/history'
+
+export const NON_CRYPTO_ASSET_TYPES: AssetTypes = {
+	Metal: ['XAU', 'XAG'],
+	FX: ['EUR', 'GBP', 'AUD'],
+}

--- a/packages/app/src/queries/rates/types.ts
+++ b/packages/app/src/queries/rates/types.ts
@@ -22,3 +22,5 @@ export type PythResponse = {
 	v: number[]
 	s: string
 }
+
+export type AssetTypes = Record<string, string[]>

--- a/packages/app/src/queries/rates/useCandlesticksQuery.ts
+++ b/packages/app/src/queries/rates/useCandlesticksQuery.ts
@@ -6,8 +6,7 @@ import { getSupportedResolution } from 'components/TVChart/utils'
 import { DEFAULT_NETWORK_ID } from 'constants/defaults'
 import logError from 'utils/logError'
 
-import { DEFAULT_PYTH_TV_ENDPOINT } from './constants'
-import { AssetTypes } from './types'
+import { DEFAULT_PYTH_TV_ENDPOINT, NON_CRYPTO_ASSET_TYPES } from './constants'
 import { mapCandles, mapPythCandles } from './utils'
 
 export const requestCandlesticks = async (
@@ -19,14 +18,11 @@ export const requestCandlesticks = async (
 ) => {
 	const ratesEndpoint = getRatesEndpoint(networkId)
 	const pythTvEndpoint = DEFAULT_PYTH_TV_ENDPOINT
-	const nonCryptoTypes: AssetTypes = {
-		Metal: ['XAU', 'XAG'],
-		FX: ['EUR', 'GBP', 'AUD'],
-	}
 
 	let prefix =
-		Object.keys(nonCryptoTypes).find((type) => nonCryptoTypes[type].includes(currencyKey!)) ||
-		'Crypto'
+		Object.keys(NON_CRYPTO_ASSET_TYPES).find((type) =>
+			NON_CRYPTO_ASSET_TYPES[type].includes(currencyKey!)
+		) || 'Crypto'
 
 	if (period <= 3600) {
 		const response = await axios

--- a/packages/app/src/queries/rates/useCandlesticksQuery.ts
+++ b/packages/app/src/queries/rates/useCandlesticksQuery.ts
@@ -7,6 +7,7 @@ import { DEFAULT_NETWORK_ID } from 'constants/defaults'
 import logError from 'utils/logError'
 
 import { DEFAULT_PYTH_TV_ENDPOINT } from './constants'
+import { AssetTypes } from './types'
 import { mapCandles, mapPythCandles } from './utils'
 
 export const requestCandlesticks = async (
@@ -18,8 +19,14 @@ export const requestCandlesticks = async (
 ) => {
 	const ratesEndpoint = getRatesEndpoint(networkId)
 	const pythTvEndpoint = DEFAULT_PYTH_TV_ENDPOINT
-	const metalAssets = ['XAU', 'XAG']
-	const prefix = metalAssets.includes(currencyKey!) ? 'Metal' : 'Crypto'
+	const nonCryptoTypes: AssetTypes = {
+		Metal: ['XAU', 'XAG'],
+		FX: ['EUR', 'GBP', 'AUD'],
+	}
+
+	let prefix =
+		Object.keys(nonCryptoTypes).find((type) => nonCryptoTypes[type].includes(currencyKey!)) ||
+		'Crypto'
 
 	if (period <= 3600) {
 		const response = await axios


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the prefix of `GBP`, `EUR` and `AUD` to `FX` instead of Crypto

## Related issue
#2680
#2683 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1193" alt="截屏2023-07-27 14 59 06" src="https://github.com/Kwenta/kwenta/assets/4819006/9359e89b-9aeb-4bd7-9eb7-0aa0a3f10904">
