### PR TITLE
Custom display value for ETHBTC, so dropdown shows "ETH/BTC".

### DIFF
--- a/packages/sdk/src/utils/futures.ts
+++ b/packages/sdk/src/utils/futures.ts
@@ -146,6 +146,7 @@ export const getMarketName = (asset: FuturesMarketAsset | null) => {
 
 export const getDisplayAsset = (asset: string | null) => {
 	if (!asset) return null
+	if (asset === 'ETHBTC') return 'ETH/BTC'
 	if (asset === 'STETH') return 'stETH'
 	if (asset === 'STETHETH') return 'stETH/ETH'
 	return asset[0] === 's' ? asset.slice(1) : asset


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a custom handling of "ETHBTC" `getDisplayAsset` to return "ETH/BTC".
Value should appear in market dropdown.


## Related issue
None

## Motivation and Context
Easier to skim markets and identify this ratio market.

## How Has This Been Tested?
Crude testing in Chrome using local source override. Less than ideal.

## Screenshots (if appropriate):
Showing from and to:

![Kwenta_From](https://github.com/Kwenta/kwenta/assets/216550/bf1c9002-190f-4fdb-ac07-046709c4ba93) ![Kwenta_To](https://github.com/Kwenta/kwenta/assets/216550/669f4b37-13d7-419c-9307-334afa8f4111)