### PR TITLE
Fix: Missing asset charts on landing page

### DIFF
--- a/packages/app/src/sections/homepage/Assets.tsx
+++ b/packages/app/src/sections/homepage/Assets.tsx
@@ -1,5 +1,5 @@
 import { SECONDS_PER_DAY } from '@kwenta/sdk/constants'
-import { MarketKeyByAsset } from '@kwenta/sdk/utils'
+import { getDisplayAsset, MarketKeyByAsset } from '@kwenta/sdk/utils'
 import { wei } from '@synthetixio/wei'
 import { ColorType, createChart, UTCTimestamp } from 'lightweight-charts'
 import router from 'next/router'
@@ -85,7 +85,12 @@ export const PriceChart = ({ asset }: PriceChartProps) => {
 			},
 		})
 
-		requestCandlesticks(asset, Math.floor(Date.now() / 1000) - SECONDS_PER_DAY, undefined, 3600)
+		requestCandlesticks(
+			getDisplayAsset(asset),
+			Math.floor(Date.now() / 1000) - SECONDS_PER_DAY,
+			undefined,
+			3600
+		)
 			.then((bars) => {
 				let positive = false
 				if (bars !== undefined) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ETH & BTC charts are missing on the landing page because of the symbol name change.
<img width="1321" alt="截屏2023-07-31 15 50 58" src="https://github.com/Kwenta/kwenta/assets/4819006/d8953d5a-708d-4519-b4e3-cf86565da2f2">

The PR resolves this issue.
<img width="1355" alt="截屏2023-07-31 16 04 55" src="https://github.com/Kwenta/kwenta/assets/4819006/d5958fa1-237f-4918-9987-39415846bb75">

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
