### PR TITLE
Fixed the decimal place of market price on mobile

### DIFF
--- a/packages/app/src/sections/futures/Trade/MarketsDropdownSelector.tsx
+++ b/packages/app/src/sections/futures/Trade/MarketsDropdownSelector.tsx
@@ -54,7 +54,7 @@ const MarketsDropdownSelector: FC<Props> = (props) => (
 				<MobileRightContainer>
 					<div>
 						<NumericValue value={props.priceDetails.priceInfo}>
-							{formatDollars(props.priceDetails.priceInfo?.price ?? '0')}
+							{formatDollars(props.priceDetails.priceInfo?.price ?? '0', { suggestDecimals: true })}
 						</NumericValue>
 						<NumericValue value={props.priceDetails.oneDayChange} colored>
 							{formatPercent(props.priceDetails.oneDayChange)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use `suggestedDecimals` for market price on mobile

## Related issue
Closes #2717 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="476" alt="截屏2023-08-01 11 08 01" src="https://github.com/Kwenta/kwenta/assets/4819006/e383e7e9-0a5c-42d9-bf54-956564aa535c">
