### PR TITLE
Increase eth keeper deposit when more than 5 pending orders

### DIFF
--- a/packages/app/src/state/constants.ts
+++ b/packages/app/src/state/constants.ts
@@ -54,3 +54,5 @@ export const DEFAULT_MAP_BY_NETWORK = {
 	420: {},
 	10: {},
 }
+
+export const EST_KEEPER_GAS_FEE = 0.002

--- a/packages/app/src/state/futures/__tests__/actions.test.ts
+++ b/packages/app/src/state/futures/__tests__/actions.test.ts
@@ -1,0 +1,72 @@
+import { FuturesMarketKey } from '@kwenta/sdk/types'
+import { wei } from '@synthetixio/wei'
+
+import { setupStore } from 'state/store'
+
+import {
+	mockSmartMarginAccount,
+	preloadedStateWithSmartMarginAccount,
+} from '../../../../testing/unit/mocks/data/futures'
+import { calculateCrossMarginFees, fetchMarkets } from '../actions'
+import { PreviewAction } from '../types'
+
+jest.mock('../../sdk')
+
+describe('Futures actions - keeper deposits', () => {
+	test('calculates correct ETH deposit when users has no existing balance', async () => {
+		const mockAccount = mockSmartMarginAccount('1000', '0')
+		const store = setupStore(preloadedStateWithSmartMarginAccount(mockAccount))
+		await store.dispatch(fetchMarkets())
+
+		const orderParams = {
+			market: {
+				key: FuturesMarketKey.sETHPERP,
+				address: '0x123',
+			},
+			orderPrice: wei(2000),
+			sizeDelta: wei(10),
+			marginDelta: wei(1000),
+			action: 'trade' as PreviewAction,
+		}
+		store.dispatch(calculateCrossMarginFees(orderParams, 0))
+		expect(Number(store.getState().futures.crossMargin.fees.keeperEthDeposit)).toEqual(0.01)
+	})
+
+	test('calculates correct ETH deposit when users has some existing orders and balance', async () => {
+		const mockAccount = mockSmartMarginAccount('1000', '0.01')
+		const store = setupStore(preloadedStateWithSmartMarginAccount(mockAccount))
+		await store.dispatch(fetchMarkets())
+
+		const orderParams = {
+			market: {
+				key: FuturesMarketKey.sETHPERP,
+				address: '0x123',
+			},
+			orderPrice: wei(2000),
+			sizeDelta: wei(10),
+			marginDelta: wei(1000),
+			action: 'trade' as PreviewAction,
+		}
+		store.dispatch(calculateCrossMarginFees(orderParams, 5))
+		expect(Number(store.getState().futures.crossMargin.fees.keeperEthDeposit)).toEqual(0.002)
+	})
+
+	test('requires no deposit when balance is enough', async () => {
+		const mockAccount = mockSmartMarginAccount('1000', '0.01')
+		const store = setupStore(preloadedStateWithSmartMarginAccount(mockAccount))
+		await store.dispatch(fetchMarkets())
+
+		const orderParams = {
+			market: {
+				key: FuturesMarketKey.sETHPERP,
+				address: '0x123',
+			},
+			orderPrice: wei(2000),
+			sizeDelta: wei(10),
+			marginDelta: wei(1000),
+			action: 'trade' as PreviewAction,
+		}
+		store.dispatch(calculateCrossMarginFees(orderParams, 4))
+		expect(Number(store.getState().futures.crossMargin.fees.keeperEthDeposit)).toEqual(0)
+	})
+})

--- a/packages/app/testing/unit/mocks/data/futures.ts
+++ b/packages/app/testing/unit/mocks/data/futures.ts
@@ -11,7 +11,7 @@ import { FUTURES_INITIAL_STATE } from 'state/futures/reducer'
 
 import { PRELOADED_STATE, TEST_ADDR } from './app'
 
-export const mockSmartMarginAccount = (freeMargin: string = '1000') => ({
+export const mockSmartMarginAccount = (freeMargin: string = '1000', keeperEthBal = '0.05') => ({
 	account: '0xe1ba3B0A962FbC525a9f9503AEE3310940Bb2a6F',
 	positionHistory: [],
 	trades: [],
@@ -19,7 +19,7 @@ export const mockSmartMarginAccount = (freeMargin: string = '1000') => ({
 	idleTransfers: [],
 	balanceInfo: {
 		freeMargin: freeMargin,
-		keeperEthBal: '0.05',
+		keeperEthBal: keeperEthBal,
 		allowance: freeMargin,
 		walletEthBal: '1',
 	},

--- a/packages/sdk/src/constants/futures.ts
+++ b/packages/sdk/src/constants/futures.ts
@@ -48,7 +48,7 @@ export const ORDERS_FETCH_SIZE = 500
 
 export const ISOLATED_MARGIN_ORDER_TYPES: FuturesOrderType[] = ['market']
 export const CROSS_MARGIN_ORDER_TYPES: SmartMarginOrderType[] = ['market', 'limit', 'stop_market']
-export const ORDER_KEEPER_ETH_DEPOSIT = wei(0.01)
+export const MIN_ACCOUNT_KEEPER_BAL = wei(0.01)
 export const DEFAULT_DELAYED_LEVERAGE_CAP = wei(100)
 export const MAX_POSITION_BUFFER = 0.01
 export const MIN_MARGIN_AMOUNT = wei(50)


### PR DESCRIPTION
## Description

Calculates ETH deposit based on existing orders to ensure there is enough balance for execution.

## Motivation and Context

Existing logic was to only maintain a 0.01 balance which can cause issues when users have many orders.

## How Has This Been Tested?

Tests included