### PR TITLE
Fix: Add two more decimal spaces for PEPE and SHIB

### DIFF
--- a/packages/app/src/sections/futures/Trade/MarketsDropdown.tsx
+++ b/packages/app/src/sections/futures/Trade/MarketsDropdown.tsx
@@ -235,7 +235,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 											)}
 										</div>
 									),
-									size: 35,
+									size: 30,
 								},
 								{
 									header: () => <TableHeader>{t('futures.markets-drop-down.market')}</TableHeader>,
@@ -249,7 +249,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 											<Body>{getDisplayAsset(row.original.asset)}</Body>
 										</FlexDivRowCentered>
 									),
-									size: 80,
+									size: 70,
 								},
 								{
 									header: () => <TableHeader>{t('futures.markets-drop-down.price')}</TableHeader>,
@@ -265,7 +265,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 											</div>
 										)
 									},
-									size: 80,
+									size: 95,
 								},
 								{
 									header: () => <TableHeader>{t('futures.markets-drop-down.change')}</TableHeader>,

--- a/packages/app/src/sections/futures/Trade/MarketsDropdown.tsx
+++ b/packages/app/src/sections/futures/Trade/MarketsDropdown.tsx
@@ -249,7 +249,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 											<Body>{getDisplayAsset(row.original.asset)}</Body>
 										</FlexDivRowCentered>
 									),
-									size: 70,
+									size: 65,
 								},
 								{
 									header: () => <TableHeader>{t('futures.markets-drop-down.price')}</TableHeader>,
@@ -265,10 +265,14 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 											</div>
 										)
 									},
-									size: 95,
+									size: 100,
 								},
 								{
-									header: () => <TableHeader>{t('futures.markets-drop-down.change')}</TableHeader>,
+									header: () => (
+										<TableHeader style={{ width: '70px', textAlign: 'right' }}>
+											{t('futures.markets-drop-down.change')}
+										</TableHeader>
+									),
 									cell: ({ row }) => {
 										return (
 											<div>
@@ -284,6 +288,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 																row.original.change ? row.original.change * 100 : '0',
 																2
 															)}
+															style={{ textAlign: 'right', width: '60px' }}
 														/>
 													}
 												/>
@@ -293,7 +298,7 @@ const MarketsDropdown: React.FC<MarketsDropdownProps> = ({ mobile }) => {
 									accessorKey: 'change',
 									sortingFn: 'basic',
 									enableSorting: true,
-									size: 50,
+									size: 60,
 								},
 							]}
 							data={options}

--- a/packages/sdk/src/utils/number.ts
+++ b/packages/sdk/src/utils/number.ts
@@ -224,7 +224,7 @@ export const suggestedDecimals = (value: WeiSource) => {
 	if (value >= 0.001) return 6
 	if (value >= 0.0001) return 7
 	if (value >= 0.00001) return 8
-	return 9
+	return 11
 }
 
 export const floorNumber = (num: WeiSource, decimals?: number) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add two more decimal spaces for PEPE and SHIB

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1790" alt="截屏2023-07-27 22 25 20" src="https://github.com/Kwenta/kwenta/assets/4819006/08c661e0-a815-49c0-8a97-d409e78db714">
<img width="1245" alt="截屏2023-07-27 22 25 51" src="https://github.com/Kwenta/kwenta/assets/4819006/339d09d4-ec75-44f7-a55b-579e06fa71dd">
