### PR TITLE
refactor(sdk): update ethcall to 5 version

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,7 +59,7 @@
 		"bn.js": "^5.2.1",
 		"codegen-graph-ts": "^0.1.4",
 		"date-fns": "^2.30.0",
-		"ethcall": "4.7.2",
+		"ethcall": "5.0.1",
 		"ethers": "^5.7.2",
 		"graphql-request": "^6.1.0",
 		"lodash": "^4.17.21",

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -26,7 +26,7 @@ const DEFAULT_CONTEXT: Partial<IContext> = {
 
 export default class Context implements IContext {
 	private context: IContext
-	public multicallProvider = new EthCallProvider()
+	public multicallProvider: EthCallProvider
 	public contracts: ContractsMap
 	public multicallContracts: MulticallContractsMap
 	public events = new EventEmitter().setMaxListeners(100)
@@ -35,9 +35,7 @@ export default class Context implements IContext {
 	constructor(context: IContext) {
 		this.context = { ...DEFAULT_CONTEXT, ...context }
 
-		if (context.provider) {
-			this.multicallProvider.init(context.provider)
-		}
+		this.multicallProvider = new EthCallProvider(context.networkId, context.provider)
 
 		if (context.signer) {
 			this.setSigner(context.signer)
@@ -82,8 +80,8 @@ export default class Context implements IContext {
 
 	public async setProvider(provider: ethers.providers.Provider) {
 		this.context.provider = provider
-		this.multicallProvider.init(provider)
 		const networkId = (await provider.getNetwork()).chainId as NetworkId
+		this.multicallProvider = new EthCallProvider(networkId, provider)
 
 		this.setNetworkId(networkId)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ importers:
         specifier: ^2.30.0
         version: 2.30.0
       ethcall:
-        specifier: 4.7.2
-        version: 4.7.2
+        specifier: 5.0.1
+        version: 5.0.1
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -12300,6 +12300,20 @@ packages:
       '@ethersproject/contracts': 5.7.0
       '@ethersproject/providers': 5.7.2
       '@types/node': 17.0.45
+      abi-coder: 4.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /ethcall@5.0.1:
+    resolution: {integrity: sha512-xolhtk8lZEAsmtDpK4aXq0CRUo1PoWMa4ofyBfB6hw5gdJbWheQOjh7L257RL9C6/gXuLnELE7goKHBbqGBcCQ==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2
+      '@types/node': 18.15.13
       abi-coder: 4.1.1
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
Update `ethcall` to 5 version.

## Description
With the addition of the new SNX market, our `multicall v2` stopped receiving mart information. In the new version `ethcall` uses `multicall v3`

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
