### PR TITLE
Fix: Number input on safari

### DIFF
--- a/packages/app/src/sections/exchange/TradeCard/CurrencyCard/CurrencyCardInput.tsx
+++ b/packages/app/src/sections/exchange/TradeCard/CurrencyCard/CurrencyCardInput.tsx
@@ -141,7 +141,6 @@ const CurrencyAmount = styled(NumericInput)`
 
 	input {
 		font-size: 30px;
-		line-height: 2.25em;
 		letter-spacing: -1px;
 		height: 30px;
 		width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
@insulineru reported the following issue today
<img width="605" alt="截屏2023-07-27 20 01 21" src="https://github.com/Kwenta/kwenta/assets/4819006/ed01b326-1d01-419f-be31-847253ed1aa5">
The solution is suggested by @koredefashokun 
I verified the solution across different browsers (safari, chrome, and firefox) 

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Open the exchange page and click on the input box
2. Type a random value 
3. Move the mouse to the next input
4. The random value stays in the first input box without any change

## Screenshots (if appropriate):
<img width="699" alt="截屏2023-07-27 20 22 19" src="https://github.com/Kwenta/kwenta/assets/4819006/9977655e-0495-43e1-b333-4879c9c01671">
