### PR TITLE
Fix: Missing asset icon of position history table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kwenta",
-	"version": "7.4.14",
+	"version": "7.4.15",
 	"description": "Kwenta",
 	"main": "index.js",
 	"scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kwenta/app",
-	"version": "7.4.14",
+	"version": "7.4.15",
 	"scripts": {
 		"dev": "next",
 		"build": "next build",

--- a/packages/app/src/sections/futures/TraderHistory.tsx
+++ b/packages/app/src/sections/futures/TraderHistory.tsx
@@ -1,6 +1,6 @@
 import { ZERO_WEI } from '@kwenta/sdk/constants'
 import { FuturesPositionHistory } from '@kwenta/sdk/dist/types'
-import { getMarketName } from '@kwenta/sdk/utils'
+import { getMarketName, MarketKeyByAsset } from '@kwenta/sdk/utils'
 import { wei, WeiSource } from '@synthetixio/wei'
 import router from 'next/router'
 import { FC, memo, useMemo } from 'react'
@@ -51,7 +51,7 @@ const TraderHistory: FC<TraderHistoryProps> = memo(
 					return {
 						...stat,
 						rank: i + 1,
-						currencyIconKey: stat.asset ? (stat.asset[0] !== 's' ? 's' : '') + stat.asset : '',
+						currencyIconKey: MarketKeyByAsset[stat.asset],
 						marketShortName: getMarketName(stat.asset),
 						status: stat.isOpen ? 'Open' : stat.isLiquidated ? 'Liquidated' : 'Closed',
 						funding,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some asset icons are missing from the position history table (or leaderboard) because of the new asset mapping.
This PR resolves this issue.

## Related issue
Closes #2726 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Test wallet: 0x614B7de7A18839489e587157D4a44e939a1bfbe7
1. Go to the dashboard > history page 
2. No missing assets icons are found after the fix (see the screenshot below)

## Screenshots (if appropriate):
<img width="1323" alt="截屏2023-08-02 11 29 06" src="https://github.com/Kwenta/kwenta/assets/4819006/1eefd462-3aa1-4fc7-85e3-17c5cf05d818">
