### PR TITLE
Add SDK versioning

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Build code
         run: pnpm build
+
+      - name: Bump version
+        run: pnpm bump-version
       
       - name: Publish
         run: |

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kwenta/sdk",
-	"version": "0.0.1",
+	"version": "1.0.3",
 	"description": "SDK for headless interaction with Kwenta",
 	"main": "dist/index.js",
 	"directories": {
@@ -11,7 +11,8 @@
 		"dev": "tsc -b -w",
 		"build": "tsc -b",
 		"check-types": "tsc --noEmit",
-		"generate-contract-types": "typechain --target ethers-v5 --out-dir ./src/contracts/types './src/contracts/abis/*.json' --show-stack-traces"
+		"generate-contract-types": "typechain --target ethers-v5 --out-dir ./src/contracts/types './src/contracts/abis/*.json' --show-stack-traces",
+		"bump-version": "npm version '$(cat package.json | jq -r '.version')'"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
## Description
This PR adds versioning to the SDK. It creates a new version on NPM before attempting to publish, fixing an issue where it was impossible to publish the SDK.

## Related issue
N/A

## Motivation and Context
Enable continuous deployment for the SDK.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
