### PR TITLE
Fix: Disabling staking data fetching on unsupported networks

### DIFF
--- a/packages/app/src/sections/leaderboard/Leaderboard.tsx
+++ b/packages/app/src/sections/leaderboard/Leaderboard.tsx
@@ -28,9 +28,10 @@ import {
 import { selectWallet } from 'state/wallet/selectors'
 import media from 'styles/media'
 
+import TraderHistory from '../futures/TraderHistory'
+
 import AllTime from './AllTime'
 import Competition from './Competition'
-import TraderHistory from '../futures/TraderHistory'
 
 type LeaderboardProps = {
 	compact?: boolean

--- a/packages/app/src/state/app/hooks.ts
+++ b/packages/app/src/state/app/hooks.ts
@@ -3,12 +3,10 @@ import { useEffect } from 'react'
 import { fetchBalances } from 'state/balances/actions'
 import { fetchEarnTokenPrices } from 'state/earn/actions'
 import { selectMarkets } from 'state/futures/selectors'
-import { useAppDispatch, useAppSelector, useFetchAction, usePollAction } from 'state/hooks'
+import { useAppDispatch, useAppSelector, usePollAction } from 'state/hooks'
 import { fetchPreviousDayPrices, updatePrices } from 'state/prices/actions'
 import { setConnectionError } from 'state/prices/reducer'
 import sdk from 'state/sdk'
-import { fetchClaimableRewards } from 'state/staking/actions'
-import { selectTradingRewardsSupportedNetwork } from 'state/staking/selectors'
 import { selectNetwork, selectWallet } from 'state/wallet/selectors'
 import { serializePrices } from 'utils/futures'
 
@@ -19,17 +17,11 @@ export function useAppData(ready: boolean) {
 	const wallet = useAppSelector(selectWallet)
 	const markets = useAppSelector(selectMarkets)
 	const network = useAppSelector(selectNetwork)
-	const networkSupportsTradingRewards = useAppSelector(selectTradingRewardsSupportedNetwork)
 
 	usePollAction('fetchEarnTokenPrices', fetchEarnTokenPrices, {
 		intervalTime: 60000 * 10,
 		dependencies: [wallet],
 		disabled: !wallet,
-	})
-
-	useFetchAction(fetchClaimableRewards, {
-		dependencies: [network, wallet],
-		disabled: !wallet || !networkSupportsTradingRewards,
 	})
 
 	usePollAction('fetchBalances', fetchBalances, { dependencies: [wallet, network] })

--- a/packages/app/src/state/futures/hooks.ts
+++ b/packages/app/src/state/futures/hooks.ts
@@ -132,8 +132,10 @@ export const useFetchStakeMigrateData = () => {
 	})
 	useFetchAction(() => fetchFuturesFees({ start, end }), {
 		dependencies: [networkId, wallet, start, end],
+		disabled: !wallet || !networkSupportsStaking,
 	})
 	useFetchAction(() => fetchFuturesFeesForAccount({ start, end }), {
 		dependencies: [networkId, wallet, start, end],
+		disabled: !wallet || !networkSupportsStaking,
 	})
 }

--- a/packages/app/src/state/staking/actions.ts
+++ b/packages/app/src/state/staking/actions.ts
@@ -3,6 +3,10 @@ import { BigNumber } from 'ethers'
 
 import { notifyError } from 'components/ErrorNotifier'
 import { monitorTransaction } from 'contexts/RelayerContext'
+import {
+	selectStakingSupportedNetwork,
+	selectTradingRewardsSupportedNetwork,
+} from 'state/staking/selectors'
 import { FetchStatus, ThunkConfig } from 'state/types'
 import { selectWallet } from 'state/wallet/selectors'
 import logError from 'utils/logError'
@@ -27,7 +31,8 @@ export const fetchStakingData = createAsyncThunk<StakingAction, void, ThunkConfi
 	async (_, { getState, extra: { sdk } }) => {
 		try {
 			const wallet = selectWallet(getState())
-			if (!wallet) return ZERO_STAKING_DATA
+			const supportedNetwork = selectStakingSupportedNetwork(getState())
+			if (!wallet || !supportedNetwork) return ZERO_STAKING_DATA
 
 			const {
 				rewardEscrowBalance,
@@ -65,7 +70,8 @@ export const fetchStakingV2Data = createAsyncThunk<StakingActionV2, void, ThunkC
 	async (_, { getState, extra: { sdk } }) => {
 		try {
 			const wallet = selectWallet(getState())
-			if (!wallet) return ZERO_STAKING_V2_DATA
+			const supportedNetwork = selectStakingSupportedNetwork(getState())
+			if (!wallet || !supportedNetwork) return ZERO_STAKING_V2_DATA
 
 			const {
 				rewardEscrowBalance,
@@ -135,7 +141,8 @@ export const fetchEscrowData = createAsyncThunk<EscrowBalance, void, ThunkConfig
 	async (_, { getState, extra: { sdk } }) => {
 		try {
 			const wallet = selectWallet(getState())
-			if (!wallet) return ZERO_ESCROW_BALANCE
+			const supportedNetwork = selectStakingSupportedNetwork(getState())
+			if (!wallet || !supportedNetwork) return ZERO_ESCROW_BALANCE
 
 			const { escrowData, totalVestable } = await sdk.kwentaToken.getEscrowData()
 
@@ -161,7 +168,8 @@ export const fetchEscrowV2Data = createAsyncThunk<EscrowBalance, void, ThunkConf
 	async (_, { getState, extra: { sdk } }) => {
 		try {
 			const wallet = selectWallet(getState())
-			if (!wallet) return ZERO_ESCROW_BALANCE
+			const supportedNetwork = selectStakingSupportedNetwork(getState())
+			if (!wallet || !supportedNetwork) return ZERO_ESCROW_BALANCE
 
 			const { escrowData, totalVestable } = await sdk.kwentaToken.getEscrowV2Data()
 
@@ -187,7 +195,8 @@ export const fetchEstimatedRewards = createAsyncThunk<EstimatedRewards, void, Th
 	async (_, { getState, extra: { sdk } }) => {
 		try {
 			const wallet = selectWallet(getState())
-			if (!wallet) return ZERO_ESTIMATED_REWARDS
+			const supportedNetwork = selectStakingSupportedNetwork(getState())
+			if (!wallet || !supportedNetwork) return ZERO_ESTIMATED_REWARDS
 
 			const { estimatedKwentaRewards, estimatedOpRewards } =
 				await sdk.kwentaToken.getEstimatedRewards()
@@ -313,12 +322,11 @@ export const fetchClaimableRewards = createAsyncThunk<ClaimableRewards, void, Th
 	'staking/fetchClaimableRewards',
 	async (_, { getState, extra: { sdk } }) => {
 		try {
-			const {
-				staking: { epochPeriod },
-			} = getState()
 			const wallet = selectWallet(getState())
+			const supportedNetwork = selectTradingRewardsSupportedNetwork(getState())
+			if (!wallet || !supportedNetwork) return ZERO_CLAIMABLE_REWARDS
 
-			if (!wallet) return ZERO_CLAIMABLE_REWARDS
+			const { epochPeriod } = await sdk.kwentaToken.getStakingData()
 
 			const { claimableRewards: claimableKwentaRewards, totalRewards: kwentaRewards } =
 				await sdk.kwentaToken.getClaimableAllRewards(epochPeriod, false, false, 9)

--- a/packages/app/src/state/wallet/actions.ts
+++ b/packages/app/src/state/wallet/actions.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser'
 import { ethers } from 'ethers'
 
 import { fetchBalances } from 'state/balances/actions'
-import { fetchStakeMigrateData } from 'state/staking/actions'
+import { fetchClaimableRewards } from 'state/staking/actions'
 import type { ThunkConfig } from 'state/types'
 
 import { setWalletAddress } from './reducer'
@@ -13,7 +13,7 @@ export const resetWalletAddress = createAsyncThunk<void, string | undefined, Thu
 	async (walletAddress, { dispatch }) => {
 		dispatch(setWalletAddress(walletAddress))
 		dispatch(fetchBalances())
-		dispatch(fetchStakeMigrateData())
+		dispatch(fetchClaimableRewards())
 	}
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user is now seeing the data fetching error on an unsupported network. 
<img width="190" alt="Screenshot_2023-08-02_at_15 16 08" src="https://github.com/Kwenta/kwenta/assets/4819006/97edf732-f198-4493-9fd0-ee378f9b9963">
1. Disabled staking data fetching on unsupported networks
2. Fixed the lint warning

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
On market page,
1. Switch to the Ethereum mainnet
2. No data fetching error

On staking page,
1. Switch to the Ethereum mainnet
2. No data fetching error

## Screenshots (if appropriate):
